### PR TITLE
Feature: add Logwrapper module for centralized logging with FastAPI integration

### DIFF
--- a/modules/logwrapper/README.md
+++ b/modules/logwrapper/README.md
@@ -1,0 +1,46 @@
+# logwrapper (Merkezi Loglama Servisi)
+
+Merkezi loglama için hafif bir modül. Tüm modüllerin loglarını tek yerde toplar.
+
+Özellikler:
+- Console + dönen dosya handler
+- Bellek içi halka buffer (REST ile okunabilir)
+- JSON veya okunabilir format
+- Warnings -> logging
+- Modül bazlı seviye override
+- FastAPI router (opsiyonel)
+
+## Kullanım
+
+Kütüphane olarak:
+
+```python
+from modules.logwrapper import init_logging, get_router
+
+init_logging()  # erken çağırın
+
+# FastAPI ile entegrasyon (opsiyonel)
+app = FastAPI()
+router = get_router()
+if router is not None:
+    app.include_router(router)
+```
+
+CLI/servis gibi çalıştırma:
+
+```bash
+python -m modules.logwrapper.xLogService
+```
+
+## Konfigürasyon
+`modules/logwrapper/config/config.yml` içinde. Ortam değişkenleri ve `init_logging(overrides=...)` ile override edilebilir.
+
+- LOG_LEVEL: konsol seviyesi
+- LOG_FILE: dosya yolu
+
+## DryCode Notları
+
+## Gateway Notu
+Gateway içinde merkezi loglama başlatılması opsiyoneldir; mevcut kurulumda gateway başlarken `init_logging()` çağrısı denenir. Başarısız olsa bile modüller çalışmaya devam eder.
+- Tek sorumluluk: modül sadece log altyapısını kurar ve minimal API sunar.
+- Dış bağımlılıklar: yalnızca opsiyonel `PyYAML` ve `FastAPI` (API için). Başka bağımlılık yok.

--- a/modules/logwrapper/__init__.py
+++ b/modules/logwrapper/__init__.py
@@ -1,0 +1,15 @@
+"""
+logwrapper modülü: merkezi loglama altyapısı.
+
+Dışa açılan basit API:
+- init_logging(overrides: dict | None) -> None
+- get_memory_handler() -> InMemoryLogHandler | None
+- get_router() -> fastapi.APIRouter (opsiyonel)
+"""
+from .xLogService import init_logging, get_memory_handler, get_router
+
+__all__ = [
+    "init_logging",
+    "get_memory_handler",
+    "get_router",
+]

--- a/modules/logwrapper/api/__init__.py
+++ b/modules/logwrapper/api/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/modules/logwrapper/api/router.py
+++ b/modules/logwrapper/api/router.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+try:
+    from fastapi import APIRouter
+    from pydantic import BaseModel
+except Exception:  # pragma: no cover
+    APIRouter = None  # type: ignore
+    BaseModel = object  # type: ignore
+
+from ..xLogService import get_memory_handler
+
+
+if APIRouter is not None:
+    router = APIRouter(prefix="/logs", tags=["logs"])  # type: ignore
+
+    class LevelChange(BaseModel):  # type: ignore
+        logger: str
+        level: str
+
+    @router.get("/")
+    def list_logs(n: int = 200) -> Dict[str, Any]:
+        handler = get_memory_handler()
+        items = handler.tail(n) if handler else []
+        return {"count": len(items), "items": items}
+
+    @router.post("/level")
+    def set_level(payload: LevelChange) -> Dict[str, str]:
+        log = logging.getLogger(payload.logger)
+        try:
+            level_value = getattr(logging, payload.level.upper())
+        except Exception:
+            level_value = payload.level
+        log.setLevel(level_value)
+        return {"status": "ok"}
+else:  # Placeholder to avoid import error when FastAPI not installed
+    router = None  # type: ignore

