### PR TITLE
arduino: request retry & telemetry scaffolding; add tests; autonomy smoke harness; interactions rule

### DIFF
--- a/modules/arduino_serial/config/config.yml
+++ b/modules/arduino_serial/config/config.yml
@@ -6,9 +6,13 @@ write_timeout: 0.1
 reconnect_sec: 2.0
 heartbeat_ms: 100
 auto_heartbeat: true
+# Request/retry tuning (milliseconds for timeouts where noted)
+request_max_retries: 0    # number of additional retries after first attempt
+request_timeout_ms: 1000 # default timeout for requests (ms) if not provided
 telemetry:
   enabled: false
   interval_ms: 100
+  endpoint: null  # optional HTTP endpoint to POST telemetry events, e.g. http://localhost:8090/telemetry/events
 log_level: INFO
 rfid:
   allowed_uids: []

--- a/modules/arduino_serial/tests/fake_transport_sim.py
+++ b/modules/arduino_serial/tests/fake_transport_sim.py
@@ -1,0 +1,65 @@
+import time
+import json
+import threading
+
+
+class FakeTransportSim:
+    """Simple fake serial transport for tests.
+
+    - Collected writes are available in `._buf` (bytes).
+    - Incoming messages are queued in `._read_q` as bytes and returned by `readline()`.
+    - `write()` will parse JSON and auto-respond for known `cmd` values.
+    """
+
+    def __init__(self, auto_delay: float = 0.01):
+        self._buf = b""
+        self._read_q = []
+        self._lock = threading.Lock()
+        self._auto_delay = float(auto_delay)
+
+    def readline(self):
+        # simulate blocking read
+        time.sleep(self._auto_delay)
+        with self._lock:
+            if self._read_q:
+                return (self._read_q.pop(0) + b"\n")
+        return b""
+
+    def write(self, data: bytes) -> int:
+        # record write
+        with self._lock:
+            self._buf += data
+        # Try to parse JSON and schedule an automatic response for basic commands
+        try:
+            text = data.decode("utf-8", errors="ignore").strip()
+            if not text:
+                return len(data)
+            # may contain multiple lines; parse the first JSON-like segment
+            line = text.splitlines()[0]
+            obj = json.loads(line)
+            # default auto-replies for a few known commands
+            reply = None
+            cmd = obj.get("cmd")
+            if cmd == "hello":
+                reply = {"ok": True, "cmd": "hello"}
+            elif cmd == "get_state":
+                reply = {"ok": True, "state": "idle"}
+            elif cmd == "hb":
+                reply = {"ok": True, "msg": "hb"}
+            elif cmd == "telemetry_start":
+                reply = {"ok": True}
+
+            if reply is not None:
+                # schedule immediate insertion into read queue
+                with self._lock:
+                    self._read_q.append(json.dumps(reply).encode("utf-8"))
+        except Exception:
+            pass
+        return len(data)
+
+    def inject_msg(self, obj: dict) -> None:
+        with self._lock:
+            self._read_q.append(json.dumps(obj).encode("utf-8"))
+
+    def close(self):
+        return

--- a/modules/arduino_serial/tests/test_fake_simulator_response.py
+++ b/modules/arduino_serial/tests/test_fake_simulator_response.py
@@ -1,0 +1,16 @@
+from modules.arduino_serial.tests.fake_transport_sim import FakeTransportSim
+from modules.arduino_serial.xArduinoSerialService import xArduinoSerialService
+
+
+def test_fake_transport_auto_reply_hello():
+    dt = FakeTransportSim()
+    svc = xArduinoSerialService(transport_factory=lambda *a, **k: dt)
+    svc.start()
+    try:
+        resp = svc.request({"cmd": "hello"}, timeout=1.0)
+        assert isinstance(resp, dict)
+        assert resp.get("ok") is True
+        # confirm write happened
+        assert dt._buf, "expected writes to transport"
+    finally:
+        svc.stop()

