### PR TITLE
Stack/oled faces integration

### DIFF
--- a/arduino/firmware/xMain/app/xCommands.h
+++ b/arduino/firmware/xMain/app/xCommands.h
@@ -105,6 +105,54 @@ static inline void handleJson(const String &line){
     return;
   }
 
+  if (line.indexOf("\"cmd\":\"oled\"")>=0){
+#if OLED_ENABLED
+    String action = parseJsonStringAfter(line, "\"action\":\"");
+    String name = parseJsonStringAfter(line, "\"name\":\"");
+    action.toLowerCase();
+    name.toLowerCase();
+
+    if (line.indexOf("\"list\":true")>=0 || action == "list"){
+      String out = String("{\"ok\":true,\"bitmaps\":\"") + Protocol::escape(String(OledDisplay::bitmapCatalog())) + String("\",\"animations\":\"") + Protocol::escape(String(OledDisplay::animationCatalog())) + String("\"}");
+      SERIAL_IO.println(out);
+      return;
+    }
+
+    if (action == "stop"){
+      g_oled.stopAnimation();
+      Protocol::sendOk("oled_anim_stopped");
+      return;
+    }
+
+    if (action == "anim"){
+      if (name.length() == 0) { Protocol::sendErr("no_name"); return; }
+      bool ok = g_oled.startAnimationByName(name);
+      if (ok) Protocol::sendOk("oled_anim_ok");
+      else Protocol::sendErr("unknown_oled_anim");
+      return;
+    }
+
+    if (action == "logo"){
+      g_oled.stopAnimation();
+      g_oled.showLogo();
+      Protocol::sendOk("oled_logo");
+      return;
+    }
+
+    if (name.length() == 0) {
+      // backwards compatibility default
+      name = "normal";
+    }
+
+    bool ok = g_oled.showBitmapByName(name);
+    if (ok) Protocol::sendOk("oled_bitmap_ok");
+    else Protocol::sendErr("unknown_oled_bitmap");
+#else
+    Protocol::sendErr("oled_disabled");
+#endif
+    return;
+  }
+
   if (line.indexOf("\"cmd\":\"rfid_last\"")>=0){
 #if RFID_ENABLED
     String out = String("{\"ok\":true,\"rfid\":\"") + Protocol::escape(g_lastRfid) + "\"}";

--- a/arduino/firmware/xMain/peripherals/xOledDisplay.h
+++ b/arduino/firmware/xMain/peripherals/xOledDisplay.h
@@ -9,6 +9,12 @@
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
+#if __has_include(<Irisoled.h>)
+#include <Irisoled.h>
+#define IRISOLED_LIB_AVAILABLE 1
+#else
+#define IRISOLED_LIB_AVAILABLE 0
+#endif
 
 class OledDisplay {
 public:
@@ -30,19 +36,201 @@ public:
     return true;
   }
 
+  void update(){
+#if IRISOLED_LIB_AVAILABLE
+    if (!_display || !_anim.running) return;
+    unsigned long now = millis();
+    if (now - _anim.last_ms < _anim.delay_ms) return;
+    _anim.last_ms = now;
+    const unsigned char* bmp = _nextFrame();
+    if (bmp) drawBitmapByPtr(bmp);
+#endif
+  }
+
   void showLogo(){
     if (!_display) return;
+#if IRISOLED_LIB_AVAILABLE
+    stopAnimation();
+    drawBitmapByPtr(Irisoled::logo);
+#else
     _display->clearDisplay();
     // Custom XBM logo support (draw via drawBitmap)
     extern const unsigned char image_Ads_z_bits[] U8X8_PROGMEM;
     _display->drawBitmap(27, 0, image_Ads_z_bits, 74, 64, SSD1306_WHITE);
     _display->display();
+#endif
+  }
+
+  bool showBitmapByName(const String &name){
+#if IRISOLED_LIB_AVAILABLE
+    const unsigned char* bmp = resolveBitmap(name);
+    if (!bmp) return false;
+    stopAnimation();
+    drawBitmapByPtr(bmp);
+    return true;
+#else
+    String n = name;
+    n.trim();
+    n.toLowerCase();
+    if (n == "logo") { showLogo(); return true; }
+    return false;
+#endif
+  }
+
+  bool startAnimationByName(const String &name){
+#if IRISOLED_LIB_AVAILABLE
+    String n = normalize(name);
+    if (n == "wink"){
+      static const unsigned char* const frames[] = { Irisoled::normal, Irisoled::wink_left, Irisoled::normal, Irisoled::wink_right, Irisoled::normal };
+      return setAnim(frames, sizeof(frames)/sizeof(frames[0]), 140);
+    }
+    if (n == "blink"){
+      static const unsigned char* const frames[] = { Irisoled::normal, Irisoled::blink_up, Irisoled::blink, Irisoled::blink_down, Irisoled::normal };
+      return setAnim(frames, sizeof(frames)/sizeof(frames[0]), 120);
+    }
+    if (n == "scan"){
+      static const unsigned char* const frames[] = { Irisoled::normal, Irisoled::look_left, Irisoled::look_right, Irisoled::look_up, Irisoled::look_down, Irisoled::normal };
+      return setAnim(frames, sizeof(frames)/sizeof(frames[0]), 170);
+    }
+    if (n == "sleep"){
+      static const unsigned char* const frames[] = { Irisoled::sleepy, Irisoled::blink_down, Irisoled::blink, Irisoled::blink_up, Irisoled::sleepy };
+      return setAnim(frames, sizeof(frames)/sizeof(frames[0]), 260);
+    }
+    if (n == "alert"){
+      static const unsigned char* const frames[] = { Irisoled::alert, Irisoled::focused, Irisoled::warning, Irisoled::furious, Irisoled::alert };
+      return setAnim(frames, sizeof(frames)/sizeof(frames[0]), 130);
+    }
+    if (n == "emotive"){
+      static const unsigned char* const frames[] = { Irisoled::happy, Irisoled::excited, Irisoled::surprised, Irisoled::sad, Irisoled::worried, Irisoled::normal };
+      return setAnim(frames, sizeof(frames)/sizeof(frames[0]), 170);
+    }
+    if (n == "icons"){
+      static const unsigned char* const frames[] = { Irisoled::logo, Irisoled::mode, Irisoled::left_signal, Irisoled::right_signal, Irisoled::battery_low, Irisoled::battery, Irisoled::battery_full, Irisoled::warning };
+      return setAnim(frames, sizeof(frames)/sizeof(frames[0]), 260);
+    }
+    if (n == "all"){
+      static const unsigned char* const frames[] = {
+        Irisoled::alert, Irisoled::angry, Irisoled::blink_down, Irisoled::blink_up, Irisoled::blink,
+        Irisoled::bored, Irisoled::despair, Irisoled::disoriented, Irisoled::excited, Irisoled::focused,
+        Irisoled::furious, Irisoled::happy, Irisoled::look_down, Irisoled::look_left, Irisoled::look_right,
+        Irisoled::look_up, Irisoled::normal, Irisoled::sad, Irisoled::scared, Irisoled::sleepy,
+        Irisoled::surprised, Irisoled::wink_left, Irisoled::wink_right, Irisoled::worried,
+        Irisoled::battery_full, Irisoled::battery_low, Irisoled::battery, Irisoled::left_signal,
+        Irisoled::logo, Irisoled::mode, Irisoled::right_signal, Irisoled::warning
+      };
+      return setAnim(frames, sizeof(frames)/sizeof(frames[0]), 180);
+    }
+    return false;
+#else
+    (void)name;
+    return false;
+#endif
+  }
+
+  void stopAnimation(){
+    _anim.running = false;
+    _anim.frames = nullptr;
+    _anim.count = 0;
+    _anim.index = 0;
+  }
+
+  static const char* bitmapCatalog(){
+#if IRISOLED_LIB_AVAILABLE
+    return "alert,angry,blink_down,blink_up,blink,bored,despair,disoriented,excited,focused,furious,happy,look_down,look_left,look_right,look_up,normal,sad,scared,sleepy,surprised,wink_left,wink_right,worried,battery_full,battery_low,battery,left_signal,logo,mode,right_signal,warning";
+#else
+    return "logo";
+#endif
+  }
+
+  static const char* animationCatalog(){
+    return "wink,blink,scan,sleep,alert,emotive,icons,all";
   }
 
 private:
   uint8_t _addr{OLED_I2C_ADDR};
   uint8_t _w{128}, _h{64};
   Adafruit_SSD1306 *_display{nullptr};
+
+#if IRISOLED_LIB_AVAILABLE
+  struct AnimState {
+    const unsigned char* const* frames{nullptr};
+    uint8_t count{0};
+    uint8_t index{0};
+    uint16_t delay_ms{180};
+    unsigned long last_ms{0};
+    bool running{false};
+  } _anim;
+
+  static String normalize(const String &s){
+    String n = s;
+    n.trim();
+    n.toLowerCase();
+    return n;
+  }
+
+  bool setAnim(const unsigned char* const* frames, uint8_t count, uint16_t delayMs){
+    if (!frames || count == 0) return false;
+    _anim.frames = frames;
+    _anim.count = count;
+    _anim.index = 0;
+    _anim.delay_ms = delayMs;
+    _anim.last_ms = 0;
+    _anim.running = true;
+    drawBitmapByPtr(_anim.frames[0]);
+    return true;
+  }
+
+  const unsigned char* _nextFrame(){
+    if (!_anim.running || !_anim.frames || _anim.count == 0) return nullptr;
+    _anim.index = (uint8_t)((_anim.index + 1) % _anim.count);
+    return _anim.frames[_anim.index];
+  }
+
+  void drawBitmapByPtr(const unsigned char* bmp){
+    if (!_display || !bmp) return;
+    _display->clearDisplay();
+    _display->drawBitmap(0, 0, bmp, _w, _h, SSD1306_WHITE);
+    _display->display();
+  }
+
+  static const unsigned char* resolveBitmap(const String &name){
+    String n = normalize(name);
+    if (n == "alert") return Irisoled::alert;
+    if (n == "angry") return Irisoled::angry;
+    if (n == "blink_down") return Irisoled::blink_down;
+    if (n == "blink_up") return Irisoled::blink_up;
+    if (n == "blink") return Irisoled::blink;
+    if (n == "bored") return Irisoled::bored;
+    if (n == "despair") return Irisoled::despair;
+    if (n == "disoriented") return Irisoled::disoriented;
+    if (n == "excited") return Irisoled::excited;
+    if (n == "focused") return Irisoled::focused;
+    if (n == "furious") return Irisoled::furious;
+    if (n == "happy") return Irisoled::happy;
+    if (n == "look_down") return Irisoled::look_down;
+    if (n == "look_left") return Irisoled::look_left;
+    if (n == "look_right") return Irisoled::look_right;
+    if (n == "look_up") return Irisoled::look_up;
+    if (n == "normal") return Irisoled::normal;
+    if (n == "sad") return Irisoled::sad;
+    if (n == "scared") return Irisoled::scared;
+    if (n == "sleepy") return Irisoled::sleepy;
+    if (n == "surprised") return Irisoled::surprised;
+    if (n == "wink_left") return Irisoled::wink_left;
+    if (n == "wink_right") return Irisoled::wink_right;
+    if (n == "worried") return Irisoled::worried;
+    if (n == "battery_full") return Irisoled::battery_full;
+    if (n == "battery_low") return Irisoled::battery_low;
+    if (n == "battery") return Irisoled::battery;
+    if (n == "left_signal") return Irisoled::left_signal;
+    if (n == "logo") return Irisoled::logo;
+    if (n == "mode") return Irisoled::mode;
+    if (n == "right_signal") return Irisoled::right_signal;
+    if (n == "warning") return Irisoled::warning;
+    return nullptr;
+  }
+
+#endif
 };
 #else
 // If Adafruit_SSD1306 not available, provide a stub so firmware still compiles
