### PR TITLE
Feature/Controller

### DIFF
--- a/arduino/firmware/xMain/actuators/xNemaController.cpp
+++ b/arduino/firmware/xMain/actuators/xNemaController.cpp
@@ -1,0 +1,62 @@
+#include "xNemaController.h"
+#include "../xConfig.h"
+#include <math.h>
+
+// Use global Robot instance for steppers and the global radio instance
+#include "../xRobot.h"
+extern Robot robot;
+extern EbyteRadio g_ebyteRadio;
+
+NemaController g_nema(&robot.steppers, &g_ebyteRadio);
+
+NemaController::NemaController(StepperPair* pair, EbyteRadio* radio): steppers(pair), radio(radio) {}
+
+void NemaController::begin(){
+  if (steppers) steppers->begin();
+}
+
+// Map joystick X,Y (-127..127) to left/right stepper speeds (steps/s)
+void NemaController::applyJoystick(int8_t x, int8_t y){
+  // Normalize to -1..1
+  float nx = (float)x / 127.0f;
+  float ny = (float)y / 127.0f;
+  // Tank mixing: left = forward + turn, right = forward - turn
+  float left = ny + nx;
+  float right = ny - nx;
+  // Clamp
+  left = constrain(left, -1.0f, 1.0f);
+  right = constrain(right, -1.0f, 1.0f);
+  float lspd = left * maxSpeedStepsPerSec;
+  float rspd = right * maxSpeedStepsPerSec;
+  // Apply toggles
+  if (!leftEnabled) lspd = 0.0f;
+  if (!rightEnabled) rspd = 0.0f;
+  steppers->setSpeed(lspd, rspd);
+}
+
+void NemaController::update(){
+  // If new packet arrived, process it
+  if (radio && radio->newPacket){
+    // Copy and consume
+    MasterPacket1 pkt = radio->lastPkt;
+    radio->newPacket = false;
+
+    // Determine toggles based on button bits (BTN_MOTOR1 = right, BTN_MOTOR2 = left)
+    // Button bits documented in xMaster/src/SharedVariables.h
+    const uint16_t BTN_MOTOR1 = (1<<9);
+    const uint16_t BTN_MOTOR2 = (1<<10);
+    rightEnabled = (pkt.Buttons & BTN_MOTOR1);
+    leftEnabled  = (pkt.Buttons & BTN_MOTOR2);
+
+    // Apply joystick mapping
+    applyJoystick(pkt.Rstick_X, pkt.Rstick_Y);
+
+    // Display incoming info
+    String s = String("SRC:") + radio->lastSource + " ";
+    s += String("X=") + pkt.Rstick_X + ",Y=" + pkt.Rstick_Y;
+    SERIAL_IO.println(s);
+  }
+
+  // Always run stepper update so AccelStepper processes ramping
+  if (steppers) steppers->update();
+}

