### PR TITLE
Feature: add NeoPixel automation engine with API and configuration

### DIFF
--- a/modules/interactions/README.md
+++ b/modules/interactions/README.md
@@ -1,0 +1,68 @@
+# Interactions Module
+
+Durumlara/olaylara göre NeoPixel animasyonlarını otomatik seçen hafif bir kural motoru.
+
+## Özellikler
+- HTTP üzerinden mevcut NeoPixel servisine bağlanır (`/neopixel`).
+- Base (sürekli) + Transient (kısa) efekt katmanı, öncelik ve cooldown ile.
+- Sistem metrikleri: CPU sıcaklık/yük, ağ burst sezgisi.
+- Olay besleme: `POST /interactions/event` ile (ör: `speech.start`, `error`).
+- Donanım haritalama: Jewel (7) + Stick (16 tek sıra). Şimdilik tüm strip’e animasyon uygular.
+
+## Kurulum
+- FastAPI uygulaması: `xInteractionsService.create_app()`.
+- Varsayılan port: 8095 (`config/config.yml`).
+
+## API
+- GET `/interactions/state`: aktif base/effect ve son metrikler.
+- POST `/interactions/event` `{ type, data? }`: olay tetikle (ör: `speech.start`).
+- POST `/interactions/effect` `{ name, duration_ms? }`: manuel kısa efekt.
+- POST `/interactions/base` `{ name, color? }`: geçici base override.
+
+### Gateway Entegrasyonu
+Gateway, `interactions` router’ını tek portta sunar. NeoPixel uçları da gateway’de açıksa, kurallar doğrudan bu uçlara istek gönderir; modülü ayrı başlatmaya gerek yoktur.
+
+## Varsayılan Davranış (config.yml)
+- Sıcaklık ≥ 75°C: BREATHE kırmızı (base, high)
+- 65–74°C: PULSE turuncu (base, medium)
+- CPU yük ≥ 0.9: PULSE sarı (base, medium)
+- Ağ burst: COMET 800ms (transient, cooldown 3s)
+- speech.start: RAINBOW_CYCLE 1s (transient)
+- speech.end: COMET 600ms (transient)
+- Arduino disconnected: THEATER_CHASE magenta (base, high)
+- error: METEOR 500ms (critical, cooldown 10s)
+- warning: PULSE 400ms (high, cooldown 3s)
+- Hiçbiri değilse: BREATHE teal (idle base)
+
+## Kural/Config Yapısı
+`modules/interactions/config/config.yml`
+- `adapter.http_base_url`: NeoPixel HTTP tabanı (varsayılan: `http://localhost:8092/neopixel`).
+- `hardware.segments`: Jewel + Stick tanımı (ileri geliştirme için hazır).
+- `thresholds`: cpu_temp/cpu_load/net burst eşikleri.
+- `rules`: sıralı değerlendirilir. Koşullar (örnek anahtarlar):
+  - `event`, `cpu_temp_gte`, `cpu_temp_lt`, `cpu_load_gte`, `net_burst`, `arduino_connected`
+- `defaults.idle`: boşta gösterilecek base animasyon.
+
+### Yeni Uyarı/Etkileşim Ekleme
+1. `rules` listesine yeni bir kural ekleyin:
+```yaml
+- id: my_custom
+  when: { event: my.event }
+  action: { effect: { name: COMET, duration_ms: 700 } }
+  priority: high
+  cooldown_ms: 2000
+```
+2. Olayı gönderin:
+```json
+POST /interactions/event
+{ "type": "my.event" }
+```
+3. Renge özel davranmak isterseniz `base.color: "#RRGGBB"` verebilirsiniz (uyumlu animasyonlarda dolgu yapılır, aksi halde animasyon adı oynatılır).
+
+## Notlar
+- Quiet hours varsayılan olarak kapalıdır (isteğe göre eklenebilir).
+- NeoPixel servisi yoksa istekler sessizce yok sayılır (No-Op mod).
+- İleride segment/mask desteklemek için NeoPixel API genişletimi önerilir.
+
+---
+Bu modül DryCode prensiplerine uygundur: tek sorumluluklu dosyalar, config odaklı, sade API.

