### PR TITLE
Feature/ Whatsapp Notifier

### DIFF
--- a/modules/notifier/README.md
+++ b/modules/notifier/README.md
@@ -1,17 +1,25 @@
 # Notifier
 
-Telegram/Discord bildirimleri için basit köprü. İsteğe bağlı Telegram botu uzun anket (polling) ile çalışır.
+A lightweight bridge for Telegram, Discord, and WhatsApp Web alerts. Telegram support optionally spins up a long-polling bot so you can issue commands back into the platform.
 
-## Kurulum
-1) `modules/notifier/config/config.yml` içinde bot ayarlarını doldur:
+## Setup
+1. Fill out `modules/notifier/config/config.yml`:
 ```
 telegram:
 	bot_token: "123:ABC"
-	chat_id: "-100..."        # varsayılan gönderim hedefi
-	allowed_user_ids: [123456] # boş ise herkes
+	chat_id: "-100..."        # default outbound target
+	allowed_user_ids: [123456] # empty list means everyone
 	polling:
-		enabled: true            # botu aktif eder
+		enabled: true            # toggle Telegram bot
 		interval_sec: 2.5
+whatsapp_web:
+	enabled: false
+	recipient: "+905551111111"
+	send_mode: "instant"      # instant | schedule
+	schedule_delay_sec: 90     # only used when send_mode=schedule
+	wait_time_sec: 15          # pywhatkit wait before typing
+	close_time_sec: 5          # wait before tab close
+	tab_close: true            # close tab after send
 discord:
 	webhook: ""
 quiet_hours:
@@ -20,23 +28,36 @@ quiet_hours:
 	end: "08:00"
 ```
 
-2) Servisi çalıştır: `python -m modules.notifier.xNotifierService` veya üst seviye orchestrator.
+2. Run the service via `python -m modules.notifier.xNotifierService` (or through your orchestrator).
 
 ## API
 - GET `/notify/healthz`
-- POST `/notify/telegram` `{ text, chat_id? }` (configte token/chat_id gerektirir)
-- POST `/notify/discord` `{ text }` (configte webhook gerektirir)
+- POST `/notify/telegram` `{ text, chat_id? }` (requires token + chat_id in config)
+- POST `/notify/discord` `{ text }` (requires webhook in config)
+- POST `/notify/whatsapp` `{ text, to?, delay_sec? }` (drives the WhatsApp Web sender)
 - POST `/notify/test`
 
 ## Telegram bot
-- `polling.enabled` true ise bot arkaplanda `/start`, `/ping`, `/help` komutlarını dinler.
-- Mesaj geldiğinde quiet hours etkinse bildirim göndermez, bilgi mesajı yollar.
-- `allowed_user_ids` doluysa sadece listedekileri kabul eder.
-- Genişletilmiş komutlar (gateway base_url üzerinden):
-	- `/status` modül sağlık özeti
-	- `/snap` kamera snapshot linki
-	- `/stream` kamera stream linki
-	- `/pt <pan> <tilt>` pan/tilt kontrolü (derece)
-	- `/pan <deg>`, `/tilt <deg>` tek eksen
-	- `/neofill r g b`, `/neoclear` NeoPixel kontrolü
-	- `/say <metin>` TTS (speak servisi)
+- When `polling.enabled` is true, the bot listens for `/start`, `/ping`, `/help` in the background.
+- Quiet hours suppress outgoing alerts and respond with an informational notice instead.
+- If `allowed_user_ids` is non-empty, only those Telegram user IDs can interact.
+- Extended commands (proxied to the gateway `base_url`):
+	- `/status` overall module health
+	- `/snap` camera snapshot
+	- `/stream` MJPEG stream info
+	- `/pt <pan> <tilt>` pan/tilt degrees
+	- `/pan <deg>` and `/tilt <deg>` single-axis helpers
+	- `/neofill r g b`, `/neoclear` NeoPixel controls
+	- `/say <text>` triggers the speak service
+
+## WhatsApp Web sender
+- Install `pywhatkit` (and its dependencies) inside the environment: `pip install pywhatkit`.
+- Log into WhatsApp Web manually and keep the browser session open; the sender hijacks that session to send a message.
+- Configure the `whatsapp_web` block:
+	- `recipient` must be an international MSISDN (e.g., `+9055...`).
+	- `send_mode: instant` uses `pywhatkit.sendwhatmsg_instantly` (~15 s prep window).
+	- `send_mode: schedule` falls back to `pywhatkit.sendwhatmsg`, so delivery happens at least `schedule_delay_sec` seconds later.
+	- `wait_time_sec`, `close_time_sec`, and `tab_close` mirror pywhatkit’s browser automation knobs.
+- POST `/notify/whatsapp` with `{ "text": "Hello" }` to deliver; optionally override the destination with `to`.
+- This flow is outbound-only: no inbound commands or media uploads through WhatsApp Web.
+- During sending, avoid touching keyboard/mouse—pywhatkit simulates human interaction and can be interrupted easily.

