### PR TITLE
Fix/gateway module mount and degraded startup

### DIFF
--- a/modules/arduino_serial/api/router.py
+++ b/modules/arduino_serial/api/router.py
@@ -24,8 +24,11 @@ def get_router(svc: xArduinoSerialService) -> APIRouter:
 
     @r.post("/send")
     def send(obj: Dict[str, Any]):
-        svc.send(obj)
-        return {"ok": True}
+        try:
+            svc.send(obj)
+            return {"ok": True}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
 
     @r.post("/request")
     def request(obj: Dict[str, Any], timeout: float = 1.0):

--- a/modules/gateway/config/config.yml
+++ b/modules/gateway/config/config.yml
@@ -15,6 +15,7 @@ include:
   logs: true
   animate: true
   piservo: true
+  autonomy: true
   ota: true
   mutagen: true
   hardware: true

--- a/modules/gateway/services/bootstrap.py
+++ b/modules/gateway/services/bootstrap.py
@@ -21,9 +21,13 @@ def _include_arduino(app: FastAPI, started: Dict[str, object]) -> None:
 
 
 def _include_vision_bridge(app: FastAPI, started: Dict[str, object]) -> None:
+    from modules.vision_bridge.config_loader import load_config as load_vision_cfg  # type: ignore
+    from modules.vision_bridge.services.processor import VisionProcessor  # type: ignore
     from modules.vision_bridge.api.router import get_router as get_vision_router  # type: ignore
-    app.include_router(get_vision_router(started.get("arduino")))
-    started["vision_bridge"] = True
+    vcfg = load_vision_cfg(None)
+    processor = VisionProcessor(vcfg)
+    app.include_router(get_vision_router(processor, started.get("arduino")))
+    started["vision_bridge"] = processor
 
 
 def _include_neopixel(app: FastAPI, started: Dict[str, object]) -> None:
@@ -152,7 +156,10 @@ def _include_animate(app: FastAPI, started: Dict[str, object]) -> None:
     ardu = started.get("arduino")
     anim = xAnimateService(serial=ardu) if ardu is not None else xAnimateService()
     if hasattr(anim, "start"):
-        anim.start()
+        try:
+            anim.start()
+        except Exception as exc:
+            logger.warning("animate service failed to start, running degraded: %s", exc)
     started["animate"] = anim
     app.include_router(get_anim_router(anim))
     logger.info("module animate mounted")

--- a/modules/gateway/tests/test_mounts.py
+++ b/modules/gateway/tests/test_mounts.py
@@ -1,8 +1,65 @@
 def test_gateway_bootstrap_mounts():
     from fastapi import FastAPI
     from modules.gateway.services.bootstrap import bootstrap
-    cfg = {"include": {"ota": True, "mutagen": True}}
+
+    include_cfg = {
+        "arduino": True,
+        "vision_bridge": True,
+        "neopixel": True,
+        "interactions": True,
+        "speak": True,
+        "speech": True,
+        "wakeword": True,
+        "ollama": True,
+        "wiki_rag": True,
+        "camera": True,
+        "logs": True,
+        "animate": True,
+        "piservo": True,
+        "autonomy": True,
+        "hardware": True,
+        "telemetry": True,
+        "diagnostics": True,
+        "state_manager": True,
+        "scheduler": True,
+        "notifier": True,
+        "calibration": True,
+        "config_center": True,
+        "ota": False,
+        "mutagen": False,
+    }
+
+    cfg = {"include": include_cfg}
     app = FastAPI()
     started = bootstrap(app, cfg)
-    assert "ota" in started
-    assert "mutagen" in started
+
+    expected_mounted = [
+        "arduino",
+        "vision_bridge",
+        "neopixel",
+        "interactions",
+        "speak",
+        "speech",
+        "wakeword",
+        "ollama",
+        "wiki_rag",
+        "camera",
+        "logs",
+        "animate",
+        "piservo",
+        "autonomy",
+        "hardware",
+        "telemetry",
+        "diagnostics",
+        "state_manager",
+        "scheduler",
+        "notifier",
+        "calibration",
+        "config_center",
+    ]
+
+    for module_name in expected_mounted:
+        assert module_name in started
+
+    assert "ota" not in started
+    assert "mutagen" not in started