--- a/modules/arduino_serial/tests/test_request_retry.py
+++ b/modules/arduino_serial/tests/test_request_retry.py
@@ -1,0 +1,44 @@
+import time
+import json
+
+from modules.arduino_serial.xArduinoSerialService import xArduinoSerialService
+
+
+class DummyTransportNoReply:
+    def __init__(self):
+        self._buf = b""
+        self._read_q = []
+
+    def readline(self):
+        # do a small sleep to simulate blocking read but return no data
+        time.sleep(0.01)
+        if self._read_q:
+            return (self._read_q.pop(0) + b"\n")
+        return b""
+
+    def write(self, data: bytes) -> int:
+        self._buf += data
+        return len(data)
+
+    def close(self):
+        pass
+
+
+def test_request_retries_trigger_multiple_writes():
+    dt = DummyTransportNoReply()
+    # configure one retry (so total sends = 2)
+    svc = xArduinoSerialService(config_overrides={"request_max_retries": 1}, transport_factory=lambda *a, **k: dt)
+    svc.start()
+    try:
+        try:
+            svc.request({"cmd": "hello"}, timeout=0.05)
+        except Exception:
+            # expected to timeout after retries
+            pass
+
+        # buffer should contain two send attempts
+        data = dt._buf.decode("utf-8", errors="ignore")
+        lines = [ln for ln in data.splitlines() if ln.strip()]
+        assert len(lines) >= 2, f"expected >=2 writes, got {len(lines)}: {lines}"
+    finally:
+        svc.stop()

--- a/modules/arduino_serial/xArduinoSerialService.py
+++ b/modules/arduino_serial/xArduinoSerialService.py
@@ -7,6 +7,10 @@ import os
 import logging
 from queue import Queue, Empty
 from typing import Any, Dict, Optional, Callable, List