--- a/modules/interactions/__init__.py
+++ b/modules/interactions/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+try:
+    from .xInteractionsService import xInteractionsService, create_app  # noqa: F401
+except Exception:  # pragma: no cover
+    pass

--- a/modules/interactions/api/__init__.py
+++ b/modules/interactions/api/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+try:
+    from .router import get_router  # noqa: F401
+except Exception:  # pragma: no cover
+    pass

--- a/modules/interactions/api/router.py
+++ b/modules/interactions/api/router.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from typing import Any, Dict, Optional
+
+try:
+    from ..services.engine import InteractionEngine
+except Exception:  # pragma: no cover
+    from modules.interactions.services.engine import InteractionEngine  # type: ignore
+
+
+def get_router(engine: InteractionEngine) -> APIRouter:
+    r = APIRouter(prefix="/interactions")
+
+    @r.get("/state")
+    def state():
+        return engine.get_state()
+
+    @r.post("/event")
+    def push_event(payload: Dict[str, Any]):
+        t = str(payload.get("type", "")).strip()
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else None
+        if not t:
+            return {"ok": False, "error": "type is required"}
+        engine.push_event(t, data)
+        return {"ok": True}
+
+    @r.post("/effect")
+    def effect(payload: Dict[str, Any]):
+        name = str(payload.get("name", "COMET"))
+        dur = int(payload.get("duration_ms", 800))
+        engine.push_event("manual.effect", {"name": name, "duration_ms": dur})
+        return {"ok": True}
+
+    @r.post("/base")
+    def base(payload: Dict[str, Any]):
+        name = str(payload.get("name", "BREATHE"))
+        color = payload.get("color")
+        engine.set_state(manual_base=(name, color))
+        return {"ok": True}
+
+    return r

--- a/modules/interactions/config/config.yml
+++ b/modules/interactions/config/config.yml
@@ -1,0 +1,76 @@
+server:
+  host: 0.0.0.0
+  port: 8095
+
+adapter:
+  mode: http
+  http_base_url: http://localhost:8092/neopixel
+
+hardware:
+  num_leds: 23  # 7 jewel + 16 stick (tek sıra)
+  segments:
+    - { name: jewel, start: 0, count: 7, reverse: false }
+    - { name: stick, start: 7, count: 16, reverse: false }
+
+tick_interval_ms: 800
+
+thresholds:
+  cpu_temp: { warm: 65, hot: 75, hysteresis: 3 }
+  cpu_load: { high: 0.9, window_s: 60 }
+  net: { burst_mbps: 20, min_duration_ms: 200 }
+
+defaults:
+  brightness: 0.6
+  idle:
+    base: { name: BREATHE, color: "#30E3CA", speed: slow }
+
+rules:
+  - id: cpu_hot
+    when: { cpu_temp_gte: 75 }
+    action: { base: { name: BREATHE, color: "#FF0000", speed: slow } }
+    priority: high
+
+  - id: cpu_warm
+    when: { cpu_temp_gte: 65, cpu_temp_lt: 75 }
+    action: { base: { name: PULSE, color: "#FF7F00", speed: slow } }
+    priority: medium
+
+  - id: cpu_load_high
+    when: { cpu_load_gte: 0.9 }
+    action: { base: { name: PULSE, color: "#FFD000", speed: slow } }
+    priority: medium
+
+  - id: net_burst
+    when: { net_burst: true }
+    action: { effect: { name: COMET, duration_ms: 800 } }
+    priority: medium
+    cooldown_ms: 3000
+
+  - id: speech_start
+    when: { event: speech.start }
+    action: { effect: { name: RAINBOW_CYCLE, duration_ms: 1000 } }
+    priority: high
+    cooldown_ms: 1000
+
+  - id: speech_end
+    when: { event: speech.end }
+    action: { effect: { name: COMET, duration_ms: 600 } }
+    priority: medium
+    cooldown_ms: 1000
+
+  - id: arduino_disconnected
+    when: { arduino_connected: false }
+    action: { base: { name: THEATER_CHASE, color: "#FF00FF" } }
+    priority: high
+
+  - id: error_ping
+    when: { event: error }
+    action: { effect: { name: METEOR, duration_ms: 500 } }
+    priority: critical
+    cooldown_ms: 10000
+
+  - id: warning_ping
+    when: { event: warning }
+    action: { effect: { name: PULSE, duration_ms: 400 } }
+    priority: high
+    cooldown_ms: 3000