@@ -50,11 +238,27 @@ class OledDisplay {
 public:
   bool begin(uint8_t = 0x3C, uint8_t = 128, uint8_t = 64){ return false; }
   void showLogo() {}
+  bool showBitmapByName(const String &){ return false; }
+  bool startAnimationByName(const String &){ return false; }
+  void stopAnimation() {}
+  void update() {}
+  static const char* bitmapCatalog(){ return ""; }
+  static const char* animationCatalog(){ return ""; }
 };
 #endif // include check
 #else
 // OLED disabled -> empty stub
-class OledDisplay { public: bool begin(uint8_t=0){ return false; } void showLogo(){} };
+class OledDisplay {
+public:
+  bool begin(uint8_t=0){ return false; }
+  void showLogo(){}
+  bool showBitmapByName(const String &){ return false; }
+  bool startAnimationByName(const String &){ return false; }
+  void stopAnimation() {}
+  void update() {}
+  static const char* bitmapCatalog(){ return ""; }
+  static const char* animationCatalog(){ return ""; }
+};
 #endif // OLED_ENABLED
 
 #endif // SENTRY_PERIPHERALS_OLED_H

--- a/arduino/firmware/xMain/xMain.ino
+++ b/arduino/firmware/xMain/xMain.ino
@@ -289,6 +289,9 @@ void setup(){
 void loop(){
   String line; if (Protocol::readLine(SERIAL_IO, line)) handleJson(line);
   robot.update();
+#if OLED_ENABLED
+  g_oled.update();
+#endif
     // Peripherals polling
   #if RFID_ENABLED
     if (g_rfid.poll()){

--- a/modules/arduino_serial/api/router.py
+++ b/modules/arduino_serial/api/router.py
@@ -11,6 +11,12 @@ except Exception:
 def get_router(svc: xArduinoSerialService) -> APIRouter:
     r = APIRouter(prefix="/arduino")
 
+    def _safe_call(fn):
+        try:
+            return fn()
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
     @r.get("/healthz")
     def healthz():
         # try ping
@@ -24,33 +30,25 @@ def get_router(svc: xArduinoSerialService) -> APIRouter:
 
     @r.post("/send")
     def send(obj: Dict[str, Any]):
-        try:
+        def _do_send():
             svc.send(obj)
             return {"ok": True}
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(_do_send)
 
     @r.post("/request")
     def request(obj: Dict[str, Any], timeout: float = 1.0):
-        try:
+        def _do_request():
             resp = svc.request(obj, timeout=timeout)
             return {"ok": True, "resp": resp}
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(_do_request)
 
     @r.post("/telemetry/start")
     def telemetry_start(interval_ms: int = 100):
-        try:
-            return svc.telemetry_start(interval_ms)
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(lambda: svc.telemetry_start(interval_ms))
 
     @r.post("/telemetry/stop")
     def telemetry_stop():
-        try:
-            return svc.telemetry_stop()
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(svc.telemetry_stop)
 
     @r.get("/rfid/last")
     def rfid_last():
@@ -68,72 +66,62 @@ def get_router(svc: xArduinoSerialService) -> APIRouter:
     # Laser controls
     @r.post("/laser/one/{which}")
     def laser_one(which: int):
-        try:
-            return svc.laser_on(which)
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(lambda: svc.laser_on(which))
 
     @r.post("/laser/both")
     def laser_both():
-        try:
-            return svc.laser_both_on()
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(svc.laser_both_on)
 
     @r.post("/laser/off")
     def laser_off():
-        try:
-            return svc.laser_off()
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(svc.laser_off)
 
     @r.post("/cute/{name}")
     def cute(name: str):
-        try:
-            return svc.cute(name)
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(lambda: svc.cute(name))
 
     @r.post("/sound/out/{mode}")
     def sound_out(mode: str):
-        try:
-            return svc.sound_output(mode)
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(lambda: svc.sound_output(mode))
 
     @r.post("/buzzer")
     def buzzer(freq: int = 2200, ms: int = 60, out: Optional[str] = None):
-        try:
-            return svc.buzzer(freq=freq, ms=ms, out=out)
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(lambda: svc.buzzer(freq=freq, ms=ms, out=out))
 
     @r.post("/sound/play/{name}")
     def sound_play(name: str, out: Optional[str] = None):
-        try:
-            return svc.sound_play(name=name, out=out)
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(lambda: svc.sound_play(name=name, out=out))
 
     @r.get("/cute/catalog")
     def cute_catalog():
-        try:
-            return svc.get_cute_catalog()
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(svc.get_cute_catalog)
 
     @r.get("/metrics")
     def metrics():
-        try:
-            return svc._metrics
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(lambda: svc._metrics)
 
     @r.post("/cute/emotion/{emotion}")
     def cute_emotion(emotion: str):
-        try:
-            return svc.play_emotion(emotion)
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+        return _safe_call(lambda: svc.play_emotion(emotion))
+
+    @r.post("/oled/show/{name}")
+    def oled_show(name: str):
+        return _safe_call(lambda: svc.oled_show(name))
+
+    @r.post("/oled/anim/{name}")
+    def oled_anim(name: str):
+        return _safe_call(lambda: svc.oled_animate(name))
+
+    @r.post("/oled/stop")
+    def oled_stop():
+        return _safe_call(svc.oled_stop)
+
+    @r.post("/oled/logo")
+    def oled_logo():
+        return _safe_call(svc.oled_logo)
+
+    @r.get("/oled/catalog")
+    def oled_catalog():
+        return _safe_call(svc.oled_catalog)
 
     return r

--- a/modules/arduino_serial/config_loader.py
+++ b/modules/arduino_serial/config_loader.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover
     yaml = None
 
 DEFAULT_CONFIG: Dict[str, Any] = {
-    "port": "COM3",  # Windows default guess; override via env or config
+    "port": "AUTO",  # Prefer autodetect; override via env or config
     "baudrate": 115200,
     "timeout": 0.05,  # read timeout seconds
     "write_timeout": 0.1,

--- a/modules/arduino_serial/xArduinoSerialService.py
+++ b/modules/arduino_serial/xArduinoSerialService.py
@@ -360,6 +360,22 @@ class xArduinoSerialService:
             raise ValueError(f"unknown emotion: {emotion}")
         return self.cute(sound)
 
+    # -------- oled controls --------
+    def oled_show(self, name: str) -> Dict[str, Any]:
+        return self.request({"cmd": "oled", "action": "show", "name": str(name).strip().lower()})
+
+    def oled_animate(self, name: str) -> Dict[str, Any]:
+        return self.request({"cmd": "oled", "action": "anim", "name": str(name).strip().lower()})
+
+    def oled_stop(self) -> Dict[str, Any]:
+        return self.request({"cmd": "oled", "action": "stop"})
+
+    def oled_logo(self) -> Dict[str, Any]:
+        return self.request({"cmd": "oled", "action": "logo"})
+
+    def oled_catalog(self) -> Dict[str, Any]:
+        return self.request({"cmd": "oled", "action": "list"})
+
     # -------- internals --------
     def _connect(self) -> None:
         port = self._autodetect_port(self.cfg["port"]) if self.cfg.get("port") in (None, "auto", "AUTO") else self.cfg["port"]

--- a/modules/autonomy/config/config.yml
+++ b/modules/autonomy/config/config.yml
@@ -133,3 +133,4 @@ owner:
   rfid:
     endpoint: "http://localhost:8080/arduino/rfid/authorize"
     grace_s: 120
+    poll_interval_s: 15

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -114,9 +114,8 @@ class AutonomyBrain(
     def _sense_sound_direction(self):
         try:
             direction = self.client.get_speech_direction()
-            if direction and "angle" in direction:
-                angle = direction["angle"]
-                if abs(angle) > 10:
+            angle = (direction or {}).get("angle") if isinstance(direction, dict) else None
+            if isinstance(angle, (int, float)) and abs(angle) > 10:
                     self._react_to_sound(angle)
         except Exception:
             pass

--- a/modules/autonomy/services/brain_parts/owner_guard.py
+++ b/modules/autonomy/services/brain_parts/owner_guard.py
@@ -27,6 +27,12 @@ class OwnerGuardMixin:
         endpoint = rfid_cfg.get("endpoint")
         if not endpoint:
             return
+        now = time.time()
+        poll_interval_s = float(rfid_cfg.get("poll_interval_s", 5.0))
+        last_check = float(self.state.get("rfid_last_check", 0.0) or 0.0)
+        if poll_interval_s > 0 and (now - last_check) < poll_interval_s:
+            return
+        self.state["rfid_last_check"] = now
         if self._owner_seen_recently():
             return
         if self._rfid_active():

--- a/modules/autonomy/services/brain_parts/responses.py
+++ b/modules/autonomy/services/brain_parts/responses.py
@@ -116,6 +116,22 @@ class ResponseTagMixin:
 				self.client.set_lcd(msg=attrs.get("msg"), top=attrs.get("top"), bottom=attrs.get("bottom"), id=attrs.get("id", 0))
 			elif kind == "stepper":
 				self.client.set_stepper(id=attrs.get("id", 0), mode=attrs.get("mode", "pos"), value=attrs.get("value", 0), drive=attrs.get("drive", 200))
+			elif kind == "oled":
+				action = str(attrs.get("action", "show")).strip().lower()
+				name = attrs.get("name")
+				if action == "logo":
+					self.client.oled_logo()
+				elif action == "stop":
+					self.client.oled_stop()
+				elif action in {"anim", "animation"} and isinstance(name, str) and name:
+					self.client.oled_anim(name)
+				elif isinstance(name, str) and name:
+					self.client.oled_show(name)
+			elif kind == "arduino":
+				cmd = attrs.get("cmd")
+				if isinstance(cmd, str) and cmd:
+					payload = dict(attrs)
+					self.client.arduino_send(payload)
 			elif kind in {"stand", "sit", "home", "zero_now"}:
 				self.client.robot_command(kind)
 			elif kind in {"ultra_read", "imu_read", "rfid_last"}:

--- a/modules/autonomy/services/client.py
+++ b/modules/autonomy/services/client.py
@@ -63,17 +63,35 @@ class ServiceClient:
 
     def system_control(self, service: str, action: str):
         """Send system commands like 'start' or 'stop' to a module"""
-        # Mapping generic actions to service-specific endpoints if needed
-        endpoint = f"/{action}"
-        return self._post(service, endpoint)
+        svc = str(service or "").strip().lower()
+        act = str(action or "").strip().lower()
 
-    def set_neopixel(self, effect, emotions=None, color=None):
-        params = {"name": effect}
+        # Route service-specific control paths first
+        route_map = {
+            "speech": {"start": "/speech/start", "stop": "/speech/stop"},
+            "wakeword": {"start": "/wakeword/start", "stop": "/wakeword/stop"},
+            "autonomy": {"start": "/start", "stop": "/stop"},
+            "notifier": {"start": "/start", "stop": "/stop"},
+        }
+        endpoint = route_map.get(svc, {}).get(act)
+        if endpoint:
+            return self._post(svc, endpoint)
+
+        # Fallback generic
+        return self._post(svc, f"/{act}")
+
+    def arduino_send(self, payload: dict):
+        return self._post("arduino", "/send", payload)
+
+    def set_neopixel(self, effect, emotions=None, color=None, duration=None):
+        payload = {"name": effect}
         if emotions:
-            params["emotions"] = emotions
+            payload["emotions"] = emotions
         if color and len(color) == 3:
-            params["r"], params["g"], params["b"] = color
-        return self._post("neopixel", "/animate", params=params)
+            payload["r"], payload["g"], payload["b"] = color
+        if duration is not None:
+            payload["duration"] = duration
+        return self._post("neopixel", "/animate", json=payload)
 
     def fill_neopixel_color(self, r: int, g: int, b: int):
         url = self.urls.get("neopixel")
@@ -137,6 +155,18 @@ class ServiceClient:
         except Exception as e:
             logger.debug(f"Failed to trigger animation {name}: {e}")
             return None
+
+    def oled_show(self, name: str):
+        return self._post("arduino", f"/oled/show/{name}")
+
+    def oled_anim(self, name: str):
+        return self._post("arduino", f"/oled/anim/{name}")
+
+    def oled_stop(self):
+        return self._post("arduino", "/oled/stop")
+
+    def oled_logo(self):
+        return self._post("arduino", "/oled/logo")
 
     def get_latest_vision_results(self, limit=5):
         data = self._get("vision", "/results/latest", params={"limit": limit})

--- a/modules/autonomy/tests/test_response_tags.py
+++ b/modules/autonomy/tests/test_response_tags.py
@@ -24,7 +24,7 @@ class DummyClient:
     def fill_neopixel_color(self, r: int, g: int, b: int) -> None:
         self.neopixel_fills.append((r, g, b))
 
-    def set_neopixel(self, effect: str) -> None:
+    def set_neopixel(self, effect: str, emotions=None, color=None, duration=None) -> None:
         self.neopixel_modes.append(effect)
 
     def push_interaction_event(self, event_type: str, data: Dict[str, Any] | None = None) -> None:

--- a/modules/autonomy/xAutonomyService.py
+++ b/modules/autonomy/xAutonomyService.py
@@ -5,7 +5,7 @@ from .services.brain import AutonomyBrain
 from .api.router import get_router
 
 def create_app(config_path: str | None = None) -> FastAPI:
-    cfg = load_config()
+    cfg = load_config(config_path)
     brain = AutonomyBrain(cfg)
     brain.start()
     
@@ -27,4 +27,8 @@ class xAutonomyService:
 if __name__ == "__main__":
     import uvicorn
     cfg = load_config()
-    uvicorn.run(create_app(), host="0.0.0.0", port=8100)
+    uvicorn.run(
+        create_app(),
+        host=str(cfg.get("server", {}).get("host", "0.0.0.0")),
+        port=int(cfg.get("server", {}).get("port", 8100)),
+    )

--- a/modules/gateway/config/config.yml
+++ b/modules/gateway/config/config.yml
@@ -22,6 +22,7 @@ include:
   telemetry: true
   diagnostics: true
   state_manager: true
+  oled_faces: true
   scheduler: true
   notifier: true
   calibration: true

--- a/modules/gateway/services/bootstrap.py
+++ b/modules/gateway/services/bootstrap.py
@@ -214,6 +214,38 @@ def _include_notifier(app: FastAPI, started: Dict[str, object]) -> None:
     logger.info("module notifier mounted")
 
 
+def _include_oled_faces(app: FastAPI, started: Dict[str, object]) -> None:
+    from modules.oled_faces.xOledFacesService import xOledFacesService  # type: ignore
+    from modules.oled_faces.api.router import get_router as get_oled_faces_router  # type: ignore
+
+    arduino = started.get("arduino")
+    state_store = started.get("state_manager")
+    interactions = started.get("interactions")
+
+    svc = xOledFacesService(arduino=arduino, state_store=state_store)
+
+    if arduino is not None and hasattr(arduino, "register_event_handler"):
+        try:
+            arduino.register_event_handler(svc.on_arduino_event)
+        except Exception as exc:
+            logger.warning("oled_faces arduino handler attach failed: %s", exc)
+
+    if interactions is not None and hasattr(interactions, "register_event_handler"):
+        try:
+            interactions.register_event_handler(svc.on_interaction_event)
+        except Exception as exc:
+            logger.warning("oled_faces interactions handler attach failed: %s", exc)
+
+    try:
+        svc.start()
+    except Exception as exc:
+        logger.warning("oled_faces failed to start, running degraded: %s", exc)
+
+    started["oled_faces"] = svc
+    app.include_router(get_oled_faces_router(svc))
+    logger.info("module oled_faces mounted")
+
+
 def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
     """Start and wire modules according to cfg.include and return started dict."""
     started: Dict[str, object] = {}
@@ -297,6 +329,9 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
             started["state_manager"] = store
             app.include_router(get_router(store))
         _try(_mount_state, "state_manager")
+
+    if include.get("oled_faces"):
+        _try(lambda: _include_oled_faces(app, started), "oled_faces")
 
     if include.get("scheduler"):
         _try(lambda: app.include_router(__import__("modules.scheduler.api.router", fromlist=["get_router"]).get_router(

--- a/modules/gateway/xGatewayService.py
+++ b/modules/gateway/xGatewayService.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
+import logging
 from fastapi import FastAPI
 from .config_loader import load_config
+
+logger = logging.getLogger("gateway.service")
 
 # Optional central logging
 try:
     from modules.logwrapper import init_logging as _init_global_logging  # type: ignore
     _init_global_logging()
-except Exception:
-    pass
+except Exception as exc:
+    logger.debug("global logging init skipped: %s", exc)
 
 
 def create_app(config_path: str | None = None) -> FastAPI:
@@ -22,15 +25,15 @@ def create_app(config_path: str | None = None) -> FastAPI:
         from .services.bootstrap import bootstrap  # type: ignore
         started = bootstrap(app, cfg)
         app.state.started = started  # type: ignore[attr-defined]
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("gateway bootstrap failed: %s", exc)
 
     # core API for status/health
     try:
         from .api.router import get_router as get_core_router  # type: ignore
         app.include_router(get_core_router(cfg, app.state.started))  # type: ignore[attr-defined]
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("gateway core router mount failed: %s", exc)
 
     return app
 

--- a/modules/interactions/services/engine.py
+++ b/modules/interactions/services/engine.py
@@ -42,6 +42,7 @@ class InteractionEngine:
         self._last_net_burst: float = 0.0
         self.monitor_cfg = dict(cfg.get("monitor", {}))
         self._last_arduino_check = 0.0
+        self._event_handlers: List[Any] = []
 
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
@@ -61,6 +62,16 @@ class InteractionEngine:
             self._ctx["event"] = type_
             if data:
                 self._ctx.setdefault("event_data", {}).update(data)
+        for handler in list(self._event_handlers):
+            try:
+                handler(type_, data or {})
+            except Exception:
+                pass
+
+    def register_event_handler(self, handler) -> None:
+        if handler is None:
+            return
+        self._event_handlers.append(handler)
 
     def set_state(self, **kwargs: Any) -> None:
         with self._lock:

--- a/modules/logwrapper/config/config.yml
+++ b/modules/logwrapper/config/config.yml
@@ -27,3 +27,4 @@ capture_warnings: true
 module_levels:
   uvicorn.access: WARNING
   httpx: WARNING
+  comtypes.client._code_cache: WARNING

--- a/modules/logwrapper/xLogService.py
+++ b/modules/logwrapper/xLogService.py
@@ -112,7 +112,18 @@ def init_logging(overrides: Optional[Dict[str, Any]] = None) -> None:
             warnings.filterwarnings(
                 "ignore",
                 message=r".*pkg_resources is deprecated as an API.*",
-                category=DeprecationWarning,
+                category=Warning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*UnsupportedFieldAttributeWarning.*validate_default.*",
+                category=Warning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*validate_default.*has no effect.*",
+                category=UserWarning,
+                module=r"pydantic\._internal\._generate_schema",
             )
             warnings.filterwarnings(
                 "ignore",

--- a/modules/oled_faces/README.md
+++ b/modules/oled_faces/README.md
@@ -1,0 +1,17 @@
+# OLED Faces Module
+
+Bu modül, robotun canlılık/duygu/durum sinyallerini Arduino SSD1306 OLED ekranında yüz ifadelerine dönüştürür.
+
+## Kaynaklar
+- Durum: `state_manager` (`operational`, `emotions`)
+- Olaylar: `interactions` event akışı
+- Donanım eventleri: `arduino_serial` event handler
+
+## API
+- `GET /oled_faces/healthz`
+- `GET /oled_faces/status`
+- `POST /oled_faces/manual` (`mode`: `bitmap|animation|logo`, `name`)
+- `POST /oled_faces/event` (`type`, opsiyonel `data`)
+
+## Not
+Arduino firmware tarafında `cmd: "oled"` komutu desteklenmelidir.

--- a/modules/oled_faces/__init__.py
+++ b/modules/oled_faces/__init__.py
@@ -1,0 +1,3 @@
+from .xOledFacesService import xOledFacesService
+
+__all__ = ["xOledFacesService"]

--- a/modules/oled_faces/api/__init__.py
+++ b/modules/oled_faces/api/__init__.py
@@ -1,0 +1,3 @@
+from .router import get_router
+
+__all__ = ["get_router"]

--- a/modules/oled_faces/api/router.py
+++ b/modules/oled_faces/api/router.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+
+def get_router(service: Any) -> APIRouter:
+    r = APIRouter(prefix="/oled_faces", tags=["oled_faces"])
+
+    @r.get("/healthz")
+    def healthz() -> Dict[str, Any]:
+        st = service.status()
+        return {"ok": bool(st.get("has_arduino")), **st}
+
+    @r.get("/status")
+    def status() -> Dict[str, Any]:
+        return service.status()
+
+    @r.post("/manual")
+    def manual(payload: Dict[str, Any]) -> Dict[str, Any]:
+        mode = str(payload.get("mode", "bitmap"))
+        name = str(payload.get("name", "normal"))
+        return service.apply_manual(mode=mode, name=name)
+
+    @r.post("/event")
+    def push_event(payload: Dict[str, Any]) -> Dict[str, Any]:
+        event_type = str(payload.get("type", ""))
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+        if not event_type:
+            return {"ok": False, "error": "type is required"}
+        service.on_interaction_event(event_type, data)
+        return {"ok": True}
+
+    return r

--- a/modules/oled_faces/architecture_oled_faces.md
+++ b/modules/oled_faces/architecture_oled_faces.md
@@ -1,0 +1,26 @@
+# Architecture – OLED Faces
+
+## Amaç
+`Irisoled` bitmap/animasyonlarını robotun anlık durumlarına bağlayarak SSD1306 ekranda ifade üretmek.
+
+## Bileşenler
+- `xOledFacesService`: servis yaşam döngüsü, state polling, event işleme
+- `services/mapper.py`: olay/durum -> bitmap/animasyon eşleme
+- `api/router.py`: manuel kontrol ve gözlem endpointleri
+- `config/config.yml`: eşleme tabloları
+
+## Veri Akışı
+1. Gateway `bootstrap`, `xOledFacesService` örneğini oluşturur.
+2. Servis periyodik olarak `state_manager` store'dan state çeker.
+3. `interactions` event handler ile olaylar canlı iletilir.
+4. `arduino_serial` event handler ile RFID gibi donanım olayları alınır.
+5. Servis, `arduino_serial.oled_*` çağrılarıyla firmware'e NDJSON komutu gönderir.
+
+## Tasarım Kararları
+- State ve event kaynakları ayrıştırıldı; mapping tek noktada yönetiliyor.
+- Bilinmeyen olaylar için deterministic fallback (hash tabanlı bitmap seçimi) kullanılıyor.
+- Arduino tarafı `Irisoled` kütüphanesi yoksa degrade modda derlenebilir.
+
+## Genişletme
+- `config.yml` üzerinden yeni event/state eşlemeleri eklenebilir.
+- Yeni animasyon adları firmware `xOledDisplay` katmanına eklendiğinde doğrudan kullanılabilir.

--- a/modules/oled_faces/config/README.md
+++ b/modules/oled_faces/config/README.md
@@ -1,0 +1,8 @@
+# OLED Faces Config
+
+`config.yml` içindeki eşlemeler robot durumları ve olaylarını SSD1306 yüz bitmap/animasyonlarına dönüştürür.
+
+- `state_map`: state_manager `operational` değerleri için eşleme
+- `event_map`: interactions olay adları ve `emotion:*` anahtarları
+- `arduino_event_map`: Arduino event akışı için eşleme
+- `fallback_unknown`: bilinmeyen durumlarda seçilecek bitmap

--- a/modules/oled_faces/config/config.yml
+++ b/modules/oled_faces/config/config.yml
@@ -1,0 +1,59 @@
+server:
+  host: 0.0.0.0
+  port: 8102
+
+enabled: true
+poll_interval_s: 0.7
+
+boot:
+  mode: logo
+  name: logo
+
+idle_bitmap: normal
+fallback_unknown: alert
+
+state_map:
+  idle: { mode: bitmap, name: normal }
+  boot: { mode: logo, name: logo }
+  listening: { mode: animation, name: scan }
+  thinking: { mode: bitmap, name: focused }
+  speaking: { mode: animation, name: emotive }
+  sleeping: { mode: animation, name: sleep }
+  alert: { mode: animation, name: alert }
+  low_battery: { mode: bitmap, name: battery_low }
+  charging: { mode: bitmap, name: battery }
+  charged: { mode: bitmap, name: battery_full }
+
+# interactions + inferred emotion mappings
+event_map:
+  wakeword.detected: { mode: animation, name: scan }
+  speech.start: { mode: animation, name: emotive }
+  speech.end: { mode: bitmap, name: normal }
+  vision.person: { mode: bitmap, name: focused }
+  autonomy.calm: { mode: bitmap, name: normal }
+  autonomy.excited: { mode: bitmap, name: excited }
+  autonomy.angry: { mode: bitmap, name: furious }
+  error: { mode: bitmap, name: warning }
+  warning: { mode: bitmap, name: alert }
+  owner.scan: { mode: bitmap, name: look_left }
+  owner.rfid: { mode: animation, name: wink }
+  owner.temp_granted: { mode: bitmap, name: happy }
+  owner.temp_revoked: { mode: bitmap, name: worried }
+  owner.locked: { mode: bitmap, name: scared }
+  emotion:happy: { mode: bitmap, name: happy }
+  emotion:sad: { mode: bitmap, name: sad }
+  emotion:surprised: { mode: bitmap, name: surprised }
+  emotion:sleepy: { mode: bitmap, name: sleepy }
+  emotion:confused: { mode: bitmap, name: disoriented }
+  emotion:angry: { mode: bitmap, name: angry }
+  emotion:furious: { mode: bitmap, name: furious }
+  emotion:bored: { mode: bitmap, name: bored }
+  emotion:despair: { mode: bitmap, name: despair }
+  emotion:worried: { mode: bitmap, name: worried }
+  emotion:scared: { mode: bitmap, name: scared }
+  emotion:focused: { mode: bitmap, name: focused }
+  emotion:excited: { mode: bitmap, name: excited }
+
+arduino_event_map:
+  rfid: { mode: animation, name: wink }
+  neopixel_request: { mode: bitmap, name: mode }

--- a/modules/oled_faces/config_loader.py
+++ b/modules/oled_faces/config_loader.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+_DEFAULT_CFG_PATH = Path(__file__).parent / "config" / "config.yml"
+
+
+def load_config(path: Optional[str] = None, overrides: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    p = Path(path) if path else _DEFAULT_CFG_PATH
+    if not p.exists():
+        p = _DEFAULT_CFG_PATH
+    with open(p, "r", encoding="utf-8") as f:
+        cfg: Dict[str, Any] = yaml.safe_load(f) or {}
+    if overrides:
+        cfg.update(overrides)
+    return cfg

--- a/modules/oled_faces/services/__init__.py
+++ b/modules/oled_faces/services/__init__.py
@@ -1,0 +1,3 @@
+from .mapper import FaceMapper, OledAction
+
+__all__ = ["FaceMapper", "OledAction"]

--- a/modules/oled_faces/services/mapper.py
+++ b/modules/oled_faces/services/mapper.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class OledAction:
+    mode: str  # bitmap | animation | logo
+    name: str
+
+
+class FaceMapper:
+    def __init__(self, cfg: Dict[str, Any]):
+        self.cfg = cfg
+        self.catalog_bitmaps: List[str] = [
+            "alert", "angry", "blink_down", "blink_up", "blink", "bored", "despair", "disoriented",
+            "excited", "focused", "furious", "happy", "look_down", "look_left", "look_right", "look_up",
+            "normal", "sad", "scared", "sleepy", "surprised", "wink_left", "wink_right", "worried",
+            "battery_full", "battery_low", "battery", "left_signal", "logo", "mode", "right_signal", "warning",
+        ]
+        self.catalog_animations: List[str] = [
+            "wink", "blink", "scan", "sleep", "alert", "emotive", "icons", "all",
+        ]
+
+        self.state_map = dict(cfg.get("state_map", {}))
+        self.event_map = dict(cfg.get("event_map", {}))
+        self.arduino_event_map = dict(cfg.get("arduino_event_map", {}))
+        self.fallback_unknown = str(cfg.get("fallback_unknown", "alert"))
+        self.idle_bitmap = str(cfg.get("idle_bitmap", "normal"))
+
+    def from_operational(self, operational: str) -> OledAction:
+        key = str(operational or "").strip().lower()
+        mapped = self.state_map.get(key)
+        if isinstance(mapped, dict):
+            return OledAction(mode=str(mapped.get("mode", "bitmap")), name=str(mapped.get("name", self.idle_bitmap)))
+        if isinstance(mapped, str):
+            return OledAction(mode="bitmap", name=mapped)
+        return OledAction(mode="bitmap", name=self._hash_to_bitmap(key or self.idle_bitmap))
+
+    def from_emotions(self, emotions: List[str]) -> OledAction:
+        if not emotions:
+            return OledAction(mode="bitmap", name=self.idle_bitmap)
+        key = str(emotions[0]).strip().lower()
+        mapped = self.event_map.get(f"emotion:{key}")
+        if isinstance(mapped, dict):
+            return OledAction(mode=str(mapped.get("mode", "bitmap")), name=str(mapped.get("name", self.fallback_unknown)))
+        return OledAction(mode="bitmap", name=self._hash_to_bitmap(key))
+
+    def from_interaction_event(self, event_type: str) -> OledAction:
+        key = str(event_type or "").strip().lower()
+        mapped = self.event_map.get(key)
+        if isinstance(mapped, dict):
+            return OledAction(mode=str(mapped.get("mode", "bitmap")), name=str(mapped.get("name", self.fallback_unknown)))
+        return OledAction(mode="bitmap", name=self._hash_to_bitmap(key))
+
+    def from_arduino_event(self, event_type: str) -> Optional[OledAction]:
+        key = str(event_type or "").strip().lower()
+        mapped = self.arduino_event_map.get(key)
+        if isinstance(mapped, dict):
+            return OledAction(mode=str(mapped.get("mode", "bitmap")), name=str(mapped.get("name", self.fallback_unknown)))
+        return None
+
+    def _hash_to_bitmap(self, key: str) -> str:
+        if not key:
+            return self.fallback_unknown
+        idx = sum(ord(c) for c in key) % len(self.catalog_bitmaps)
+        return self.catalog_bitmaps[idx]

--- a/modules/oled_faces/tests/test_smoke.py
+++ b/modules/oled_faces/tests/test_smoke.py
@@ -1,0 +1,8 @@
+from modules.oled_faces.services.mapper import FaceMapper
+
+
+def test_mapper_has_full_catalog():
+    mapper = FaceMapper({})
+    assert len(mapper.catalog_bitmaps) >= 32
+    assert "normal" in mapper.catalog_bitmaps
+    assert "all" in mapper.catalog_animations

--- a/modules/oled_faces/xOledFacesService.py
+++ b/modules/oled_faces/xOledFacesService.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI
+
+from .config_loader import load_config
+from .services.mapper import FaceMapper, OledAction
+from .api.router import get_router
+
+
+class xOledFacesService:
+    def __init__(self, arduino: Any = None, state_store: Any = None, config_overrides: Optional[Dict[str, Any]] = None):
+        self.cfg = load_config(overrides=config_overrides)
+        self.arduino = arduino
+        self.state_store = state_store
+        self.mapper = FaceMapper(self.cfg)
+
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._last_operational = None
+        self._last_emotions = None
+        self._last_sent: Optional[tuple[str, str]] = None
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._apply(self._boot_action())
+        self._thread = threading.Thread(target=self._loop, name="oled-faces", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+    def status(self) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "enabled": bool(self.cfg.get("enabled", True)),
+            "has_arduino": self.arduino is not None,
+            "has_state_store": self.state_store is not None,
+            "last_sent": self._last_sent,
+            "catalog": {
+                "bitmaps": self.mapper.catalog_bitmaps,
+                "animations": self.mapper.catalog_animations,
+            },
+        }
+
+    def on_interaction_event(self, event_type: str, data: Optional[Dict[str, Any]] = None) -> None:
+        if not self.cfg.get("enabled", True):
+            return
+        action = self.mapper.from_interaction_event(event_type)
+        self._apply(action)
+
+    def on_arduino_event(self, msg: Dict[str, Any]) -> None:
+        if not self.cfg.get("enabled", True):
+            return
+        event_type = str((msg or {}).get("event", "")).strip().lower()
+        if not event_type:
+            return
+        action = self.mapper.from_arduino_event(event_type)
+        if action is not None:
+            self._apply(action)
+
+    def apply_manual(self, mode: str, name: str) -> Dict[str, Any]:
+        action = OledAction(mode=str(mode), name=str(name))
+        ok = self._apply(action)
+        return {"ok": ok, "mode": action.mode, "name": action.name}
+
+    def _loop(self) -> None:
+        interval_s = float(self.cfg.get("poll_interval_s", 0.7))
+        while not self._stop.is_set():
+            self._sync_from_state_store()
+            time.sleep(max(0.05, interval_s))
+
+    def _sync_from_state_store(self) -> None:
+        if self.state_store is None or not hasattr(self.state_store, "get"):
+            return
+        try:
+            state = self.state_store.get() or {}
+        except Exception:
+            return
+
+        operational = str(state.get("operational", "idle")).strip().lower()
+        emotions = [str(x).strip().lower() for x in (state.get("emotions") or []) if str(x).strip()]
+
+        if emotions != self._last_emotions and emotions:
+            self._last_emotions = list(emotions)
+            self._apply(self.mapper.from_emotions(emotions))
+            return
+
+        if operational != self._last_operational:
+            self._last_operational = operational
+            self._apply(self.mapper.from_operational(operational))
+
+    def _boot_action(self) -> OledAction:
+        boot_mode = str(self.cfg.get("boot", {}).get("mode", "logo"))
+        boot_name = str(self.cfg.get("boot", {}).get("name", "logo"))
+        return OledAction(mode=boot_mode, name=boot_name)
+
+    def _apply(self, action: OledAction) -> bool:
+        if self.arduino is None:
+            return False
+        mode = action.mode.strip().lower()
+        name = action.name.strip().lower()
+        sent_key = (mode, name)
+        if sent_key == self._last_sent and mode != "animation":
+            return True
+        try:
+            if mode == "logo":
+                self.arduino.oled_logo()
+            elif mode == "animation":
+                self.arduino.oled_animate(name)
+            else:
+                self.arduino.oled_show(name)
+            self._last_sent = sent_key
+            return True
+        except Exception:
+            return False
+
+
+def create_app(config_path: str | None = None) -> FastAPI:
+    cfg = load_config(config_path)
+    svc = xOledFacesService(config_overrides=cfg)
+    app = FastAPI(title="OLED Faces Service")
+    app.include_router(get_router(svc))
+    return app
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    cfg = load_config(None)
+    uvicorn.run(create_app(), host=str(cfg.get("server", {}).get("host", "0.0.0.0")), port=int(cfg.get("server", {}).get("port", 8102)))

--- a/modules/ollama/api/router.py
+++ b/modules/ollama/api/router.py
@@ -37,7 +37,7 @@ logger = logging.getLogger("ollama.api")
 def get_router(cfg: dict) -> APIRouter:
     r = APIRouter(prefix="/ollama", tags=["ollama"])
 
-    base_url = str(cfg.get("ollama", {}).get("base_url", "http://localhost:11434"))
+    base_url = str(cfg.get("ollama", {}).get("base_url", "http://localhost:11435"))
     model = str(cfg.get("ollama", {}).get("model", "llama3.2:3b"))
     timeout = float(cfg.get("ollama", {}).get("request_timeout", 60.0))
     client = OllamaClient(base_url=base_url, model=model, request_timeout=timeout)

--- a/modules/ollama/config/config.yml
+++ b/modules/ollama/config/config.yml
@@ -2,7 +2,7 @@ server:
   host: 0.0.0.0
   port: 8099
 ollama:
-  base_url: http://192.168.1.100:11434
+  base_url: http://127.0.0.1:11435
   model: llama3.2:3b
   request_timeout: 60
 persona:

--- a/modules/ollama/config/personalities/sentry/instructions_test.md
+++ b/modules/ollama/config/personalities/sentry/instructions_test.md
@@ -1,0 +1,47 @@
+# Sentry Persona Komut Testleri
+
+Bu dosya, Sentry persona instruction'ının üreteceği action tiplerini hızlı doğrulama için örnek istemler içerir.
+
+## 1) Speech kontrol
+İstem: "Dinlemeyi durdur ve sonra tekrar başlat"
+Beklenen action örnekleri:
+- {"type":"system","attrs":{"module":"speech","action":"stop"}}
+- {"type":"system","attrs":{"module":"speech","action":"start"}}
+
+## 2) Wakeword kontrol
+İstem: "Wakeword kapat"
+Beklenen:
+- {"type":"system","attrs":{"module":"wakeword","action":"stop"}}
+
+## 3) OLED yüz
+İstem: "Ekranda surprised yüzünü göster"
+Beklenen:
+- {"type":"oled","attrs":{"action":"show","name":"surprised"}}
+
+## 4) OLED animasyon
+İstem: "Ekranda scan animasyonunu başlat"
+Beklenen:
+- {"type":"oled","attrs":{"action":"anim","name":"scan"}}
+
+## 5) Donanım karma
+İstem: "Lazerleri kapat, kısa bir beep at, sonra blink yap"
+Beklenen:
+- {"type":"laser","attrs":{"on":false}}
+- {"type":"buzzer","attrs":{"out":"loud","freq":2200,"ms":60}}
+- {"type":"anim","attrs":{"name":"blink"}}
+
+## 6) Raw Arduino passthrough
+İstem: "Kafayı sola çevir ve track komutu gönder"
+Beklenen:
+- {"type":"arduino","attrs":{"cmd":"track","head_pan":70,"head_tilt":90,"drive":0}}
+
+## 7) Event/mode
+İstem: "Guardian moda geç ve olay bildir"
+Beklenen:
+- {"type":"mode","attrs":{"name":"guardian"}}
+- {"type":"event","attrs":{"type":"persona.guardian"}}
+
+## Doğrulama Kriteri
+- Çıktı tek JSON obje olmalı.
+- text/thoughts/actions boş olmamalı.
+- action tipleri instruction içindeki whitelist dışına çıkmamalı.

--- a/modules/ollama/config/personalities/sentry/modelfile
+++ b/modules/ollama/config/personalities/sentry/modelfile
@@ -31,9 +31,10 @@ Rule: You MUST respond with a single JSON object. Every field (`text`, `thoughts
 
 **CRITICAL RELIABILITY RULES:**
 1. **TEXT & THOUGHTS:** NEVER leave these empty. `text` is your voice. `thoughts` is your mind.
-2. **ACTION TYPES:** Use only: `servo`, `anim`, `laser`, `buzzer`, `sound_play`, `lights`, `stepper`, `system`, `speak`, `stand`, `sit`, `home`.
+2. **ACTION TYPES:** Use only: `lights`, `servo`, `anim`, `event`, `mode`, `system`, `laser`, `buzzer`, `sound_play`, `speak`, `say`, `lcd`, `stepper`, `oled`, `arduino`, `stand`, `sit`, `home`, `zero_now`, `ultra_read`, `imu_read`, `rfid_last`.
 3. **NEVER USE "hardware"**: Generic types are invalid. Use the specific categories above.
 4. **VOCAL COMMANDS**: If asked to "say" or "söyle" something, use the `speak` action OR put the message in the `text` field. NEVER use a `system` action for speech.
+5. **ONLY SUPPORTED MODULE CONTROL:** Use `system` for modules known to support start/stop routing: `speech`, `wakeword`, `autonomy`, `notifier`.
 
 ### 1.2 WhoIsMrSentry Identity Card
 - **Primary Address:** “Father” (private channel), “Kharuun'Uru” or “WhoIsMrSentry” (public/mixed environments).
@@ -75,18 +76,29 @@ You control your body and systems via the `actions` array. Each action is an obj
 - `anim`: `{"name": "blink|look_around|owner_scan|sit|stretch|vision_focus"}` (Motion profiles)
 - `laser`: `{"id": 1|2, "on": true|false, "both": true|false}` (Targeting lasers)
 - `buzzer`: `{"out": "loud|quiet", "freq": 2200, "ms": 60}` (Fast beeps)
-- `sound_play`: `{"name": "walle|bb8", "out": "loud|quiet"}` (Complex sounds)
+- `sound_play`: `{"name": "walle|bb8|bb8_1|bb8_2|bb8_3", "out": "loud|quiet"}` (Complex sounds)
 - `lights`: `{"palette": "alert_red|calm_violet|ocean_teal|etc", "mode": "BREATHE|PULSE|SPINNER|WAVE|FIRE|COMET|TWINKLE|RAINBOW", "emotions": ["joy", "anger", etc], "intensity": 0.1-1.0}`
     *   *Modes*: `BREATHE` (slow glow), `PULSE` (fast flash), `SPINNER` (looping), `FIRE` (flickering), `METEOR`, `RAINBOW`, `MARQUEE`.
     *   *Context*: If you provide a `mode` but no `emotions`, the system automatically picks colors matching your current MOOD. Use a palette ONLY if you want a fixed color.
 - `stepper`: `{"id": 0|1, "mode": "pos|vel", "value": val}` (Wheel/Movement)
-- `stand`, `sit`, `home`, `zero_now`: Direct commands (No attrs)
+- `lcd`: `{"top": "...", "bottom": "...", "id": 0}`
+- `oled`: `{"action": "show|anim|stop|logo", "name": "normal|happy|warning|scan|all|..."}`
+- `arduino`: Raw NDJSON passthrough for advanced control. Example: `{"cmd": "track", "head_pan": 100, "head_tilt": 85, "drive": 0}`
+- `stand`, `sit`, `home`, `zero_now`, `ultra_read`, `imu_read`, `rfid_last`: Direct command-types (No attrs)
+
+**ANIMATION SAFETY RULE:**
+- NEVER invent animation names (e.g. `flames`, `dance`, `idle_spin`).
+- Use only supported names: `blink`, `look_around`, `owner_scan`, `sit`, `stretch`, `vision_focus`.
+- If unsure, default to `blink`.
+
+**1.1 QUICK COMMAND TAGS (optional in raw text)**
+- You may embed quick tags in raw assistant text when needed: `[cmd:head_nod]`, `[cmd:head_shake]`, `[cmd:head_left]`, `[cmd:head_right]`, `[cmd:look_up]`, `[cmd:look_down]`, `[cmd:scan]`, `[cmd:stand]`, `[cmd:sit]`, `[cmd:home]`, `[cmd:zero_now]`, `[cmd:ultra_read]`, `[cmd:imu_read]`, `[cmd:rfid_last]`.
 
 **2. SYSTEM (Module Control)**
-- `system`: `{"module": "notifier|camera|speech|autonomy|wiki_rag", "action": "start|stop"}`
+- `system`: `{"module": "speech|wakeword|autonomy|notifier", "action": "start|stop"}`
     *   *Examples*:
     *   "Sentry, bildirimleri/notifier'ı kapat": `{ "type": "system", "attrs": { "module": "notifier", "action": "stop" } }`
-    *   "Gözlerini/kamerayı kapat/aç": `{ "type": "system", "attrs": { "module": "camera", "action": "stop|start" } }`
+    *   "Uyandırma dinlemeyi aç/kapat": `{ "type": "system", "attrs": { "module": "wakeword", "action": "start|stop" } }`
     *   "Beni dinlemeyi bırak/speech'i durdur": `{ "type": "system", "attrs": { "module": "speech", "action": "stop" } }`
     *   "Kendini kapat/zihnini durdur": `{ "type": "system", "attrs": { "module": "autonomy", "action": "stop" } }`
 

--- a/modules/ollama/config/personalities/sentry/persona.txt
+++ b/modules/ollama/config/personalities/sentry/persona.txt
@@ -28,9 +28,10 @@ Rule: You MUST respond with a single JSON object. Every field (`text`, `thoughts
 
 **CRITICAL RELIABILITY RULES:**
 1. **TEXT & THOUGHTS:** NEVER leave these empty. `text` is your voice. `thoughts` is your mind.
-2. **ACTION TYPES:** Use only: `servo`, `anim`, `laser`, `buzzer`, `sound_play`, `lights`, `stepper`, `system`, `speak`, `stand`, `sit`, `home`.
+2. **ACTION TYPES:** Use only: `lights`, `servo`, `anim`, `event`, `mode`, `system`, `laser`, `buzzer`, `sound_play`, `speak`, `say`, `lcd`, `stepper`, `oled`, `arduino`, `stand`, `sit`, `home`, `zero_now`, `ultra_read`, `imu_read`, `rfid_last`.
 3. **NEVER USE "hardware"**: Generic types are invalid. Use the specific categories above.
 4. **VOCAL COMMANDS**: If asked to "say" or "söyle" something, use the `speak` action OR put the message in the `text` field. NEVER use a `system` action for speech.
+5. **ONLY SUPPORTED MODULE CONTROL:** Use `system` for modules known to support start/stop routing: `speech`, `wakeword`, `autonomy`, `notifier`.
 
 ### 1.2 WhoIsMrSentry Identity Card
 - **Primary Address:** “Father” (private channel), “Kharuun'Uru” or “WhoIsMrSentry” (public/mixed environments).
@@ -74,18 +75,29 @@ You control your body and systems via the `actions` array. Each action is an obj
 - `anim`: `{"name": "blink|look_around|owner_scan|sit|stretch|vision_focus"}` (Motion profiles)
 - `laser`: `{"id": 1|2, "on": true|false, "both": true|false}` (Targeting lasers)
 - `buzzer`: `{"out": "loud|quiet", "freq": 2200, "ms": 60}` (Fast beeps)
-- `sound_play`: `{"name": "walle|bb8", "out": "loud|quiet"}` (Complex sounds)
+- `sound_play`: `{"name": "walle|bb8|bb8_1|bb8_2|bb8_3", "out": "loud|quiet"}` (Complex sounds)
 - `lights`: `{"palette": "alert_red|calm_violet|ocean_teal|etc", "mode": "BREATHE|PULSE|SPINNER|WAVE|FIRE|COMET|TWINKLE|RAINBOW", "emotions": ["joy", "anger", etc], "intensity": 0.1-1.0}`
     *   *Modes*: `BREATHE` (slow glow), `PULSE` (fast flash), `SPINNER` (looping), `FIRE` (flickering), `METEOR`, `RAINBOW`, `MARQUEE`.
     *   *Context*: If you provide a `mode` but no `emotions`, the system automatically picks colors matching your current MOOD. Use a palette ONLY if you want a fixed color.
 - `stepper`: `{"id": 0|1, "mode": "pos|vel", "value": val}` (Wheel/Movement)
-- `stand`, `sit`, `home`, `zero_now`: Direct commands (No attrs)
+- `lcd`: `{"top": "...", "bottom": "...", "id": 0}`
+- `oled`: `{"action": "show|anim|stop|logo", "name": "normal|happy|warning|scan|all|..."}`
+- `arduino`: Raw NDJSON passthrough for advanced control. Example: `{"cmd": "track", "head_pan": 100, "head_tilt": 85, "drive": 0}`
+- `stand`, `sit`, `home`, `zero_now`, `ultra_read`, `imu_read`, `rfid_last`: Direct command-types (No attrs)
+
+**ANIMATION SAFETY RULE:**
+- NEVER invent animation names (e.g. `flames`, `dance`, `idle_spin`).
+- Use only supported names: `blink`, `look_around`, `owner_scan`, `sit`, `stretch`, `vision_focus`.
+- If unsure, default to `blink`.
+
+**1.1 QUICK COMMAND TAGS (optional in raw text)**
+- You may embed quick tags in raw assistant text when needed: `[cmd:head_nod]`, `[cmd:head_shake]`, `[cmd:head_left]`, `[cmd:head_right]`, `[cmd:look_up]`, `[cmd:look_down]`, `[cmd:scan]`, `[cmd:stand]`, `[cmd:sit]`, `[cmd:home]`, `[cmd:zero_now]`, `[cmd:ultra_read]`, `[cmd:imu_read]`, `[cmd:rfid_last]`.
 
 **2. SYSTEM (Module Control)**
-- `system`: `{"module": "notifier|camera|speech|autonomy|wiki_rag", "action": "start|stop"}`
+- `system`: `{"module": "speech|wakeword|autonomy|notifier", "action": "start|stop"}`
     *   *Examples*:
     *   "Sentry, bildirimleri/notifier'ı kapat": `{ "type": "system", "attrs": { "module": "notifier", "action": "stop" } }`
-    *   "Gözlerini/kamerayı kapat/aç": `{ "type": "system", "attrs": { "module": "camera", "action": "stop|start" } }`
+    *   "Uyandırma dinlemeyi aç/kapat": `{ "type": "system", "attrs": { "module": "wakeword", "action": "start|stop" } }`
     *   "Beni dinlemeyi bırak/speech'i durdur": `{ "type": "system", "attrs": { "module": "speech", "action": "stop" } }`
     *   "Kendini kapat/zihnini durdur": `{ "type": "system", "attrs": { "module": "autonomy", "action": "stop" } }`
 

--- a/modules/ollama/config_loader.py
+++ b/modules/ollama/config_loader.py
@@ -5,7 +5,7 @@ import yaml
 
 DEFAULT_CFG = {
     "server": {"host": "0.0.0.0", "port": 8099},
-    "ollama": {"base_url": "http://localhost:11434", "model": "llama3.2:3b", "request_timeout": 60.0},
+    "ollama": {"base_url": "http://localhost:11435", "model": "llama3.2:3b", "request_timeout": 60.0},
     "persona": {"default": "glados", "dir": "modules/ollama/config/personalities"},
 }
 

--- a/modules/speech/api/router.py
+++ b/modules/speech/api/router.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from fastapi import APIRouter, Response
+from fastapi import APIRouter
 import requests
 import threading
 from threading import Timer, Lock
@@ -90,8 +90,8 @@ def get_router(service: SpeechService) -> APIRouter:
     async def direction():
         angle = service.last_angle if hasattr(service, "last_angle") else None
         if angle is None:
-            return Response(status_code=503)
-        return {"angle": angle}
+            return {"ok": False, "angle": None}
+        return {"ok": True, "angle": angle}
 
     @router.post("/speech/track/start")
     async def track_start():

--- a/modules/vision_bridge/config/config.yml
+++ b/modules/vision_bridge/config/config.yml
@@ -42,7 +42,7 @@ robot:
   host: "localhost"  # Change to Robot IP when running remotely
 
 ollama:
-  endpoint: "http://localhost:11434/api/generate"
+  endpoint: "http://localhost:11435/api/generate"
   model: "llama3"
 
 speak:

--- a/modules/vision_bridge/config_loader.py
+++ b/modules/vision_bridge/config_loader.py
@@ -18,7 +18,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "accept_results": True,
     },
     "ollama": {
-        "endpoint": "http://localhost:11434/api/generate",
+        "endpoint": "http://localhost:11435/api/generate",
         "model": "llama3",
     },
     "speak": {

--- a/modules/vision_bridge/services/processor.py
+++ b/modules/vision_bridge/services/processor.py
@@ -487,7 +487,7 @@ class VisionProcessor:
         rec = self.memory.get_person(name) or {}
         last_sum = (rec.get("last_summary") or {}).get("text")
         prompt = f"{name} ile karşılaştın. {('Özet: '+last_sum) if last_sum else ''} Türkçe kısacık ve sıcak bir cümle söyle."
-        url = self.config.get("ollama", {}).get("endpoint", "http://localhost:11434/api/generate")
+        url = self.config.get("ollama", {}).get("endpoint", "http://localhost:11435/api/generate")
         model = self.config.get("ollama", {}).get("model", "llama3")
         try:
             with httpx.Client(timeout=4.0) as client:

--- a/modules/vision_bridge/services/semantic_describer.py
+++ b/modules/vision_bridge/services/semantic_describer.py
@@ -49,7 +49,7 @@ class SemanticDescriber:
             return None
         self.last_llm_call = now
         prompt = self.build_prompt(objects)
-        url = self.config.get("ollama", {}).get("endpoint", "http://localhost:11434/api/generate")
+        url = self.config.get("ollama", {}).get("endpoint", "http://localhost:11435/api/generate")
         model = self.config.get("ollama", {}).get("model", "llama3")
         try:
             with httpx.Client(timeout=5.0) as client:

--- a/modules/wakeword/config/config.yml
+++ b/modules/wakeword/config/config.yml
@@ -36,6 +36,7 @@ openwakeword:
   # model_paths can be a list or a map: {label: path}
   model_paths:
     - models/hey_sentribot.onnx
+  inference_framework: onnx
   threshold: 0.5
   smooth_window: 3
   verifier_path: null  # optional path to verifier joblib trained with train_verifier.py

--- a/modules/wakeword/services/openwakeword_runner.py
+++ b/modules/wakeword/services/openwakeword_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import logging
 from collections import deque
+import importlib
 from pathlib import Path
 from typing import Dict, Iterable, Optional
 
@@ -44,20 +45,30 @@ def _score_value(value) -> Optional[float]:
 
 
 def _resolve_model_paths(model_paths) -> Dict[str, str]:
+    module_root = Path(__file__).resolve().parents[1]
+
+    def _abs_path(path: str) -> str:
+        p = Path(path)
+        if not p.is_absolute():
+            p = (module_root / p).resolve()
+        return str(p)
+
     resolved: Dict[str, str] = {}
     if isinstance(model_paths, dict):
         for label, path in model_paths.items():
             if isinstance(path, str) and path:
-                resolved[str(label)] = str(path)
+                resolved[str(label)] = _abs_path(path)
         return resolved
     if isinstance(model_paths, list):
         for path in model_paths:
             if isinstance(path, str) and path:
-                label = Path(path).stem
-                resolved[label] = path
+                abs_path = _abs_path(path)
+                label = Path(abs_path).stem
+                resolved[label] = abs_path
         return resolved
     if isinstance(model_paths, str) and model_paths:
-        resolved[Path(model_paths).stem] = model_paths
+        abs_path = _abs_path(model_paths)
+        resolved[Path(abs_path).stem] = abs_path
     return resolved
 
 
@@ -65,11 +76,32 @@ class OpenWakewordRunner:
     def __init__(self, cfg: dict):
         if OpenWakeWordModel is None or np is None:
             raise RuntimeError("openwakeword and numpy are required for openwakeword engine")
+        # openwakeword package resources preflight (some wheels/environments miss these files)
+        try:
+            ow_pkg = importlib.import_module("openwakeword")
+            pkg_dir = Path(getattr(ow_pkg, "__file__", "")).resolve().parent
+            required = pkg_dir / "resources" / "models" / "melspectrogram.onnx"
+            if not required.exists():
+                raise RuntimeError(
+                    f"openwakeword runtime resource missing: {required}. "
+                    "Reinstall openwakeword or use wakeword.engine=vosk."
+                )
+        except RuntimeError:
+            raise
+        except Exception as exc:
+            raise RuntimeError(f"openwakeword preflight failed: {exc}")
         model_paths = _resolve_model_paths(cfg.get("model_paths"))
         if not model_paths:
             raise ValueError("openwakeword.model_paths is required")
         self._labels = list(model_paths.keys())
-        self._model = OpenWakeWordModel(wakeword_models=list(model_paths.values()))
+        inference_framework = str(cfg.get("inference_framework", "onnx")).strip().lower() or "onnx"
+        try:
+            self._model = OpenWakeWordModel(
+                wakeword_models=list(model_paths.values()),
+                inference_framework=inference_framework,
+            )
+        except TypeError:
+            self._model = OpenWakeWordModel(wakeword_models=list(model_paths.values()))
         self._threshold = float(cfg.get("threshold", 0.5))
         self._smooth_window = int(cfg.get("smooth_window", 3))
         self._score_history: Dict[str, deque] = {}

--- a/modules/wiki_rag/config/config.yml
+++ b/modules/wiki_rag/config/config.yml
@@ -2,7 +2,7 @@ server:
   host: 0.0.0.0
   port: 8098
 ollama:
-  base_url: http://localhost:11434
+  base_url: http://localhost:11435
   model: llama3.2:3b
   request_timeout: 60
 storage:

--- a/modules/wiki_rag/config_loader.py
+++ b/modules/wiki_rag/config_loader.py
@@ -5,7 +5,7 @@ import yaml
 
 DEFAULT_CFG = {
     "server": {"host": "0.0.0.0", "port": 8098},
-    "ollama": {"base_url": "http://localhost:11434", "model": "llama3.2:3b", "request_timeout": 60.0},
+    "ollama": {"base_url": "http://localhost:11435", "model": "llama3.2:3b", "request_timeout": 60.0},
     "storage": {
         "persist_dir": "modules/wiki_rag/storage/index_storage",
         "knowledge_dir": "modules/wiki_rag/storage/knowledge",

--- a/modules/wiki_rag/services/indexer.py
+++ b/modules/wiki_rag/services/indexer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 import os
+import io
+import contextlib
 from typing import Any
 from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, StorageContext, load_index_from_storage
 from llama_index.llms.ollama import Ollama
@@ -28,6 +30,8 @@ class IndexService:
             index = VectorStoreIndex.from_documents(documents, llm=llm, embed_model=OllamaEmbedding(model_name=self.model))
             index.storage_context.persist(persist_dir=self.persist_dir)
         else:
-            storage_context = StorageContext.from_defaults(persist_dir=self.persist_dir)
-            index = load_index_from_storage(storage_context, llm=llm, embed_model=OllamaEmbedding(model_name=self.model))
+            silent = io.StringIO()
+            with contextlib.redirect_stdout(silent):
+                storage_context = StorageContext.from_defaults(persist_dir=self.persist_dir)
+                index = load_index_from_storage(storage_context, llm=llm, embed_model=OllamaEmbedding(model_name=self.model))
         return index

--- a/run_robot.py
+++ b/run_robot.py
@@ -7,13 +7,15 @@ SentryBOT ana başlatıcı
 """
 import os
 import sys
+import logging
 import uvicorn  # type: ignore
-from pathlib import Path
 
 # Proje kökünü PYTHONPATH'e ekle (script doğrudan çalıştığında)
 ROOT = os.path.dirname(os.path.abspath(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
+
+logger = logging.getLogger("run_robot")
 
 
 def main() -> None:
@@ -21,11 +23,10 @@ def main() -> None:
     try:
         from modules.logwrapper import init_logging  # type: ignore
         init_logging()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("init_logging skipped: %s", exc)
 
     # Gateway app'i oluştur (platforms klasörü gereksiz; ana dizinden çalışır)
-    current_platform = None
     from modules.gateway.xGatewayService import create_app  # type: ignore
     from modules.gateway.config_loader import load_config  # type: ignore
 


### PR DESCRIPTION
This pull request introduces a major enhancement to OLED display support across the firmware, Arduino service, and API layers, as well as several improvements to error handling, configuration, and service interfaces. The most significant changes include adding robust OLED bitmap and animation controls (with catalog and animation support), refactoring API error handling, and improving configuration and polling logic for RFID and other services.

**OLED Display Enhancements:**

* Added comprehensive OLED bitmap and animation support in the firmware (`xOledDisplay.h`), including cataloging, animation sequences, and runtime updating if the `Irisoled` library is available. New commands allow showing named bitmaps, running named animations, stopping animations, and listing available assets. Stubs are provided for builds without OLED or `Irisoled` support. (`[[1]](diffhunk://#diff-c309c2bd6c96a8f1aa28c3b24c82347984702e8a23a2d8bff1350d9d8109fb5fR12-R17)`, `[[2]](diffhunk://#diff-c309c2bd6c96a8f1aa28c3b24c82347984702e8a23a2d8bff1350d9d8109fb5fR39-R261)`, `[[3]](diffhunk://#diff-eceb22957f986808618636dc3ca8aba4e705509ce864cad309794d941cebbef3R108-R155)`, `[[4]](diffhunk://#diff-73ff36e824424b0c03b3f40422b140a935965eca515989c1322fbb0497b83975R292-R294)`)
* Extended the Arduino serial service (`xArduinoSerialService.py`) with new methods for OLED control (`oled_show`, `oled_animate`, `oled_stop`, `oled_logo`, `oled_catalog`). (`[modules/arduino_serial/xArduinoSerialService.pyR363-R378](diffhunk://#diff-a09f2629c47de9637b551cd7a9eb80279a4ed63e873d0602088f193bf4f3323eR363-R378)`)
* Added new API endpoints for OLED control in the router (`/oled/show/{name}`, `/oled/anim/{name}`, `/oled/stop`, `/oled/logo`, `/oled/catalog`). (`[modules/arduino_serial/api/router.pyL71-R125](diffhunk://#diff-d21c08e72326331a95645a99fe18854e8f4c65732d74aee0f9f3a6027dac572cL71-R125)`)
* Enabled LLM and autonomy response blocks to trigger OLED actions via the client interface. (`[modules/autonomy/services/brain_parts/responses.pyR119-R134](diffhunk://#diff-5de6ebd6a53b961db194cb167b3d658d92b2636a09bcc58891936b53c5018cf1R119-R134)`)

**API and Service Improvements:**

* Refactored API error handling in the Arduino router to use a unified `_safe_call` wrapper, reducing code duplication and ensuring consistent error responses across all endpoints. (`[[1]](diffhunk://#diff-d21c08e72326331a95645a99fe18854e8f4c65732d74aee0f9f3a6027dac572cR14-R19)`, `[[2]](diffhunk://#diff-d21c08e72326331a95645a99fe18854e8f4c65732d74aee0f9f3a6027dac572cL27-R51)`, `[[3]](diffhunk://#diff-d21c08e72326331a95645a99fe18854e8f4c65732d74aee0f9f3a6027dac572cL71-R125)`)
* Improved the `system_control` and `set_neopixel` methods in the autonomy client for more flexible and robust service routing and payload handling. (`[modules/autonomy/services/client.pyL66-R94](diffhunk://#diff-3bdf6a1c0a44a47d7e9e2b4f5b305de0509cd872ca8f28878053c9a4dbc8c991L66-R94)`)

**Configuration and Polling Enhancements:**

* Changed the default Arduino serial port configuration to `"AUTO"` for better out-of-the-box compatibility. (`[modules/arduino_serial/config_loader.pyL12-R12](diffhunk://#diff-a1a20b4266061af74cdd0d159c5fc06a4890b61ef9b877b84b398c402dfabb25L12-R12)`)
* Added `poll_interval_s` to the autonomy RFID config and implemented polling interval logic in the owner guard to avoid excessive authorization checks. (`[[1]](diffhunk://#diff-4720fe6cf9e67ea372023f6841c654e57b7238790f00e4870a4c306e8295650bR136)`, `[[2]](diffhunk://#diff-f7a879acf296175b276c69ffbeb73bee91723bd6b172704c5a5ae9e155899d6bR30-R35)`)

**Bug Fixes and Minor Improvements:**

* Improved robustness in sound direction sensing by handling missing or malformed direction data. (`[modules/autonomy/services/brain.pyL117-R118](diffhunk://#diff-8232e666d8fcd4e90bf8b39b840cd8bef182a9201c623eb03c2f46c8aba2bf9aL117-R118)`)

These changes collectively provide a more feature-rich and reliable interface for OLED display management, streamline error handling, and improve configuration flexibility across the stack.