--- a/modules/notifier/config/config.yml
+++ b/modules/notifier/config/config.yml
@@ -11,6 +11,14 @@ telegram:
   polling:
     enabled: true
     interval_sec: 2.5
+whatsapp_web:
+  enabled: true
+  recipient: "your_number_here"
+  send_mode: "instant"   # instant | schedule
+  schedule_delay_sec: 90
+  wait_time_sec: 15
+  close_time_sec: 5
+  tab_close: false
 discord:
   webhook: ""
 quiet_hours:

--- a/modules/notifier/services/whatsapp_web.py
+++ b/modules/notifier/services/whatsapp_web.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+logger = logging.getLogger("notifier.whatsapp_web")
+
+
+class WhatsAppWebSender:
+    def __init__(
+        self,
+        recipient: str,
+        *,
+        wait_time_sec: int = 15,
+        tab_close: bool = True,
+        close_time_sec: int = 5,
+        send_mode: str = "instant",
+        schedule_delay_sec: int = 75,
+    ) -> None:
+        self._recipient = recipient.strip()
+        self._wait_time = max(wait_time_sec, 1)
+        self._tab_close = tab_close
+        self._close_time = max(close_time_sec, 1)
+        self._send_mode = send_mode if send_mode in ("instant", "schedule") else "instant"
+        self._schedule_delay = max(schedule_delay_sec, 60)
+
+    async def send_text(self, text: str, *, to: str | None = None, delay_override_sec: int | None = None) -> bool:
+        message = text.strip()
+        target = (to or self._recipient).strip()
+        if not message or not target:
+            return False
+        delay = delay_override_sec if delay_override_sec is not None else None
+        if delay is None and self._send_mode == "schedule":
+            delay = self._schedule_delay
+        return await asyncio.to_thread(self._send_blocking, target, message, delay)
+
+    def _send_blocking(self, phone_number: str, message: str, delay_sec: int | None) -> bool:
+        try:
+            import pywhatkit
+        except Exception:
+            logger.error("pywhatkit bulunamadı. `pip install pywhatkit` çalıştırın.")
+            return False
+        try:
+            if delay_sec is None:
+                pywhatkit.sendwhatmsg_instantly(
+                    phone_number,
+                    message,
+                    wait_time=self._wait_time,
+                    tab_close=self._tab_close,
+                    close_time=self._close_time,
+                )
+                return True
+            fire_at = datetime.now() + timedelta(seconds=max(delay_sec, 60))
+            pywhatkit.sendwhatmsg(
+                phone_number,
+                message,
+                fire_at.hour,
+                fire_at.minute,
+                wait_time=self._wait_time,
+                tab_close=self._tab_close,
+                close_time=self._close_time,
+            )
+            return True
+        except Exception:
+            logger.exception("WhatsApp Web mesajı gönderilemedi")
+            return False
+
+
+def build_whatsapp_web_sender(cfg: dict) -> WhatsAppWebSender | None:
+    web_cfg = cfg.get("whatsapp_web", {})
+    if not web_cfg.get("enabled", False):
+        return None
+    recipient = str(web_cfg.get("recipient", "")).strip()
+    if not recipient:
+        logger.warning("whatsapp_web etkin ancak recipient boş")
+        return None
+    return WhatsAppWebSender(
+        recipient=recipient,
+        wait_time_sec=int(web_cfg.get("wait_time_sec", 15)),
+        tab_close=bool(web_cfg.get("tab_close", True)),
+        close_time_sec=int(web_cfg.get("close_time_sec", 5)),
+        send_mode=str(web_cfg.get("send_mode", "instant")),
+        schedule_delay_sec=int(web_cfg.get("schedule_delay_sec", 75)),
+    )

