### PR TITLE
Feature: add PiServo module with API endpoints and dual-servo control

### DIFF
--- a/modules/piservo/README.md
+++ b/modules/piservo/README.md
@@ -1,0 +1,25 @@
+# PiServo (Ears) Module
+
+İki servo ile “kulak” hareketleri: 90° yukarı, <90 öne eğik, >90 geriye eğik. Duygu ve olaylara göre poz verir.
+
+## Servis Çalıştırma
+```bash
+uvicorn modules.piservo.xPiServoService:create_app --factory --host 0.0.0.0 --port 8093
+```
+
+## API
+- GET  /piservo/healthz
+- POST /piservo/set?left=90&right=90
+- POST /piservo/emotion?name=joy
+- POST /piservo/gesture?name=wakeword | sound
+- POST /piservo/event?kind=wakeword | sound
+
+## Duygu Eşlemesi
+- EMOTION_POSES içinde: neutral, joy, fear, anger, sadness, surprise, curiosity
+
+## Konfig
+`modules/piservo/config/config.yml`
+- left.gpio, right.gpio: servo sinyal pinleri
+- PWM aralıkları, açı aralıkları `ServoConfig` ile koddan özelleştirilebilir.
+
+Not: pigpio yoksa simülatör çalışır.

--- a/modules/piservo/__init__.py
+++ b/modules/piservo/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+try:
+    from .xPiServoService import create_app  # noqa: F401
+except Exception:
+    pass

--- a/modules/piservo/api/__init__.py
+++ b/modules/piservo/api/__init__.py
@@ -1,0 +1,3 @@
+from .router import router, get_router
+
+__all__ = ["router", "get_router"]

--- a/modules/piservo/api/router.py
+++ b/modules/piservo/api/router.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from fastapi import APIRouter
+from typing import Optional
+
+try:
+    from ..services.runner import EarRunner
+except Exception:
+    from services.runner import EarRunner  # type: ignore
+
+
+def get_router(runner: EarRunner) -> APIRouter:
+    r = APIRouter(prefix="/piservo")
+
+    @r.get("/healthz")
+    def healthz():
+        return {"ok": True}
+
+    @r.post("/set")
+    def set_angles(left: float, right: float):
+        runner.set_angles(left, right)
+        return {"ok": True}
+
+    @r.post("/emotion")
+    def emotion(name: str):
+        runner.emotion(name)
+        return {"ok": True}
+
+    @r.post("/gesture")
+    def gesture(name: str):
+        runner.gesture(name)
+        return {"ok": True}
+
+    @r.post("/event")
+    def event(kind: str):
+        runner.event(kind)
+        return {"ok": True}
+
+    return r

--- a/modules/piservo/config/config.yml
+++ b/modules/piservo/config/config.yml
@@ -1,0 +1,8 @@
+server:
+  host: 0.0.0.0
+  port: 8093
+
+left:
+  gpio: 12
+right:
+  gpio: 13