--- a/arduino/firmware/xMain/actuators/xNemaController.cpp
+++ b/arduino/firmware/xMain/actuators/xNemaController.cpp
@@ -17,6 +17,10 @@ void NemaController::begin(){
 
 // Map joystick X,Y (-127..127) to left/right stepper speeds (steps/s)
 void NemaController::applyJoystick(int8_t x, int8_t y){
+  if (!_enabled){
+    if (steppers) steppers->setSpeed(0.0f, 0.0f);
+    return;
+  }
   // Normalize to -1..1
   float nx = (float)x / 127.0f;
   float ny = (float)y / 127.0f;
@@ -60,3 +64,16 @@ void NemaController::update(){
   // Always run stepper update so AccelStepper processes ramping
   if (steppers) steppers->update();
 }
+
+void NemaController::setEnabled(bool en){
+  _enabled = en;
+  if (!_enabled && steppers){
+    steppers->setSpeed(0.0f, 0.0f);
+  }
+}
+
+bool NemaController::isEnabled() const { return _enabled; }
+
+bool NemaController::isLeftMotorEnabled() const { return leftEnabled; }
+
+bool NemaController::isRightMotorEnabled() const { return rightEnabled; }

--- a/arduino/firmware/xMain/actuators/xNemaController.h
+++ b/arduino/firmware/xMain/actuators/xNemaController.h
@@ -1,0 +1,26 @@
+#ifndef X_NEMA_CONTROLLER_H
+#define X_NEMA_CONTROLLER_H
+
+#include <Arduino.h>
+#include "xStepperPair.h"
+#include "../peripherals/xEbyteRadio.h"
+#include "../xConfig.h"
+
+class NemaController {
+public:
+  NemaController(StepperPair* pair, EbyteRadio* radio);
+  void begin();
+  void update(); // poll radio packets and drive steppers
+
+private:
+  StepperPair* steppers;
+  EbyteRadio* radio;
+  bool leftEnabled{false};
+  bool rightEnabled{false};
+  float maxSpeedStepsPerSec{SKATE_SPEED_LIMIT};
+  void applyJoystick(int8_t x, int8_t y);
+};
+
+extern NemaController g_nema;
+
+#endif // X_NEMA_CONTROLLER_H

--- a/arduino/firmware/xMain/actuators/xNemaController.h
+++ b/arduino/firmware/xMain/actuators/xNemaController.h
@@ -11,6 +11,10 @@ public:
   NemaController(StepperPair* pair, EbyteRadio* radio);
   void begin();
   void update(); // poll radio packets and drive steppers
+  void setEnabled(bool en);
+  bool isEnabled() const;
+  bool isLeftMotorEnabled() const;
+  bool isRightMotorEnabled() const;
 
 private:
   StepperPair* steppers;
@@ -18,6 +22,7 @@ private:
   bool leftEnabled{false};
   bool rightEnabled{false};
   float maxSpeedStepsPerSec{SKATE_SPEED_LIMIT};
+  bool _enabled{true};
   void applyJoystick(int8_t x, int8_t y);
 };
 

--- a/arduino/firmware/xMain/app/xIrMenuController.h
+++ b/arduino/firmware/xMain/app/xIrMenuController.h
@@ -5,6 +5,8 @@
 #include <EEPROM.h>
 #include "../xConfig.h"
 #include "../xRobot.h"
+#include "../peripherals/xEbyteRadio.h"
+#include "../actuators/xNemaController.h"
 
 #if IR_ENABLED
 
@@ -45,6 +47,8 @@ extern HallEncoder g_hall1;
 extern bool g_lcd1Ok;
 extern uint8_t g_lcdRouteMask;
 #endif
+
+extern EbyteRadio g_ebyteRadio;
 
 class IrMenuController {
 public:
@@ -381,6 +385,20 @@ public:
       return;
     }
 
+    if (_state == STATE_REMOTE){
+      if (k == "OK"){
+        g_nema.setEnabled(!g_nema.isEnabled());
+        emitEvent("remote_ctrl", g_nema.isEnabled() ? 1 : 0);
+        showRemote();
+        return;
+      }
+      if (k == "UP" || k == "DOWN"){
+        showRemote();
+        return;
+      }
+      return;
+    }
+
     // Sensor pages: allow changing subpage on IMU
     if (_state == STATE_IMU){
       if (k == "UP" || k == "DOWN"){
@@ -435,6 +453,12 @@ public:
         refreshLive(robot);
       }
     }
+    if (_state == STATE_REMOTE){
+      if (_lastUiMs == 0 || (_now - _lastUiMs) >= 250UL){
+        _lastUiMs = _now;
+        showRemote();
+      }
+    }
 
     // Non-blocking morse player
     tickMorse();
@@ -449,6 +473,7 @@ public:
     STATE_SERVO_DEG,
     STATE_LASER,
     STATE_SOUND,
+    STATE_REMOTE,
     STATE_ULTRA,
     STATE_IMU,
     STATE_RFID,
@@ -462,6 +487,7 @@ public:
     MENU_IMU,
     MENU_RFID,
     MENU_SOUND,
+    MENU_REMOTE,
     MENU_CALIBRATE,
     MENU_SYSTEM,
     MENU_COUNT,
@@ -520,6 +546,7 @@ public:
       case MENU_IMU: return "IMU";
       case MENU_RFID: return "RFID";
       case MENU_SOUND: return "SOUND";
+      case MENU_REMOTE: return "REMOTE";
       case MENU_CALIBRATE: return "CALIB";
       case MENU_SYSTEM: return "SYSTEM";
       default: return "MENU";
@@ -532,6 +559,18 @@ public:
 
   void showMenu(){
     lcdPrint("MENU", menuName(_menuIndex) + " OK=ENTER");
+  }
+
+  void showRemote(){
+    String status = g_nema.isEnabled() ? "REMOTE ON" : "REMOTE OFF";
+    String src = g_ebyteRadio.lastSource;
+    if (src.length() == 0) src = "PKT:NONE";
+    if (src.length() > 12) src = src.substring(0, 12);
+    String axes = "X" + String(g_ebyteRadio.lastPkt.Rstick_X) + "Y" + String(g_ebyteRadio.lastPkt.Rstick_Y);
+    String bottom = src + " " + axes;
+    if (g_nema.isLeftMotorEnabled()) bottom += " L";
+    if (g_nema.isRightMotorEnabled()) bottom += " R";
+    lcdPrint(status, bottom);
   }
 
 
@@ -581,6 +620,12 @@ public:
         _lastUiMs = 0;
         _soundIndex = 0;
         showSound();
+        return;
+
+      case MENU_REMOTE:
+        _state = STATE_REMOTE;
+        _lastUiMs = 0;
+        showRemote();
         return;
 
       case MENU_CALIBRATE:

--- a/arduino/firmware/xMain/peripherals/xEbyteRadio.cpp
+++ b/arduino/firmware/xMain/peripherals/xEbyteRadio.cpp
@@ -1,0 +1,103 @@
+#include "xEbyteRadio.h"
+#include "../xConfig.h"
+#include "xLcdDisplay.h"
+
+#include <SPI.h>
+
+EbyteRadio g_ebyteRadio;
+
+EbyteRadio::EbyteRadio(): radio(nullptr), _ce(0), _csn(0), newPacket(false) {}
+
+void EbyteRadio::begin(uint8_t cePin, uint8_t csnPin, uint8_t channel){
+  _ce = cePin; _csn = csnPin;
+  radio = new RF24(_ce, _csn);
+  if (!radio->begin()){
+    SERIAL_IO.println(F("EbyteRadio: radio begin failed"));
+    return;
+  }
+  radio->setPALevel(RF24_PA_LOW);
+  radio->setChannel(channel);
+  radio->setDataRate(RF24_1MBPS);
+  radio->enableDynamicPayloads();
+  radio->setAutoAck(false);
+  radio->openReadingPipe(1, masterAddr);
+  radio->openWritingPipe(slaveAddr);
+  radio->startListening();
+  SERIAL_IO.println(F("EbyteRadio: initialized"));
+}
+
+void EbyteRadio::poll(){
+  if (!radio) return;
+  if (!radio->available()) return;
+  uint8_t size = radio->getDynamicPayloadSize();
+
+  // Support two over-the-wire formats:
+  // 1) Legacy: raw MasterPacket1 (5 bytes)
+  // 2) Framed: [seq:1][payload:MasterPacket1][crc16:2] => total 8 bytes
+  if (size == sizeof(MasterPacket1)){
+    // Legacy packet (no seq, no crc)
+    radio->read(&lastPkt, size);
+    lastSource = "RF_EBYTE";
+    newPacket = true;
+    // Send lightweight ACK with seq=0 indicating legacy
+    sendAck(0, lastPkt, 0);
+    String s = String("pkt R(Legacy): X=") + lastPkt.Rstick_X + ",Y=" + lastPkt.Rstick_Y + ",B=0x" + String(lastPkt.Buttons, HEX);
+    SERIAL_IO.println(s);
+  } else if (size == (1 + sizeof(MasterPacket1) + 2)){
+    // Framed packet with seq + payload + crc
+    uint8_t buf[1 + sizeof(MasterPacket1) + 2];
+    radio->read(buf, sizeof(buf));
+    uint8_t seq = buf[0];
+    // payload copy
+    memcpy(&lastPkt, buf + 1, sizeof(MasterPacket1));
+    uint16_t rxCrc = (uint16_t)buf[1 + sizeof(MasterPacket1)] | ((uint16_t)buf[1 + sizeof(MasterPacket1) + 1] << 8);
+    // compute crc over seq + payload
+    uint16_t calc = crc16(buf, 1 + sizeof(MasterPacket1));
+    if (calc == rxCrc){
+      lastSource = String("RF_EBYTE") + "#" + String(seq);
+      newPacket = true;
+      sendAck(seq, lastPkt, 0);
+      String s = String("pkt R(Framed): seq=") + seq + " X=" + lastPkt.Rstick_X + ",Y=" + lastPkt.Rstick_Y + ",B=0x" + String(lastPkt.Buttons, HEX);
+      SERIAL_IO.println(s);
+    } else {
+      // CRC mismatch — request NACK (status=1)
+      sendAck(seq, lastPkt, 1);
+      SERIAL_IO.println(F("pkt R: CRC FAIL"));
+    }
+  } else {
+    // Unknown frame size — flush
+    radio->flush_rx();
+  }
+}
+
+// ACK packet format: [ack_seq:1][rx_X:1][rx_Y:1][status:1][crc16:2]
+void EbyteRadio::sendAck(uint8_t seq, const MasterPacket1 &echo, uint8_t status){
+  if (!radio) return;
+  uint8_t out[1+1+1+1+2];
+  out[0] = seq;
+  out[1] = (uint8_t)echo.Rstick_X;
+  out[2] = (uint8_t)echo.Rstick_Y;
+  out[3] = status;
+  uint16_t crc = crc16(out, 4);
+  out[4] = (uint8_t)(crc & 0xFF);
+  out[5] = (uint8_t)((crc >> 8) & 0xFF);
+
+  // send ACK (temporarily stop listening)
+  radio->stopListening();
+  bool ok = radio->write(out, sizeof(out));
+  if (!ok){ SERIAL_IO.println(F("EbyteRadio: ACK send failed")); }
+  radio->startListening();
+}
+
+// CRC-16/CCITT-FALSE (0x1021 init 0xFFFF)
+uint16_t EbyteRadio::crc16(const uint8_t *data, size_t len){
+  uint16_t crc = 0xFFFF;
+  for (size_t i = 0; i < len; ++i){
+    crc ^= (uint16_t)data[i] << 8;
+    for (uint8_t j = 0; j < 8; ++j){
+      if (crc & 0x8000) crc = (crc << 1) ^ 0x1021;
+      else crc <<= 1;
+    }
+  }
+  return crc;
+}

--- a/arduino/firmware/xMain/peripherals/xEbyteRadio.h
+++ b/arduino/firmware/xMain/peripherals/xEbyteRadio.h
@@ -30,8 +30,8 @@ public:
 private:
   RF24* radio;
   uint8_t _ce, _csn;
-  const uint8_t masterAddr[6] = "UST01"; // ESP master address
-  const uint8_t slaveAddr[6]  = "ALT01"; // our address
+  const uint8_t masterAddr[6] = { 'U','S','T','0','1','\0' }; // ESP master address
+  const uint8_t slaveAddr[6]  = { 'A','L','T','0','1','\0' }; // our address
   // CRC helper
   static uint16_t crc16(const uint8_t *data, size_t len);
 };