--- a/modules/neopixel/api/router.py
+++ b/modules/neopixel/api/router.py
@@ -21,7 +21,11 @@ class AnimationsResponse(BaseModel):
 
 
 class AnimateRequest(BaseModel):
-    name: str = Field(..., description="Animation key. Use /neopixel/animations to pick one", example="WAVE")
+    name: str = Field(
+        ...,
+        description="Animation key. Use /neopixel/animations to pick one",
+        json_schema_extra={"example": "WAVE"},
+    )
     color: Optional[str] = Field(None, description='Color as "R,G,B" or "#RRGGBB" (optional)')
     r: Optional[int] = Field(None, ge=0, le=255, description="Red channel (0-255)")
     g: Optional[int] = Field(None, ge=0, le=255, description="Green channel (0-255)")

--- a/modules/vision_bridge/api/router.py
+++ b/modules/vision_bridge/api/router.py
@@ -107,11 +107,13 @@ def get_router(processor: Any, ardu: Optional[xArduinoSerialService] = None) -> 
     def latest_results(limit: int = 10):
         if not processor:
             raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if not hasattr(processor, "latest_results"):
+            raise HTTPException(status_code=503, detail="Vision processor missing latest_results interface")
         limit = max(0, int(limit))
-        results = processor.latest_results
+        results = list(getattr(processor, "latest_results", []) or [])
         if limit:
             results = results[:limit]
-        return {"results": results, "count": len(processor.latest_results)}
+        return {"results": results, "count": len(results)}
 
     @r.post("/results", tags=["remote"], summary="Ingest remote detection results")
     def ingest_results(request: Request, payload: dict):