--- a/modules/interactions/config_loader.py
+++ b/modules/interactions/config_loader.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+def load_config(config_path: Optional[str] = None, overrides: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Load YAML config for interactions module with sane defaults.
+
+    Priority: explicit path > modules/interactions/config/config.yml > defaults
+    """
+    base = {
+        "server": {"host": "0.0.0.0", "port": 8095},
+        "adapter": {"mode": "http", "http_base_url": "http://localhost:8092/neopixel"},
+        "hardware": {
+            "num_leds": 23,
+            "segments": [
+                {"name": "jewel", "start": 0, "count": 7, "reverse": False},
+                {"name": "stick", "start": 7, "count": 16, "reverse": False},
+            ],
+        },
+        "thresholds": {
+            "cpu_temp": {"warm": 65, "hot": 75, "hysteresis": 3},
+            "cpu_load": {"high": 0.9, "window_s": 60},
+            "net": {"burst_mbps": 20, "min_duration_ms": 200},
+        },
+        "defaults": {
+            "brightness": 0.6,
+            "idle": {"base": {"name": "BREATHE", "color": "#30E3CA", "speed": "slow"}},
+        },
+        "rules": [],
+    }
+
+    p = config_path
+    if not p:
+        here = os.path.dirname(__file__)
+        p = os.path.join(here, "config", "config.yml")
+
+    data: Dict[str, Any] = {}
+    if p and os.path.exists(p) and yaml is not None:
+        with open(p, "r", encoding="utf-8") as f:
+            loaded = yaml.safe_load(f) or {}
+            if isinstance(loaded, dict):
+                data = loaded
+
+    # merge shallowly
+    def _merge(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+        r = dict(a)
+        for k, v in b.items():
+            if isinstance(v, dict) and isinstance(r.get(k), dict):
+                r[k] = _merge(r[k], v)  # type: ignore
+            else:
+                r[k] = v
+        return r
+
+    cfg = _merge(base, data)
+    if overrides:
+        cfg = _merge(cfg, overrides)
+    return cfg

--- a/modules/interactions/services/__init__.py
+++ b/modules/interactions/services/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+try:
+    from .engine import InteractionEngine  # noqa: F401
+    from .metrics import MetricsCollector  # noqa: F401
+    from .rules import Rule  # noqa: F401
+except Exception:  # pragma: no cover
+    pass

--- a/modules/interactions/services/adapters/neopixel_client.py
+++ b/modules/interactions/services/adapters/neopixel_client.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover
+    requests = None  # type: ignore
+
+
+class NeoHttpClient:
+    def __init__(self, base_url: str) -> None:
+        self.base = base_url.rstrip("/")
+
+    def _post(self, path: str, json: Optional[Dict[str, Any]] = None, params: Optional[Dict[str, Any]] = None) -> None:
+        if requests is None:
+            return
+        try:
+            requests.post(self.base + path, json=json, params=params, timeout=1.5)
+        except Exception:
+            pass
+
+    # Basic controls
+    def clear(self) -> None:
+        self._post("/clear")
+
+    def fill(self, r: int, g: int, b: int) -> None:
+        self._post("/fill", params={"r_": r, "g": g, "b": b})
+
+    def animate(self, name: str, emotions: Optional[list[str]] = None, iterations: Optional[int] = None) -> None:
+        params: Dict[str, Any] = {"name": name}
+        if emotions:
+            params["emotions"] = emotions
+        if iterations is not None:
+            params["iterations"] = iterations
+        self._post("/animate", params=params)
+
+    # Friendly helpers
+    def set_base(self, name: str, color: Optional[str | tuple[int, int, int]] = None, speed: Optional[str] = None) -> None:
+        # Map to animate with optional emotions: if color hex provided, we cannot pass directly; fallback to simple fill
+        if name.upper() in {"BREATHE", "PULSE", "COMET", "METEOR", "RAINBOW", "RAINBOW_CYCLE", "THEATER_CHASE"}:
+            self.animate(name)
+        elif color and isinstance(color, tuple):
+            r, g, b = color
+            self.fill(r, g, b)
+        else:
+            self.animate(name)
+
+    def play_effect(self, name: str, duration_ms: int = 800, color: Optional[str | tuple[int, int, int]] = None) -> None:
+        # Trigger an animation for a brief time, then clear to allow base to repaint next tick
+        self.set_base(name, color=color)
+        time.sleep(max(0.0, duration_ms / 1000.0))
+        # Do not clear harshly; let engine repaint base on next cycle
+
+
+class NoOpNeoClient:
+    def clear(self) -> None:  # pragma: no cover
+        pass
+
+    def fill(self, r: int, g: int, b: int) -> None:  # pragma: no cover
+        pass
+
+    def animate(self, name: str, emotions: Optional[list[str]] = None, iterations: Optional[int] = None) -> None:  # pragma: no cover
+        pass
+
+    def set_base(self, name: str, color: Optional[str | tuple[int, int, int]] = None, speed: Optional[str] = None) -> None:  # pragma: no cover
+        pass
+
+    def play_effect(self, name: str, duration_ms: int = 800, color: Optional[str | tuple[int, int, int]] = None) -> None:  # pragma: no cover
+        pass

--- a/modules/interactions/services/engine.py
+++ b/modules/interactions/services/engine.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from .metrics import MetricsCollector
+from .rules import Rule, eval_condition, priority_rank
+from .adapters.neopixel_client import NeoHttpClient, NoOpNeoClient
+
+
+class InteractionEngine:
+    def __init__(self, cfg: Dict[str, Any]):
+        self.cfg = cfg
+        self.metrics = MetricsCollector(window_s=int(cfg.get("thresholds", {}).get("cpu_load", {}).get("window_s", 60)))
+        base_url = str(cfg.get("adapter", {}).get("http_base_url", "http://localhost:8092/neopixel"))
+        self.neo = NeoHttpClient(base_url) if base_url else NoOpNeoClient()
+        # rules
+        self.rules: List[Rule] = []
+        for r in cfg.get("rules", []) or []:
+            self.rules.append(Rule(
+                id=str(r.get("id")),
+                priority=str(r.get("priority", "medium")),
+                when=dict(r.get("when", {})),
+                action=dict(r.get("action", {})),
+                cooldown_ms=int(r.get("cooldown_ms", 0)),
+            ))
+        self.defaults = dict(cfg.get("defaults", {}))
+
+        # runtime
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._last_base: Optional[Tuple[str, Optional[str | tuple[int, int, int]]]] = None
+        self._active_effect_until: float = 0.0
+        self._ctx: Dict[str, Any] = {"arduino_connected": True}
+        self._last_net_burst: float = 0.0
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._loop, name="InteractionsEngine", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+    # API
+    def push_event(self, type_: str, data: Optional[Dict[str, Any]] = None) -> None:
+        with self._lock:
+            self._ctx["event"] = type_
+            if data:
+                self._ctx.setdefault("event_data", {}).update(data)
+
+    def set_state(self, **kwargs: Any) -> None:
+        with self._lock:
+            self._ctx.update(kwargs)
+
+    def get_state(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "metrics": self._ctx.get("metrics"),
+                "active_base": self._last_base,
+                "effect_active": time.time() < self._active_effect_until,
+                "ctx": {k: v for k, v in self._ctx.items() if k not in ("metrics",)},
+            }
+
+    # Loop
+    def _loop(self) -> None:
+        interval = float(self.cfg.get("tick_interval_ms", 800)) / 1000.0
+        while not self._stop.is_set():
+            self._tick()
+            time.sleep(interval)
+
+    def _tick(self) -> None:
+        now = time.time()
+        metrics = self.metrics.sample()
+        net_burst = False
+        try:
+            thr = self.cfg.get("thresholds", {}).get("net", {})
+            burst_mbps = float(thr.get("burst_mbps", 20))
+            min_dur_ms = int(thr.get("min_duration_ms", 200))
+            if metrics.net_mbps and metrics.net_mbps >= burst_mbps:
+                net_burst = True
+                self._last_net_burst = now + max(0.05, min_dur_ms / 1000.0)
+            elif now < self._last_net_burst:
+                net_burst = True
+        except Exception:
+            pass
+
+        with self._lock:
+            self._ctx["metrics"] = {
+                "cpu_temp": metrics.cpu_temp,
+                "cpu_load": metrics.cpu_load,
+                "net_mbps": metrics.net_mbps,
+            }
+            self._ctx["arduino_connected"] = self._ctx.get("arduino_connected", True)
+            self._ctx["net_burst"] = net_burst
+
+            # Evaluate rules
+            manual_base = self._ctx.pop("manual_base", None)
+            chosen: Optional[Rule] = None
+            for r in self.rules:
+                ctx = dict(self._ctx)
+                if eval_condition(r.when, ctx) and r.ready():
+                    if chosen is None or priority_rank(r.priority) > priority_rank(chosen.priority):
+                        chosen = r
+
+            # Render
+            if manual_base and now >= self._active_effect_until:
+                name, color = manual_base
+                key = (str(name).upper(), color)
+                if key != self._last_base:
+                    self._last_base = key
+                    self.neo.set_base(name=str(name), color=color)
+            elif chosen:
+                act = chosen.action or {}
+                # effect or base
+                if "effect" in act and now >= self._active_effect_until:
+                    eff = act["effect"] or {}
+                    name = str(eff.get("name", "COMET"))
+                    duration_ms = int(eff.get("duration_ms", 800))
+                    self._active_effect_until = now + duration_ms / 1000.0
+                    chosen.stamp()
+                    # play effect asynchronously to avoid blocking
+                    threading.Thread(target=self.neo.play_effect, args=(name, duration_ms), daemon=True).start()
+                elif "base" in act and now >= self._active_effect_until:
+                    base = act["base"] or {}
+                    name = str(base.get("name", self.defaults.get("idle", {}).get("base", {}).get("name", "BREATHE")))
+                    color = base.get("color")
+                    # Apply only if changed
+                    key = (name.upper(), color)
+                    if key != self._last_base:
+                        self._last_base = key
+                        self.neo.set_base(name=name, color=color)
+                        chosen.stamp()
+            else:
+                # No rule matched; ensure idle base
+                if now >= self._active_effect_until:
+                    idle = self.defaults.get("idle", {}).get("base", {})
+                    name = str(idle.get("name", "BREATHE"))
+                    color = idle.get("color")
+                    key = (name.upper(), color)
+                    if key != self._last_base:
+                        self._last_base = key
+                        self.neo.set_base(name=name, color=color)
+
+            # one-shot event is consumed
+            self._ctx.pop("event", None)

--- a/modules/interactions/services/metrics.py
+++ b/modules/interactions/services/metrics.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover
+    psutil = None  # type: ignore
+
+
+@dataclass
+class SysMetrics:
+    cpu_temp: Optional[float] = None
+    cpu_load: Optional[float] = None  # 0..1
+    net_mbps: Optional[float] = None
+    arduino_connected: Optional[bool] = None
+
+
+class MetricsCollector:
+    def __init__(self, window_s: int = 60) -> None:
+        self.window_s = window_s
+        self._last_net = None
+        self._last_time = None
+
+    def sample(self) -> SysMetrics:
+        m = SysMetrics()
+        # CPU temperature
+        m.cpu_temp = self._read_cpu_temp()
+        # load
+        m.cpu_load = self._read_cpu_load()
+        # network
+        m.net_mbps = self._read_net_speed_mbps()
+        # arduino (placeholder): external health check can set this via event/state
+        return m
+
+    def _read_cpu_temp(self) -> Optional[float]:
+        if psutil is None:
+            return None
+        try:
+            temps = psutil.sensors_temperatures()
+            if not temps:
+                return None
+            # pick first available
+            for _, arr in temps.items():
+                if arr:
+                    return float(getattr(arr[0], "current", None) or getattr(arr[0], "temp", None))
+        except Exception:
+            pass
+        # Fallback for Linux thermal zone
+        try:
+            with open("/sys/class/thermal/thermal_zone0/temp", "r") as f:
+                val = f.read().strip()
+                return float(val) / 1000.0
+        except Exception:
+            return None
+
+    def _read_cpu_load(self) -> Optional[float]:
+        if psutil is None:
+            return None
+        try:
+            return float(psutil.cpu_percent(interval=None)) / 100.0
+        except Exception:
+            return None
+
+    def _read_net_speed_mbps(self) -> Optional[float]:
+        if psutil is None:
+            return None
+        try:
+            now = time.time()
+            counters = psutil.net_io_counters()
+            if counters is None:
+                return None
+            bytes_total = counters.bytes_recv + counters.bytes_sent
+            if self._last_net is None or self._last_time is None:
+                self._last_net = bytes_total
+                self._last_time = now
+                return 0.0
+            dt = max(1e-6, now - self._last_time)
+            db = max(0, bytes_total - self._last_net)
+            mbps = (db * 8.0 / 1_000_000.0) / dt
+            self._last_net = bytes_total
+            self._last_time = now
+            return mbps
+        except Exception:
+            return None

--- a/modules/interactions/services/rules.py
+++ b/modules/interactions/services/rules.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+import time
+
+
+@dataclass
+class Rule:
+    id: str
+    priority: str = "medium"  # critical|high|medium|low
+    when: Dict[str, Any] = field(default_factory=dict)
+    action: Dict[str, Any] = field(default_factory=dict)
+    cooldown_ms: int = 0
+    _last_ts: float = field(default=0.0, init=False, repr=False)
+
+    def ready(self) -> bool:
+        if self.cooldown_ms <= 0:
+            return True
+        return (time.time() - self._last_ts) * 1000.0 >= self.cooldown_ms
+
+    def stamp(self) -> None:
+        self._last_ts = time.time()
+
+
+def priority_rank(p: str) -> int:
+    order = {"critical": 4, "high": 3, "medium": 2, "low": 1, "idle": 0}
+    return order.get(p.lower(), 0)
+
+
+def eval_condition(cond: Dict[str, Any], ctx: Dict[str, Any]) -> bool:
+    # Supported keys
+    def get(name: str):
+        return ctx.get(name)
+
+    # Events
+    if "event" in cond:
+        ev = get("event")
+        return ev == cond["event"]
+
+    # Simple comparisons
+    def ge(a, b): return (a is not None and b is not None and a >= b)
+    def lt(a, b): return (a is not None and b is not None and a < b)
+
+    m = get("metrics") or {}
+
+    if "cpu_temp_gte" in cond and not ge(m.get("cpu_temp"), cond["cpu_temp_gte"]):
+        return False
+    if "cpu_temp_lt" in cond and not lt(m.get("cpu_temp"), cond["cpu_temp_lt"]):
+        return False
+    if "cpu_load_gte" in cond and not ge(m.get("cpu_load"), cond["cpu_load_gte"]):
+        return False
+    if "net_burst" in cond:
+        # expect ctx["net_burst"] boolean set by engine heuristic
+        if bool(cond["net_burst"]) != bool(get("net_burst")):
+            return False
+    if "arduino_connected" in cond:
+        ac = get("arduino_connected")
+        if ac is None or bool(cond["arduino_connected"]) != bool(ac):
+            return False
+    return True

--- a/modules/interactions/tests/test_smoke.py
+++ b/modules/interactions/tests/test_smoke.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from modules.interactions.xInteractionsService import xInteractionsService
+
+
+def test_smoke():
+    svc = xInteractionsService()
+    svc.start()
+    state = svc.engine.get_state()
+    assert "metrics" in state
+    svc.stop()

--- a/modules/interactions/xInteractionsService.py
+++ b/modules/interactions/xInteractionsService.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+try:
+    from .config_loader import load_config
+    from .api.router import get_router
+    from .services.engine import InteractionEngine
+except Exception:  # pragma: no cover
+    from config_loader import load_config  # type: ignore
+    from api.router import get_router  # type: ignore
+    from services.engine import InteractionEngine  # type: ignore
+
+
+def create_app(config_path: str | None = None) -> FastAPI:
+    cfg = load_config(config_path)
+    engine = InteractionEngine(cfg)
+    engine.start()
+    app = FastAPI()
+    app.include_router(get_router(engine))
+    return app
+
+
+class xInteractionsService:
+    def __init__(self, config_overrides: dict | None = None) -> None:
+        self.cfg = load_config(overrides=config_overrides)
+        self.engine = InteractionEngine(self.cfg)
+
+    def start(self) -> None:
+        self.engine.start()
+
+    def stop(self) -> None:
+        self.engine.stop()
+
+
+if __name__ == "__main__":
+    import uvicorn
+    cfg = load_config()
+    uvicorn.run(
+        create_app(),
+        host=str(cfg.get("server", {}).get("host", "0.0.0.0")),
+        port=int(cfg.get("server", {}).get("port", 8095)),
+    )


### PR DESCRIPTION
- Introduced lightweight rule engine to select Base (continuous) and Transient (short) LED effects
- Connects to existing NeoPixel HTTP service under /neopixel
- Hardware mapping prepared for Jewel (7) + Stick (16); currently applies to full strip
- FastAPI integration: xInteractionsService.create_app(); default port 8095
- Endpoints:
  - GET  /interactions/state
  - POST /interactions/event   { type, data? }
  - POST /interactions/effect  { name, duration_ms? }
  - POST /interactions/base    { name, color? }
- Gateway integration: router can be mounted; rules call NeoPixel endpoints directly
- Configuration (modules/interactions/config/config.yml):
  - adapter.http_base_url (default http://localhost:8092/neopixel)
  - hardware.segments, thresholds (cpu_temp, cpu_load, net_burst), defaults.idle
  - rules evaluated in order with conditions (event, cpu_temp_gte/lt, cpu_load_gte, net_burst, arduino_connected), priority, cooldown_ms
- Default behavior:
  - cpu_temp ≥ 75°C → BREATHE red (base, high)
  - 65–74°C → PULSE orange (base, medium)
  - cpu_load ≥ 0.9 → PULSE yellow (base, medium)
  - net burst → COMET 800ms (transient, cooldown 3s)
  - speech.start → RAINBOW_CYCLE 1s; speech.end → COMET 600ms
  - Arduino disconnected → THEATER_CHASE magenta (base, high)
  - error → METEOR 500ms (critical, cooldown 10s); warning → PULSE 400ms (high, cooldown 3s)
  - idle → BREATHE teal
- Safe no-op when NeoPixel service is unavailable
- Documentation added: usage, gateway notes, and rule/config schema with examples