--- a/arduino/firmware/xMain/peripherals/xEbyteRadio.h
+++ b/arduino/firmware/xMain/peripherals/xEbyteRadio.h
@@ -1,0 +1,41 @@
+#ifndef X_EBYTE_RADIO_H
+#define X_EBYTE_RADIO_H
+
+#include <Arduino.h>
+#include <RF24.h>
+
+// Minimal EBYTE (nRF24L01 compatible) receiver wrapper for Master packets
+// - non-blocking poll() which sets `newPacket` when a fresh packet arrives
+
+struct __attribute__((packed)) MasterPacket1 {
+  int8_t  Rstick_X;
+  int8_t  Rstick_Y;
+  uint8_t R2;
+  uint16_t Buttons;
+};
+
+class EbyteRadio {
+public:
+  EbyteRadio();
+  void begin(uint8_t cePin, uint8_t csnPin, uint8_t channel = 100);
+  void poll(); // call frequently from loop/task
+
+  // Last received packet (valid when newPacket == true until next poll)
+  MasterPacket1 lastPkt;
+  String lastSource;
+  volatile bool newPacket;
+  // Send an ACK/telemetry back to the master. Non-blocking-ish (will stop/start listening briefly).
+  void sendAck(uint8_t seq, const MasterPacket1 &echo, uint8_t status);
+
+private:
+  RF24* radio;
+  uint8_t _ce, _csn;
+  const uint8_t masterAddr[6] = "UST01"; // ESP master address
+  const uint8_t slaveAddr[6]  = "ALT01"; // our address
+  // CRC helper
+  static uint16_t crc16(const uint8_t *data, size_t len);
+};
+
+extern EbyteRadio g_ebyteRadio;
+
+#endif // X_EBYTE_RADIO_H