@@ -122,6 +124,8 @@ def get_router(processor: Any, ardu: Optional[xArduinoSerialService] = None) -> 
         """
         if not processor:
             raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if not hasattr(processor, "config") or not hasattr(processor, "ingest_remote_results"):
+            raise HTTPException(status_code=503, detail="Vision processor missing remote ingestion interface")
 
         cfg_remote = processor.config.get("remote", {})
         if not cfg_remote.get("accept_results", True):

--- a/modules/wakeword/xWakewordService.py
+++ b/modules/wakeword/xWakewordService.py
@@ -112,6 +112,7 @@ class WakewordService:
         self._last_trigger_ts = 0.0
         self._active_window = False
         self._thread: Optional[threading.Thread] = None
+        self._degraded_reason: Optional[str] = None
 
         self.capture = AudioCapture(self.cfg.get("audio", {}))
         wake_cfg = self.cfg.get("wakeword", {})
@@ -120,7 +121,17 @@ class WakewordService:
         self._openwakeword = None
         self._recognizer = None
         if self.engine == "openwakeword":
-            self._openwakeword = OpenWakewordRunner(self.cfg.get("openwakeword", {}))
+            try:
+                self._openwakeword = OpenWakewordRunner(self.cfg.get("openwakeword", {}))
+            except Exception as exc:
+                self._degraded_reason = str(exc)
+                logger.warning("wakeword openwakeword unavailable, falling back to vosk: %s", exc)
+                self.engine = "vosk"
+                try:
+                    self._recognizer = Recognizer(_resolve_model_paths(self.cfg.get("recognition", {})))
+                    self._degraded_reason = None
+                except Exception as rec_exc:
+                    self._degraded_reason = str(rec_exc)
         else:
             self._recognizer = Recognizer(_resolve_model_paths(self.cfg.get("recognition", {})))
         self.actions = WakewordActions(self.cfg.get("actions", {}))
@@ -132,6 +143,10 @@ class WakewordService:
             self._listening = True
         self._stop_event.clear()
         try:
+            if self._openwakeword is None and self._recognizer is None:
+                logger.warning("wakeword service running degraded: no engine available")
+                self._degraded_reason = self._degraded_reason or "no wakeword engine available"
+                return
             stream = self.capture.stream()
             if self.engine == "openwakeword" and self._openwakeword is not None:
                 for label in self._openwakeword.run(stream):
@@ -143,6 +158,9 @@ class WakewordService:
                     if self._stop_event.is_set():
                         break
                     self._handle_result(result)
+        except Exception as exc:
+            self._degraded_reason = str(exc)
+            logger.warning("wakeword listener stopped, running degraded: %s", exc)
         finally:
             with self._lock:
                 self._listening = False
@@ -214,6 +232,9 @@ class WakewordService:
                 "active_window": self._active_window,
                 "last_trigger_ts": self._last_trigger_ts,
                 "wakewords": list(self.detector.cfg.words),
+                "engine": self.engine,
+                "degraded": bool(self._degraded_reason),
+                "degraded_reason": self._degraded_reason,
             }
 
 


### PR DESCRIPTION
This pull request introduces several improvements to error handling, degraded mode reporting, and service initialization across multiple modules. It enhances robustness by ensuring services can gracefully handle failures and provide better diagnostics, especially for the wakeword and animation services. Additionally, it updates configuration and testing to include new modules and options.

**Error handling and degraded mode improvements:**

* Added degraded mode handling and improved error reporting to the `xWakewordService` class, including fallback to Vosk if OpenWakeword initialization fails, and reporting degraded status and reasons in the `status` method. The service now logs and tracks degraded states during startup and runtime. (`modules/wakeword/xWakewordService.py`) [[1]](diffhunk://#diff-9a54a41177550a8cc97068fdd78b77de07ee8ddea9b5f667866ef1b4b0446a42R115) [[2]](diffhunk://#diff-9a54a41177550a8cc97068fdd78b77de07ee8ddea9b5f667866ef1b4b0446a42R124-R134) [[3]](diffhunk://#diff-9a54a41177550a8cc97068fdd78b77de07ee8ddea9b5f667866ef1b4b0446a42R146-R149) [[4]](diffhunk://#diff-9a54a41177550a8cc97068fdd78b77de07ee8ddea9b5f667866ef1b4b0446a42R161-R163) [[5]](diffhunk://#diff-9a54a41177550a8cc97068fdd78b77de07ee8ddea9b5f667866ef1b4b0446a42R235-R237)
* Wrapped the animation service startup in a try/except block, logging a warning and continuing in degraded mode if initialization fails. (`modules/gateway/services/bootstrap.py`)
* Improved error handling in the Arduino serial API, returning structured error responses on exceptions. (`modules/arduino_serial/api/router.py`)

**Vision bridge and API robustness:**

* Enhanced the vision bridge integration to initialize and pass a `VisionProcessor` instance, and updated API endpoints to check for required processor interfaces, returning appropriate errors if missing. (`modules/gateway/services/bootstrap.py`, `modules/vision_bridge/api/router.py`) [[1]](diffhunk://#diff-87bb298ded2e0675e144e849278933e492cb235fa0b92c4a731d1f8ca132a147R24-R30) [[2]](diffhunk://#diff-73a3862b90bb1f4c2f357a1ca2e1ed081d421fa0a65fd3bf7a8b8f1f1bfab1caR110-R116) [[3]](diffhunk://#diff-73a3862b90bb1f4c2f357a1ca2e1ed081d421fa0a65fd3bf7a8b8f1f1bfab1caR127-R128)

**Configuration and testing updates:**

* Added the `autonomy` module to the gateway configuration and expanded the test bootstrap to cover a wide range of modules, verifying correct mounting and exclusion of disabled modules. (`modules/gateway/config/config.yml`, `modules/gateway/tests/test_mounts.py`) [[1]](diffhunk://#diff-6517541f89ecbff72d9ec0461380c95d620e9c61a286913e9094115a4a4e7f4fR18) [[2]](diffhunk://#diff-a71fcf34a3a9352a4d266f9874e9da9a3d2b5ec6914ebe9389a04caca06c8ca5L4-R65)

**API usability improvements:**

* Updated the `AnimateRequest` model to use `json_schema_extra` for the example value, improving OpenAPI documentation. (`modules/neopixel/api/router.py`)