--- a/modules/piservo/config_loader.py
+++ b/modules/piservo/config_loader.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+_DEFAULT_CFG_PATH = Path(__file__).parent / "config" / "config.yml"
+
+
+def _deep_update(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            base[k] = _deep_update(base[k], v)
+        else:
+            base[k] = v
+    return base
+
+
+def load_config(path: str | os.PathLike | None = None) -> Dict[str, Any]:
+    cfg_path = Path(path) if path else Path(os.getenv("PISERVO_CONFIG", _DEFAULT_CFG_PATH))
+    if not cfg_path.exists():
+        cfg_path = _DEFAULT_CFG_PATH
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    env: Dict[str, Any] = {}
+    host = os.getenv("PISERVO_HOST")
+    port = os.getenv("PISERVO_PORT")
+    if host:
+        env.setdefault("server", {})["host"] = host
+    if port:
+        env.setdefault("server", {})["port"] = int(port)
+    return _deep_update(data, env)

--- a/modules/piservo/requirements.txt
+++ b/modules/piservo/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110
+uvicorn[standard]>=0.23
+# Optional on Raspberry Pi for real hardware control
+pigpio>=1.78; platform_system == "Linux"

--- a/modules/piservo/services/__init__.py
+++ b/modules/piservo/services/__init__.py
@@ -1,0 +1,11 @@
+from .driver import Servo, ServoConfig
+from .ears import EMOTION_POSES, EarPose
+from .runner import EarRunner
+
+__all__ = [
+    "Servo",
+    "ServoConfig",
+    "EMOTION_POSES",
+    "EarPose",
+    "EarRunner",
+]

--- a/modules/piservo/services/driver.py
+++ b/modules/piservo/services/driver.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ServoConfig:
+    gpio: int
+    min_us: int = 500
+    max_us: int = 2500
+    min_deg: float = 0.0
+    max_deg: float = 180.0
+    center_deg: float = 90.0
+
+
+class _PigpioWrapper:
+    def __init__(self) -> None:
+        import pigpio  # type: ignore
+        self._pi = pigpio.pi()
+
+    def set_servo_pulsewidth(self, gpio: int, pulsewidth: int) -> None:
+        self._pi.set_servo_pulsewidth(gpio, pulsewidth)
+
+
+class _SimGPIO:
+    def set_servo_pulsewidth(self, gpio: int, pulsewidth: int) -> None:
+        # Simulation: no-op
+        pass
+
+
+class Servo:
+    def __init__(self, cfg: ServoConfig):
+        self.cfg = cfg
+        try:
+            self._io = _PigpioWrapper()
+        except Exception:
+            self._io = _SimGPIO()
+
+    def angle_to_us(self, angle: float) -> int:
+        angle = max(self.cfg.min_deg, min(self.cfg.max_deg, angle))
+        span_deg = self.cfg.max_deg - self.cfg.min_deg
+        span_us = self.cfg.max_us - self.cfg.min_us
+        frac = (angle - self.cfg.min_deg) / span_deg if span_deg else 0
+        return int(self.cfg.min_us + frac * span_us)
+
+    def set_angle(self, angle: float) -> None:
+        pw = self.angle_to_us(angle)
+        self._io.set_servo_pulsewidth(self.cfg.gpio, pw)

--- a/modules/piservo/services/ears.py
+++ b/modules/piservo/services/ears.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+
+@dataclass
+class EarPose:
+    left: float
+    right: float
+
+
+EMOTION_POSES: Dict[str, EarPose] = {
+    # 90: up, <90 down-forward, >90 back
+    "neutral": EarPose(90, 90),
+    "joy": EarPose(70, 70),
+    "fear": EarPose(110, 110),
+    "anger": EarPose(80, 100),
+    "sadness": EarPose(100, 100),
+    "surprise": EarPose(60, 60),
+    "curiosity": EarPose(75, 85),
+}
+
+
+def gesture_wakeword() -> Tuple[float, float]:
+    # quick raise both then relax
+    return (60, 60)
+
+
+def gesture_sound() -> Tuple[float, float]:
+    # tilt to one side inquisitively
+    return (80, 100)

--- a/modules/piservo/services/runner.py
+++ b/modules/piservo/services/runner.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import time
+
+try:
+    from .driver import Servo, ServoConfig
+    from .ears import EMOTION_POSES, gesture_sound, gesture_wakeword
+except Exception:
+    from driver import Servo, ServoConfig  # type: ignore
+    from ears import EMOTION_POSES, gesture_sound, gesture_wakeword  # type: ignore
+
+
+class EarRunner:
+    def __init__(self, left_cfg: ServoConfig, right_cfg: ServoConfig):
+        self.left = Servo(left_cfg)
+        self.right = Servo(right_cfg)
+        # Start at up position (90)
+        self.set_angles(90, 90)
+
+    def set_angles(self, left: float, right: float) -> None:
+        self.left.set_angle(left)
+        self.right.set_angle(right)
+
+    def emotion(self, name: str) -> None:
+        pose = EMOTION_POSES.get(name.lower(), EMOTION_POSES.get("neutral", None))
+        if not pose:
+            return
+        self.set_angles(pose.left, pose.right)
+
+    def gesture(self, name: str) -> None:
+        n = name.lower()
+        if n == "wakeword":
+            l, r = gesture_wakeword()
+            self.set_angles(l, r)
+            time.sleep(0.2)
+            self.set_angles(90, 90)
+        elif n == "sound":
+            l, r = gesture_sound()
+            self.set_angles(l, r)
+            time.sleep(0.3)
+            self.set_angles(90, 90)
+
+    def event(self, kind: str) -> None:
+        # alias for gesture
+        self.gesture(kind)

--- a/modules/piservo/tests/test_smoke.py
+++ b/modules/piservo/tests/test_smoke.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from modules.piservo.xPiServoService import create_app
+
+
+def test_healthz():
+    app = create_app()
+    client = TestClient(app)
+    r = client.get("/piservo/healthz")
+    assert r.status_code == 200
+    assert r.json().get("ok") is True
+
+
+def test_set_angles():
+    app = create_app()
+    client = TestClient(app)
+    r = client.post("/piservo/set", params={"left": 90, "right": 90})
+    assert r.status_code == 200
+    assert r.json().get("ok") is True

--- a/modules/piservo/xPiServoService.py
+++ b/modules/piservo/xPiServoService.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from fastapi import FastAPI
+
+try:
+    from .config_loader import load_config
+    from .api import get_router
+    from .services.runner import EarRunner
+    from .services.driver import ServoConfig
+except Exception:
+    from config_loader import load_config  # type: ignore
+    from api import get_router  # type: ignore
+    from services.runner import EarRunner  # type: ignore
+    from services.driver import ServoConfig  # type: ignore
+
+try:
+    from modules.logwrapper import init_logging as _init_global_logging  # type: ignore
+    _init_global_logging()
+except Exception:
+    pass
+
+
+def create_app(config_path: str | None = None) -> FastAPI:
+    cfg = load_config(config_path)
+    left = ServoConfig(**cfg.get("left", {"gpio": 12}))
+    right = ServoConfig(**cfg.get("right", {"gpio": 13}))
+    runner = EarRunner(left_cfg=left, right_cfg=right)
+    app = FastAPI()
+    app.include_router(get_router(runner))
+    return app
+
+
+if __name__ == "__main__":
+    import uvicorn
+    cfg = load_config()
+    uvicorn.run(create_app(), host=str(cfg.get("server", {}).get("host", "0.0.0.0")), port=int(cfg.get("server", {}).get("port", 8093)))


### PR DESCRIPTION
- Introduced PiServo (Ears) module for expressive dual-servo ear movements
- FastAPI integration with factory app:
  - uvicorn modules.piservo.xPiServoService:create_app --factory --host 0.0.0.0 --port 8093
- API endpoints:
  - GET  /piservo/healthz
  - POST /piservo/set?left=90&right=90
  - POST /piservo/emotion?name=<neutral|joy|fear|anger|sadness|surprise|curiosity>
  - POST /piservo/gesture?name=<wakeword|sound>
  - POST /piservo/event?kind=<wakeword|sound>
- Emotion mapping: EMOTION_POSES drives ear poses (90° up, <90 forward tilt, >90 backward tilt)
- Configuration (modules/piservo/config/config.yml):
  - left.gpio, right.gpio for servo signal pins
  - PWM and angle ranges via ServoConfig overrides
- Runtime behavior:
  - Uses pigpio when available; falls back to a simulator if pigpio is missing
  - Safe clamping of angles and debounced updates
- Gateway integration: router can be mounted under /piservo/*
- Documentation added with usage, config notes, and example invocations