--- a/modules/notifier/xNotifierService.py
+++ b/modules/notifier/xNotifierService.py
@@ -6,6 +6,7 @@ import logging
 from .config_loader import load_config
 from .api.router import get_router
 from .services.telegram_bot import build_telegram_bot
+from .services.whatsapp_web import build_whatsapp_web_sender
 
 
 logger = logging.getLogger("notifier")
@@ -13,22 +14,24 @@ logger = logging.getLogger("notifier")
 
 def create_app(config_path: str | None = None) -> FastAPI:
     cfg = load_config(config_path)
-    bot = build_telegram_bot(cfg)
+    telegram_bot = build_telegram_bot(cfg)
+    whatsapp_web = build_whatsapp_web_sender(cfg)
 
     app = FastAPI(title="Notifier Service")
-    app.include_router(get_router(cfg, bot))
+    app.include_router(get_router(cfg, telegram_bot, whatsapp_web))
 
     polling_enabled = cfg.get("telegram", {}).get("polling", {}).get("enabled", False)
-    if bot and polling_enabled:
+    if telegram_bot and polling_enabled:
         @app.on_event("startup")
         async def _start_bot() -> None:
             logger.info("starting telegram bot polling")
-            await bot.start()
+            await telegram_bot.start()
 
         @app.on_event("shutdown")
         async def _stop_bot() -> None:
             logger.info("stopping telegram bot polling")
-            await bot.stop()
+            await telegram_bot.stop()
+
     return app
 
 


### PR DESCRIPTION
This pull request adds outbound WhatsApp Web notification support to the notifier module, alongside Telegram and Discord. It introduces a new `WhatsAppWebSender` service, updates configuration and documentation, and extends the API to allow sending WhatsApp messages through the same notification interface. The changes are grouped below by theme.

**WhatsApp Web Integration:**

* Added new `WhatsAppWebSender` service in `modules/notifier/services/whatsapp_web.py`, supporting instant and scheduled WhatsApp Web messaging via `pywhatkit`. Includes configuration options for timing, tab management, and recipient.
* Updated `modules/notifier/config/config.yml` to include a new `whatsapp_web` block with options for enabling, recipient, send mode, and timing parameters.
* Modified `modules/notifier/xNotifierService.py` to build and inject the WhatsApp sender into the app and router, similar to the Telegram bot.

**API Enhancements:**

* Extended the API in `modules/notifier/api/router.py` to add a `/notify/whatsapp` POST endpoint for sending WhatsApp messages, with support for overriding the recipient and scheduling delay. Also updated the `/notify/test` endpoint to test WhatsApp delivery. [[1]](diffhunk://#diff-a2ec85e5adb9b4955f7378d701237bafcce6714d8ae2c24f464ca0fdfe2483d8R8) [[2]](diffhunk://#diff-a2ec85e5adb9b4955f7378d701237bafcce6714d8ae2c24f464ca0fdfe2483d8L25-R30) [[3]](diffhunk://#diff-a2ec85e5adb9b4955f7378d701237bafcce6714d8ae2c24f464ca0fdfe2483d8L58-R63) [[4]](diffhunk://#diff-a2ec85e5adb9b4955f7378d701237bafcce6714d8ae2c24f464ca0fdfe2483d8R73-R94)

**Documentation Updates:**

* Revised `modules/notifier/README.md` to document WhatsApp Web support, configuration, usage, and caveats. Improved English language clarity and updated API documentation. [[1]](diffhunk://#diff-3b6a22d88e4498e98fad517f4fec68f1f11110998db0fc72c7191bbfe3b2e47eL3-R22) [[2]](diffhunk://#diff-3b6a22d88e4498e98fad517f4fec68f1f11110998db0fc72c7191bbfe3b2e47eL23-R63)