--- a/modules/logwrapper/config/README.md
+++ b/modules/logwrapper/config/README.md
@@ -1,0 +1,16 @@
+# Logwrapper Config
+
+Aşağıdaki anahtarlar `config.yml` içinde tanımlıdır:
+
+- enable_console: bool – Konsola log yazımı
+- console_level: str – Konsol seviye eşiği (DEBUG/INFO/...)
+- enable_file: bool – Dosyaya log yazımı
+- file_path: str – Log dosya yolu
+- rotate_bytes: int – Rotasyon boyutu (bytes)
+- backup_count: int – Yedek dosya sayısı
+- json_format: bool – JSON formatta çıktı (harici bağımlılık yok)
+- buffer_size: int – Bellek içi halka buffer kapasitesi
+- capture_warnings: bool – warnings -> logging
+- module_levels: dict – Örn: {"uvicorn": "WARNING"}
+
+Override önceliği: overrides dict > ortam değişkenleri (LOG_LEVEL, LOG_FILE) > YAML > varsayılanlar.

--- a/modules/logwrapper/config/config.yml
+++ b/modules/logwrapper/config/config.yml
@@ -1,0 +1,27 @@
+# logwrapper varsayılan ayarları
+
+# Konsola yazılsın mı?
+enable_console: true
+# Konsol seiyesi (DEBUG, INFO, WARNING, ERROR)
+console_level: INFO
+
+# Dosyaya yazılsın mı?
+enable_file: true
+# Dönen dosya yolu
+file_path: logs/sentry.log
+# Maks dosya boyutu (bayt)
+rotate_bytes: 2097152  # 2MB
+# Yedek dosya sayısı
+backup_count: 5
+
+# JSON formatta çıktı
+json_format: false
+
+# Bellek içi halka buffer boyutu
+buffer_size: 1000
+
+# Python warnings -> logging
+capture_warnings: true
+
+# Modül bazlı seviye override
+module_levels: {}