--- a/arduino/firmware/xMain/xConfig.h
+++ b/arduino/firmware/xMain/xConfig.h
@@ -154,6 +154,14 @@ static const uint8_t POSE_SIT[SERVO_COUNT_TOTAL]   = {90,90, 90,90};
 // Peripherals (optional)
 // =====================
 
+// Radio (nRF24 / EBYTE E01) default CE/CSN pins (override if needed)
+#ifndef RADIO_CE_PIN
+#define RADIO_CE_PIN 46
+#endif
+#ifndef RADIO_CSN_PIN
+#define RADIO_CSN_PIN 47
+#endif
+
 // I2C LCD (16x1 büyük font modül; çoğu 16x1 aslında 8x2 adreslemeye sahiptir)
 #ifndef LCD_ENABLED
 #define LCD_ENABLED 1

--- a/arduino/firmware/xMain/xMain.ino
+++ b/arduino/firmware/xMain/xMain.ino
@@ -4,6 +4,7 @@
 #include "xRobot.h"
 #include <EEPROM.h>
 #include "xPeripherals.h"
+#include "actuators/xNemaController.h"
 
 #include "app/xLcdHub.h"
 #include "app/xIrMenuController.h"
@@ -106,6 +107,12 @@ void setup(){
   g_hall1.begin(HALL_PIN_1, 4);
   robot.steppers.attachHallEncoders(&g_hall0, &g_hall1);
 #endif
+  // Initialize EBYTE radio (nRF24L01 compatible) and NEMA controller
+#if defined(RADIO_CE_PIN) && defined(RADIO_CSN_PIN)
+  g_ebyteRadio.begin(RADIO_CE_PIN, RADIO_CSN_PIN, 100);
+#endif
+  // Initialize NEMA controller
+  g_nema.begin();
   // Auto-load IMU offsets if present
   if (EEPROM.read(EEPROM_ADDR_MAGIC)==EEPROM_MAGIC){ float p,r; EEPROM.get(EEPROM_ADDR_IMU_OFF,p); EEPROM.get(EEPROM_ADDR_IMU_OFF+sizeof(float),r); robot.imu.setOffsets(p,r); }
   // Load persisted buzzer frequencies if present
@@ -377,6 +384,9 @@ void loop(){
   if (HEARTBEAT_TIMEOUT_MS>0 && (millis() - lastHeartbeatMs > HEARTBEAT_TIMEOUT_MS)){
     robot.estop();
   }
+  // Poll radio and update NEMA controller
+  g_ebyteRadio.poll();
+  g_nema.update();
   // Telemetry periodic output
   if (telemetryOn && millis() - lastTelemetryMs >= telemetryInterval){
     lastTelemetryMs = millis(); robot.imu.read();

--- a/arduino/firmware/xMain/xMain.ino
+++ b/arduino/firmware/xMain/xMain.ino
@@ -4,6 +4,8 @@
 #include "xRobot.h"
 #include <EEPROM.h>
 #include "xPeripherals.h"
+#include "peripherals/xEbyteRadio.cpp"
+#include "actuators/xNemaController.cpp"
 #include "actuators/xNemaController.h"
 
 #include "app/xLcdHub.h"

--- a/arduino/firmware/xMain/xPeripherals.h
+++ b/arduino/firmware/xMain/xPeripherals.h
@@ -17,4 +17,8 @@ extern class OledDisplay g_oled;
 #endif
 #include "peripherals/logo_Ads_z.h"
 #include "peripherals/xIrKeyReader.h"
+#include "peripherals/xEbyteRadio.h"
+
+// Ebyte radio instance (nRF24L01 compatible)
+extern EbyteRadio g_ebyteRadio;
 #endif // ROBOT_PERIPHERALS_H


### PR DESCRIPTION
This pull request adds support for controlling the robot's NEMA stepper motors using an nRF24L01-compatible EBYTE radio receiver. It introduces new `EbyteRadio` and `NemaController` classes, integrates them into the main firmware loop, and provides configuration for radio pins. The key changes are grouped by new features and integration:

**New radio receiver and stepper controller:**

* Added `EbyteRadio` class (`xEbyteRadio.h`, `xEbyteRadio.cpp`) to handle non-blocking reception of master packets over nRF24L01-compatible radios, including legacy and framed packet formats, CRC checking, and ACK responses. [[1]](diffhunk://#diff-4cd9cee5d9386e018e2fcbf2f3f274622928b2c19235b40f0cf8ad684c9d6227R1-R41) [[2]](diffhunk://#diff-40f4b75551bb5dc0594eb2ff9fd8e6a38627566f21cb9875b824ea0d538eee29R1-R103)
* Added `NemaController` class (`xNemaController.h`, `xNemaController.cpp`) to map joystick commands from received packets to left/right stepper speeds, with support for enable toggles and speed limiting. [[1]](diffhunk://#diff-ead1b57f5a6d1c92b28345067ca2690d58a48e7161abdfec66096dac0d739f54R1-R26) [[2]](diffhunk://#diff-d5a4d02487f6a59bb2729d275eb249711a75e03c863f70b315ffeedf60b9a83dR1-R62)

**Integration into main firmware:**

* Instantiated and initialized `g_ebyteRadio` and `g_nema` in the main firmware (`xMain.ino`), including setup and loop integration for polling the radio and updating the NEMA controller each cycle. [[1]](diffhunk://#diff-73ff36e824424b0c03b3f40422b140a935965eca515989c1322fbb0497b83975R7) [[2]](diffhunk://#diff-73ff36e824424b0c03b3f40422b140a935965eca515989c1322fbb0497b83975R110-R115) [[3]](diffhunk://#diff-73ff36e824424b0c03b3f40422b140a935965eca515989c1322fbb0497b83975R387-R389)
* Exposed the radio instance in the global peripherals header for use across the codebase.

**Configuration:**

* Added default pin definitions for the radio CE and CSN pins in `xConfig.h`, allowing easy override if needed.