+try:
+    import requests
+except Exception:
+    requests = None
 
 from .config_loader import load_config
 from .contract import (
@@ -165,33 +169,54 @@ class xArduinoSerialService:
         self._metrics["tx_count"] += 1
 
     def request(self, obj: Dict[str, Any], timeout: float = 1.0) -> Dict[str, Any]:
-        self.send(obj)
-        t0 = time.time()
+        # Support config-driven retries and default timeout
+        max_retries = int(self.cfg.get("request_max_retries", 0) or 0)
+        # allow per-call timeout (seconds); if caller passed default, prefer configured ms
+        if timeout is None or timeout == 1.0:
+            cfg_ms = int(self.cfg.get("request_timeout_ms", 1000) or 1000)
+            timeout = float(cfg_ms) / 1000.0
+
         want_cmd = obj.get("cmd")
-        while True:
-            elapsed = time.time() - t0
-            remaining = timeout - elapsed
-            if remaining <= 0:
-                break
+        last_exc: Optional[Exception] = None
+        for attempt in range(0, max_retries + 1):
+            # send each attempt
+            self.send(obj)
+            t0 = time.time()
             try:
-                msg = self._rx_queue.get(timeout=remaining)
-                # Filter out initial boot "ready" message once, so it doesn't satisfy the first request.
-                if not obj.get("allow_ready", False) and isinstance(msg, dict) and msg.get("ok") is True and msg.get("msg") == "ready":
-                    # Only drop once per service lifecycle
-                    if not self._saw_boot_ready:
-                        self._saw_boot_ready = True
+                while True:
+                    elapsed = time.time() - t0
+                    remaining = timeout - elapsed
+                    if remaining <= 0:
+                        break
+                    try:
+                        msg = self._rx_queue.get(timeout=remaining)
+                        # Filter out initial boot "ready" message once, so it doesn't satisfy the first request.
+                        if not obj.get("allow_ready", False) and isinstance(msg, dict) and msg.get("ok") is True and msg.get("msg") == "ready":
+                            if not self._saw_boot_ready:
+                                self._saw_boot_ready = True
+                                continue
+                        # Ignore heartbeat acks unless we explicitly requested hb
+                        if want_cmd != "hb" and isinstance(msg, dict) and msg.get("ok") is True and msg.get("msg") == "hb":
+                            continue
+                        if isinstance(msg, dict) and ("ok" in msg or "err" in msg):
+                            return msg
                         continue
-                # Ignore heartbeat acks unless we explicitly requested hb
-                if want_cmd != "hb" and isinstance(msg, dict) and msg.get("ok") is True and msg.get("msg") == "hb":
-                    continue
-                # Prefer messages that look like a command reply: must contain 'ok' or 'err'
-                if isinstance(msg, dict) and ("ok" in msg or "err" in msg):
-                    return msg
-                # Otherwise ignore (likely telemetry) and keep waiting
+                    except Empty:
+                        # no message in remaining interval, will check overall timeout
+                        pass
+                # timed out for this attempt
+                last_exc = TimeoutError("No response from Arduino (attempt %d)" % (attempt + 1))
+            except Exception as exc:
+                last_exc = exc
+
+            # if we get here, attempt failed; if more retries remain, backoff briefly and retry
+            if attempt < max_retries:
+                time.sleep(0.05)
                 continue
-            except Empty:
-                # timed out waiting for a message in remaining interval; loop will break if overall timeout expired
-                pass
+
+        # all attempts exhausted
+        if last_exc:
+            raise last_exc
         raise TimeoutError("No response from Arduino")
 
     def try_get(self, timeout: float = 0.0) -> Optional[Dict[str, Any]]:
@@ -506,6 +531,11 @@ class xArduinoSerialService:
                     try:
                         self._write_queue.put(( _json.dumps({"ok": True, "ack_seq": int(seq)}) + "\n" ).encode("utf-8"))
                         self._metrics["acks_sent"] += 1
+                        # Emit telemetry event for ACK if configured
+                        try:
+                            self._emit_telemetry_event("arduino_ack", {"seq": int(seq)})
+                        except Exception:
+                            pass
                     except Exception:
                         # swallow errors; ACK is best-effort
                         pass
@@ -513,12 +543,22 @@ class xArduinoSerialService:
                 pass
         if event_name == "rfid":
             self._record_rfid(msg.get("uid"))
+            try:
+                self._emit_telemetry_event("arduino_rfid", {"uid": msg.get("uid")})
+            except Exception:
+                pass
         if event_name:
             for handler in list(self._event_handlers):
                 try:
                     handler(msg)
                 except Exception as exc:
                     self._logger.debug("event handler failed: %s", exc)
+        # emit telemetry for critical events like estop
+        if msg.get("cmd") == "estop" or event_name == "estop":
+            try:
+                self._emit_telemetry_event("arduino_estop", msg)
+            except Exception:
+                pass
         if msg.get("telemetry") and msg.get("rfid"):
             self._record_rfid(msg.get("rfid"))
 
@@ -572,3 +612,22 @@ class xArduinoSerialService:
             except Exception:
                 time.sleep(0.01)
                 continue
+
+    def _emit_telemetry_event(self, event_type: str, payload: dict) -> None:
+        try:
+            cfg = self.cfg.get("telemetry", {}) or {}
+            if not cfg.get("enabled", False):
+                return
+            endpoint = cfg.get("endpoint")
+            if not endpoint:
+                return
+            if requests is None:
+                return
+            body = {"type": event_type, "payload": payload, "ts": time.time()}
+            # best-effort, no raise
+            try:
+                requests.post(endpoint, json=body, timeout=0.5)
+            except Exception:
+                pass
+        except Exception:
+            pass

--- a/modules/autonomy/tests/test_smoke_harness.py
+++ b/modules/autonomy/tests/test_smoke_harness.py
@@ -1,0 +1,67 @@
+import time
+
+from modules.autonomy.services.brain import AutonomyBrain
+
+
+class FakeServiceClient:
+    def __init__(self):
+        self.calls = []
+        self._speech_queue = [
+            {"text": "Merhaba, nasılsın?", "final": True, "confidence": 0.98}
+        ]
+        self._direction_queue = [{"angle": 25}]
+
+    def select_persona(self, name):
+        self.calls.append(("select_persona", name))
+
+    def get_speech_direction(self):
+        if self._direction_queue:
+            return self._direction_queue.pop(0)
+        return None
+
+    def get_last_speech(self):
+        if self._speech_queue:
+            return self._speech_queue.pop(0)
+        return {"text": "", "final": False}
+
+    def move_head(self, pan, tilt, speed=0.8):
+        self.calls.append(("move_head", pan, tilt))
+        return {"ok": True}
+
+    def push_interaction_event(self, ev):
+        self.calls.append(("event", ev))
+
+    def speak(self, text, tone=None, engine=None):
+        self.calls.append(("speak", text))
+        return {"ok": True}
+
+    def chat(self, query, apply_actions: bool = False):
+        # simple canned response
+        return {"answer": "Ben iyiyim, teşekkürler.", "actions": None}
+
+    def update_emotions(self, emotions):
+        self.calls.append(("update_emotions", tuple(emotions)))
+
+    # stub other methods used by AutonomyBrain
+    def select_persona(self, name):
+        self.calls.append(("select_persona", name))
+
+
+def test_autonomy_smoke_harness_reacts_to_speech_and_direction():
+    cfg = {"defaults": {"loop_interval_ms": 200}, "wikirag": {"enabled": False}, "llm": {"enabled": False}}
+    brain = AutonomyBrain(cfg)
+    fake = FakeServiceClient()
+    # inject fake client
+    brain.client = fake
+
+    brain.start()
+    try:
+        # let the loop run a short time
+        time.sleep(1.0)
+        # verify that speech reaction produced a speak call
+        has_speak = any(c[0] == "speak" for c in fake.calls)
+        has_move = any(c[0] == "move_head" for c in fake.calls)
+        has_event = any(c[0] == "event" for c in fake.calls)
+        assert has_speak or has_move or has_event, f"Expected at least one reaction, got calls: {fake.calls}"
+    finally:
+        brain.stop()

--- a/modules/interactions/config/config.yml
+++ b/modules/interactions/config/config.yml
@@ -58,6 +58,14 @@ rules:
     priority: high
     cooldown_ms: 1000
 
+  - id: speech_start_cute
+    when: { event: speech.start }
+    # Play a visual effect and request a 'cute' sound from Arduino via an event payload.
+    action:
+      effect: { name: RAINBOW_CYCLE, duration_ms: 1000 }
+      arduino: { cute: happy }
+    priority: high
+    cooldown_ms: 1000
   - id: speech_end
     when: { event: speech.end }
     action: { effect: { name: COMET, duration_ms: 600 } }


### PR DESCRIPTION

This pull request introduces several improvements and new features to the Arduino serial service and its test suite. The most significant changes include adding configurable request retry logic, supporting telemetry event emission to an HTTP endpoint, and introducing new test utilities and test coverage for these features.

**Core enhancements and reliability improvements:**

* Added configurable request retry logic and default request timeout to the `xArduinoSerialService.request()` method, allowing the number of retries and timeout duration to be set via configuration. This improves robustness in case of transient communication failures. [[1]](diffhunk://#diff-a09f2629c47de9637b551cd7a9eb80279a4ed63e873d0602088f193bf4f3323eR172-R185) [[2]](diffhunk://#diff-a09f2629c47de9637b551cd7a9eb80279a4ed63e873d0602088f193bf4f3323eL180-R219) [[3]](diffhunk://#diff-204f18d85fc77276f3308974cf5a85b3ea49ddbb5386d7f3d8bf21e712da6828R9-R15)
* Added support for emitting telemetry events (such as ACKs, RFID reads, and estop events) to an HTTP endpoint if telemetry is enabled and configured. This is implemented via the new `_emit_telemetry_event` method and related configuration options. [[1]](diffhunk://#diff-a09f2629c47de9637b551cd7a9eb80279a4ed63e873d0602088f193bf4f3323eR534-R561) [[2]](diffhunk://#diff-a09f2629c47de9637b551cd7a9eb80279a4ed63e873d0602088f193bf4f3323eR615-R633) [[3]](diffhunk://#diff-204f18d85fc77276f3308974cf5a85b3ea49ddbb5386d7f3d8bf21e712da6828R9-R15) [[4]](diffhunk://#diff-a09f2629c47de9637b551cd7a9eb80279a4ed63e873d0602088f193bf4f3323eR10-R13)

**Testing improvements:**

* Introduced `FakeTransportSim`, a fake serial transport class for use in tests, supporting auto-responses for common commands and message injection.
* Added new tests: `test_fake_simulator_response.py` to verify auto-reply logic, and `test_request_retry.py` to validate retry behavior when no reply is received. [[1]](diffhunk://#diff-c198057ef2989877c582dc3bdb03e49048a6130a436be425d3ad2715877c12ffR1-R16) [[2]](diffhunk://#diff-df5d2c3cccfd9825fda13941cce5c49e2fba43b4833ea2023acd9da441fd0855R1-R44)
* Added a smoke test harness for the `AutonomyBrain` class to ensure it reacts to speech and direction events as expected using a fake client.

**Configuration and interaction rules:**

* Updated configuration files to support the new request/retry and telemetry features, including new fields in `config.yml` for request retries, timeouts, and telemetry endpoint.
* Added a new interaction rule in `interactions/config/config.yml` to trigger a 'cute' Arduino sound and visual effect on speech start.