--- a/modules/logwrapper/config_loader.py
+++ b/modules/logwrapper/config_loader.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None  # Lazy optional dependency
+
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "enable_console": True,
+    "console_level": "INFO",
+    "enable_file": True,
+    "file_path": "logs/sentry.log",
+    "rotate_bytes": 2 * 1024 * 1024,  # 2MB
+    "backup_count": 5,
+    "json_format": False,
+    "buffer_size": 1000,  # in-memory ring buffer size
+    "capture_warnings": True,
+    # Per-module level overrides, e.g. {"uvicorn": "WARNING"}
+    "module_levels": {},
+}
+
+
+def load_config(base_dir: Optional[str] = None, overrides: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """YAML config.yml dosyasını ve opsiyonel override'ları yükler.
+
+    Arama sırası:
+    - modules/logwrapper/config/config.yml
+    - base_dir altında config/config.yml (eğer verildiyse)
+
+    overrides sözlüğü sağlanırsa, YAML üzerindeki değerlere baskın gelir.
+    """
+    cfg: Dict[str, Any] = dict(DEFAULT_CONFIG)
+
+    candidates = []
+    if base_dir:
+        candidates.append(os.path.join(base_dir, "config", "config.yml"))
+    # Default module path
+    here = os.path.dirname(__file__)
+    candidates.append(os.path.join(here, "config", "config.yml"))
+
+    for path in candidates:
+        if os.path.exists(path):
+            if yaml is None:
+                break
+            with open(path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            if isinstance(data, dict):
+                cfg.update(data)
+            break
+
+    if overrides:
+        cfg.update({k: v for k, v in overrides.items() if v is not None})
+
+    # Normalize env overrides (e.g., LOG_LEVEL, LOG_FILE)
+    env_level = os.getenv("LOG_LEVEL")
+    if env_level:
+        cfg["console_level"] = env_level
+    env_file = os.getenv("LOG_FILE")
+    if env_file:
+        cfg["file_path"] = env_file
+
+    return cfg

--- a/modules/logwrapper/requirements.txt
+++ b/modules/logwrapper/requirements.txt
@@ -1,0 +1,4 @@
+PyYAML>=6.0
+# API opsiyonel: FastAPI ve Uvicorn sadece gerekli ise
+fastapi>=0.111.0
+uvicorn>=0.30.0

--- a/modules/logwrapper/services/handlers.py
+++ b/modules/logwrapper/services/handlers.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+from collections import deque
+from typing import Deque, Iterable, List, Optional
+
+
+class InMemoryLogHandler(logging.Handler):
+    """Basit halka buffer log handler.
+
+    - thread-safe: logging.Handler zaten lock içerir
+    - formatlanmış stringleri saklar (emit sonrası)
+    """
+
+    def __init__(self, maxlen: int = 1000, level: int = logging.NOTSET) -> None:
+        super().__init__(level=level)
+        self.buffer: Deque[str] = deque(maxlen=maxlen)
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+        try:
+            msg = self.format(record)
+        except Exception:  # pragma: no cover
+            msg = record.getMessage()
+        self.buffer.append(msg)
+
+    def tail(self, n: int = 100) -> List[str]:
+        if n <= 0:
+            return []
+        start = max(0, len(self.buffer) - n)
+        return list(list(self.buffer)[start:])
+
+    def iter(self) -> Iterable[str]:
+        return iter(self.buffer)
+
+
+def build_formatter(json_format: bool) -> logging.Formatter:
+    if json_format:
+        # Minimal JSON without extra deps
+        fmt = (
+            '{"time":"%(asctime)s","level":"%(levelname)s","name":"%(name)s"'
+            ',"msg":"%(message)s","module":"%(module)s","line":%(lineno)d}'
+        )
+        datefmt = "%Y-%m-%dT%H:%M:%S"
+        return logging.Formatter(fmt=fmt, datefmt=datefmt)
+    # Human friendly
+    fmt = "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
+    datefmt = "%H:%M:%S"
+    return logging.Formatter(fmt=fmt, datefmt=datefmt)

--- a/modules/logwrapper/tests/test_smoke.py
+++ b/modules/logwrapper/tests/test_smoke.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import logging
+
+from modules.logwrapper import init_logging, get_memory_handler
+
+
+def test_smoke_memory_handler():
+    init_logging({"enable_file": False})  # file IO'yu kapat
+    log = logging.getLogger("modules.logwrapper.test")
+    log.debug("dbg")
+    log.info("info")
+    handler = get_memory_handler()
+    assert handler is not None
+    items = handler.tail(5)
+    assert any("info" in i or "INFO" in i for i in items)

--- a/modules/logwrapper/xLogService.py
+++ b/modules/logwrapper/xLogService.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import logging
+import logging.config
+import os
+import warnings
+from typing import Any, Dict, Optional
+
+from .config_loader import load_config
+from .services.handlers import InMemoryLogHandler, build_formatter
+
+_MEMORY_HANDLER: Optional[InMemoryLogHandler] = None
+_ROUTER = None  # lazy import for FastAPI
+
+
+def _ensure_log_dir(path: str) -> None:
+    directory = os.path.dirname(path)
+    if directory and not os.path.exists(directory):
+        os.makedirs(directory, exist_ok=True)
+
+
+def init_logging(overrides: Optional[Dict[str, Any]] = None) -> None:
+    """Kök logger'ı merkezi olarak yapılandırır.
+
+    - Tüm modüllerin logları toplanır (disable_existing_loggers=False)
+    - Console ve dosya handler isteğe bağlı
+    - Bellek içi halka buffer handler
+    - Warnings capture
+    """
+    global _MEMORY_HANDLER
+
+    # Zaten kuruluysa tekrar yapılandırma
+    if _MEMORY_HANDLER is not None and logging.getLogger().handlers:
+        return
+
+    cfg = load_config(overrides=overrides)
+
+    handlers: Dict[str, Dict[str, Any]] = {}
+    root_handlers = []
+
+    # Memory handler
+    memory_name = "in_memory"
+    handlers[memory_name] = {
+        "()": InMemoryLogHandler,
+        "maxlen": int(cfg.get("buffer_size", 1000)),
+        "level": "DEBUG",
+    }
+    root_handlers.append(memory_name)
+
+    # Console handler
+    if cfg.get("enable_console", True):
+        handlers["console"] = {
+            "class": "logging.StreamHandler",
+            "level": cfg.get("console_level", "INFO"),
+            "stream": "ext://sys.stdout",
+        }
+        root_handlers.append("console")
+
+    # File handler with rotation
+    if cfg.get("enable_file", True):
+        path = str(cfg.get("file_path", "logs/sentry.log"))
+        _ensure_log_dir(path)
+        handlers["file"] = {
+            "class": "logging.handlers.RotatingFileHandler",
+            "level": "DEBUG",
+            "filename": path,
+            "maxBytes": int(cfg.get("rotate_bytes", 2 * 1024 * 1024)),
+            "backupCount": int(cfg.get("backup_count", 5)),
+            "encoding": "utf-8",
+        }
+        root_handlers.append("file")
+
+    # Formatters
+    json_format = bool(cfg.get("json_format", False))
+    formatter = build_formatter(json_format)
+
+    # dictConfig yapılandırması
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "default": {
+                    "()": lambda: formatter,
+                }
+            },
+            "handlers": {
+                name: {
+                    **opts,
+                    "formatter": "default",
+                }
+                for name, opts in handlers.items()
+            },
+            "root": {
+                "level": "DEBUG",
+                "handlers": root_handlers,
+            },
+        }
+    )
+
+    # Warnings -> logging
+    if cfg.get("capture_warnings", True):
+        logging.captureWarnings(True)
+        warnings.simplefilter("default")
+        # Optional: tone down known 3rd-party deprecations
+        try:
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*pkg_resources\.declare_namespace.*",
+                category=DeprecationWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*pkg_resources is deprecated as an API.*",
+                category=DeprecationWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*websockets\.legacy is deprecated.*",
+                category=DeprecationWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*WebSocketServerProtocol is deprecated.*",
+                category=DeprecationWarning,
+            )
+        except Exception:
+            pass
+
+    # Formatter instance'ını memory handler'a bağlamak için referans bulalım
+    logger = logging.getLogger()
+    for h in logger.handlers:
+        if isinstance(h, InMemoryLogHandler):
+            h.setFormatter(formatter)
+            _MEMORY_HANDLER = h
+            break
+
+    # Module bazlı level override
+    for name, level in (cfg.get("module_levels") or {}).items():
+        try:
+            logging.getLogger(name).setLevel(getattr(logging, str(level).upper()))
+        except Exception:
+            logging.getLogger(name).setLevel(level)
+
+
+def get_memory_handler() -> Optional[InMemoryLogHandler]:
+    return _MEMORY_HANDLER
+
+
+def get_router():  # lazy import to avoid FastAPI dep when unused
+    global _ROUTER
+    if _ROUTER is not None:
+        return _ROUTER
+    try:
+        from .api.router import router  # type: ignore
+    except Exception:  # FastAPI yoksa API opsiyonel
+        return None
+    _ROUTER = router
+    return _ROUTER
+
+
+if __name__ == "__main__":
+    # Servis gibi çalıştırıldığında basit demo
+    init_logging()
+    log = logging.getLogger("logwrapper.demo")
+    log.info("Logwrapper service started")
+    log.warning("This is a warning")
+    log.error("This is an error")


### PR DESCRIPTION
- Introduced lightweight centralized logging service to aggregate logs across modules
- Console + rotating file handlers; supports JSON and human-readable formats
- In-memory ring buffer (readable via optional FastAPI router)
- Redirected Python warnings to logging; per-module level overrides supported
- Library helpers: init_logging() and get_router() for easy embedding
- CLI/service entrypoint: python -m modules.logwrapper.xLogService
- Configuration at modules/logwrapper/config/config.yml with env overrides (LOG_LEVEL, LOG_FILE)
- Gateway: attempts init_logging() on startup; failures are non-blocking for other modules
- Minimal external deps: optional PyYAML and FastAPI (only for API)
- Documentation added: usage examples, configuration, and gateway notes