### PR TITLE
feat(interactions): quiet-hours suppression and forced manual effects

### DIFF
--- a/modules/interactions/README.md
+++ b/modules/interactions/README.md
@@ -7,6 +7,7 @@ Durumlara/olaylara göre NeoPixel animasyonlarını otomatik seçen hafif bir ku
 - Base (sürekli) + Transient (kısa) efekt katmanı, öncelik ve cooldown ile.
 - Sistem metrikleri: CPU sıcaklık/yük, ağ burst sezgisi.
 - Olay besleme: `POST /interactions/event` ile (ör: `speech.start`, `error`).
+- Quiet Hours (gece modu): belirli saatlerde dikkat dağıtan transient efektleri baskılar.
 - Donanım haritalama: Jewel (7) + Stick (16 tek sıra). Şimdilik tüm strip’e animasyon uygular.
 
 ## Kurulum
@@ -17,6 +18,7 @@ Durumlara/olaylara göre NeoPixel animasyonlarını otomatik seçen hafif bir ku
 - GET `/interactions/state`: aktif base/effect ve son metrikler.
 - POST `/interactions/event` `{ type, data? }`: olay tetikle (ör: `speech.start`).
 - POST `/interactions/effect` `{ name, duration_ms? }`: manuel kısa efekt.
+  - Opsiyonel: `{ force: true }` ile quiet-hours sırasında da efekt zorlanabilir.
 - POST `/interactions/base` `{ name, color? }`: geçici base override.
 
 ### Gateway Entegrasyonu
@@ -79,9 +81,25 @@ POST /interactions/event
 3. Renge özel davranmak isterseniz `base.color: "#RRGGBB"` verebilirsiniz (uyumlu animasyonlarda dolgu yapılır, aksi halde animasyon adı oynatılır).
 
 ## Notlar
-- Quiet hours varsayılan olarak kapalıdır (isteğe göre eklenebilir).
+- Quiet hours varsayılan olarak açıktır (`23:00-07:00`) ve yalnızca kritik olay efektlerine izin verir.
 - NeoPixel servisi yoksa istekler sessizce yok sayılır (No-Op mod).
 - İleride segment/mask desteklemek için NeoPixel API genişletimi önerilir.
+
+## Quiet Hours Konfigürasyonu
+`modules/interactions/config/config.yml` içinde:
+
+```yaml
+quiet_hours:
+  enabled: true
+  start: "23:00"
+  end: "07:00"
+  suppress_effects: true
+  allow_events: ["error", "warning", "owner.locked"]
+```
+
+- `suppress_effects: true` iken transient efektler baskılanır.
+- `allow_events` listesi, gece modu sırasında da çalışmasına izin verilen olay adlarıdır.
+- Base (sabit) aydınlatma için `quiet_hours_idle` kuralı dim bir görünüm uygular.
 
 ---
 Bu modül DryCode prensiplerine uygundur: tek sorumluluklu dosyalar, config odaklı, sade API.

--- a/modules/interactions/api/router.py
+++ b/modules/interactions/api/router.py
@@ -29,7 +29,8 @@ def get_router(engine: InteractionEngine) -> APIRouter:
     def effect(payload: Dict[str, Any]):
         name = str(payload.get("name", "COMET"))
         dur = int(payload.get("duration_ms", 800))
-        engine.push_event("manual.effect", {"name": name, "duration_ms": dur})
+        force = bool(payload.get("force", False))
+        engine.trigger_effect(name=name, duration_ms=dur, force=force)
         return {"ok": True}
 
     @r.post("/base", tags=["interactions"], summary="Base")

--- a/modules/interactions/config/config.yml
+++ b/modules/interactions/config/config.yml
@@ -20,6 +20,13 @@ hardware:
 
 tick_interval_ms: 800
 
+quiet_hours:
+  enabled: true
+  start: "23:00"
+  end: "07:00"
+  suppress_effects: true
+  allow_events: ["error", "warning", "owner.locked"]
+
 thresholds:
   cpu_temp: { warm: 65, hot: 75, hysteresis: 3 }
   cpu_load: { high: 0.9, window_s: 60 }
@@ -31,6 +38,11 @@ defaults:
     base: { name: BREATHE, color: "#30E3CA", speed: slow }
 
 rules:
+  - id: quiet_hours_idle
+    when: { quiet_hours_active: true }
+    action: { base: { name: BREATHE, color: "#08131A", speed: slow } }
+    priority: high
+
   - id: cpu_hot
     when: { cpu_temp_gte: 75 }
     action: { base: { name: BREATHE, color: "#FF0000", speed: slow } }

--- a/modules/interactions/services/engine.py
+++ b/modules/interactions/services/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple
@@ -43,6 +44,8 @@ class InteractionEngine:
         self.monitor_cfg = dict(cfg.get("monitor", {}))
         self._last_arduino_check = 0.0
         self._event_handlers: List[Any] = []
+        self._manual_effect: Optional[Dict[str, Any]] = None
+        self.quiet_hours_cfg = dict(cfg.get("quiet_hours", {}))
 
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
@@ -77,6 +80,14 @@ class InteractionEngine:
         with self._lock:
             self._ctx.update(kwargs)
 
+    def trigger_effect(self, name: str, duration_ms: int = 800, force: bool = False) -> None:
+        with self._lock:
+            self._manual_effect = {
+                "name": str(name),
+                "duration_ms": int(duration_ms),
+                "force": bool(force),
+            }
+
     def get_state(self) -> Dict[str, Any]:
         with self._lock:
             return {
@@ -95,6 +106,7 @@ class InteractionEngine:
 
     def _tick(self) -> None:
         now = time.time()
+        quiet_hours_active = self._is_quiet_hours_active()
         metrics = self.metrics.sample()
         self._update_arduino_state(now)
         net_burst = False
@@ -118,9 +130,12 @@ class InteractionEngine:
             }
             self._ctx["arduino_connected"] = self._ctx.get("arduino_connected", True)
             self._ctx["net_burst"] = net_burst
+            self._ctx["quiet_hours_active"] = quiet_hours_active
 
             # Evaluate rules
             manual_base = self._ctx.pop("manual_base", None)
+            manual_effect = self._manual_effect
+            self._manual_effect = None
             chosen: Optional[Rule] = None
             for r in self.rules:
                 ctx = dict(self._ctx)
@@ -129,7 +144,13 @@ class InteractionEngine:
                         chosen = r
 
             # Render
-            if manual_base and now >= self._active_effect_until:
+            if manual_effect and now >= self._active_effect_until:
+                if bool(manual_effect.get("force")) or self._effect_allowed("manual.effect"):
+                    name = str(manual_effect.get("name", "COMET"))
+                    duration_ms = int(manual_effect.get("duration_ms", 800))
+                    self._active_effect_until = now + duration_ms / 1000.0
+                    threading.Thread(target=self.neo.play_effect, args=(name, duration_ms), daemon=True).start()
+            elif manual_base and now >= self._active_effect_until:
                 name, color = manual_base
                 key = (str(name).upper(), color)
                 if key != self._last_base:
@@ -142,10 +163,12 @@ class InteractionEngine:
                     eff = act["effect"] or {}
                     name = str(eff.get("name", "COMET"))
                     duration_ms = int(eff.get("duration_ms", 800))
-                    self._active_effect_until = now + duration_ms / 1000.0
-                    chosen.stamp()
-                    # play effect asynchronously to avoid blocking
-                    threading.Thread(target=self.neo.play_effect, args=(name, duration_ms), daemon=True).start()
+                    event_name = self._ctx.get("event")
+                    if self._effect_allowed(event_name):
+                        self._active_effect_until = now + duration_ms / 1000.0
+                        chosen.stamp()
+                        # play effect asynchronously to avoid blocking
+                        threading.Thread(target=self.neo.play_effect, args=(name, duration_ms), daemon=True).start()
                 elif "base" in act and now >= self._active_effect_until:
                     base = act["base"] or {}
                     name = str(base.get("name", self.defaults.get("idle", {}).get("base", {}).get("name", "BREATHE")))
@@ -169,6 +192,49 @@ class InteractionEngine:
 
             # one-shot event is consumed
             self._ctx.pop("event", None)
+
+    def _effect_allowed(self, event_name: Any) -> bool:
+        if not bool(self.quiet_hours_cfg.get("enabled", False)):
+            return True
+        if not self._is_quiet_hours_active():
+            return True
+        if not bool(self.quiet_hours_cfg.get("suppress_effects", True)):
+            return True
+        allowed = self.quiet_hours_cfg.get("allow_events", []) or []
+        if not isinstance(allowed, list):
+            return False
+        return str(event_name or "").strip() in {str(v).strip() for v in allowed}
+
+    @staticmethod
+    def _parse_hhmm(value: str) -> Optional[Tuple[int, int]]:
+        text = str(value or "").strip()
+        parts = text.split(":")
+        if len(parts) != 2:
+            return None
+        try:
+            hh = int(parts[0])
+            mm = int(parts[1])
+        except Exception:
+            return None
+        if hh < 0 or hh > 23 or mm < 0 or mm > 59:
+            return None
+        return hh, mm
+
+    def _is_quiet_hours_active(self) -> bool:
+        if not bool(self.quiet_hours_cfg.get("enabled", False)):
+            return False
+        start = self._parse_hhmm(str(self.quiet_hours_cfg.get("start", "23:00")))
+        end = self._parse_hhmm(str(self.quiet_hours_cfg.get("end", "07:00")))
+        if start is None or end is None:
+            return False
+        now = datetime.now().hour * 60 + datetime.now().minute
+        start_min = start[0] * 60 + start[1]
+        end_min = end[0] * 60 + end[1]
+        if start_min == end_min:
+            return True
+        if start_min < end_min:
+            return start_min <= now < end_min
+        return now >= start_min or now < end_min
 
     def _update_arduino_state(self, now: float) -> None:
         if requests is None:

--- a/modules/interactions/services/rules.py
+++ b/modules/interactions/services/rules.py
@@ -58,4 +58,8 @@ def eval_condition(cond: Dict[str, Any], ctx: Dict[str, Any]) -> bool:
         ac = get("arduino_connected")
         if ac is None or bool(cond["arduino_connected"]) != bool(ac):
             return False
+    if "quiet_hours_active" in cond:
+        qh = get("quiet_hours_active")
+        if qh is None or bool(cond["quiet_hours_active"]) != bool(qh):
+            return False
     return True

--- a/modules/interactions/tests/test_smoke.py
+++ b/modules/interactions/tests/test_smoke.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import time
+
 from modules.interactions.xInteractionsService import xInteractionsService
+from modules.interactions.services.engine import InteractionEngine
 
 
 def test_smoke():
@@ -9,3 +12,59 @@ def test_smoke():
     state = svc.engine.get_state()
     assert "metrics" in state
     svc.stop()
+
+
+class _FakeNeo:
+    def __init__(self) -> None:
+        self.effects = []
+
+    def set_base(self, name, color=None, speed=None):
+        return None
+
+    def play_effect(self, name, duration_ms=800, color=None):
+        self.effects.append((str(name), int(duration_ms), color))
+
+
+def _make_engine(cfg_override=None) -> InteractionEngine:
+    cfg = {
+        "tick_interval_ms": 5,
+        "thresholds": {"cpu_load": {"window_s": 60}},
+        "adapter": {"http_base_url": ""},
+        "defaults": {"idle": {"base": {"name": "BREATHE", "color": "#000000"}}},
+        "rules": [{
+            "id": "speech_start",
+            "when": {"event": "speech.start"},
+            "action": {"effect": {"name": "RAINBOW_CYCLE", "duration_ms": 20}},
+            "priority": "high",
+        }],
+    }
+    if cfg_override:
+        cfg.update(cfg_override)
+    eng = InteractionEngine(cfg)
+    eng.neo = _FakeNeo()
+    return eng
+
+
+def test_manual_effect_works_without_rule():
+    eng = _make_engine({"rules": []})
+    eng.trigger_effect("COMET", 20)
+    eng._tick()
+    time.sleep(0.05)
+    assert eng.neo.effects and eng.neo.effects[0][0] == "COMET"
+
+
+def test_quiet_hours_suppresses_non_allowed_effects():
+    eng = _make_engine({
+        "quiet_hours": {
+            "enabled": True,
+            "start": "00:00",
+            "end": "23:59",
+            "suppress_effects": True,
+            "allow_events": ["error"],
+        }
+    })
+    eng._is_quiet_hours_active = lambda: True  # type: ignore[assignment]
+    eng.push_event("speech.start", None)
+    eng._tick()
+    time.sleep(0.05)
+    assert eng.neo.effects == []


### PR DESCRIPTION
﻿## Ozet
Interactions modulunde gece saatlerinde transient efektleri baskilayan quiet-hours davranisi eklendi. Manuel efekt tetikleme akisina force override eklendi ve kural motoru bu davranisla uyumlu hale getirildi.

## Degisiklik tipi
- [ ] Hata duzeltmesi
- [x] Yeni ozellik
- [ ] Refactor
- [x] Dokumantasyon guncellemesi
- [x] Test guncellemesi

## Etkilenen moduller
- modules/interactions

## Dogrulama
- [ ] Lokal calistirma tamamlandi (python run_robot.py veya hedef modul calistirma)
- [x] Ilgili testler geciyor
- [x] Gerekli dokuman/konfig guncellemeleri yapildi

## Arduino Kontrat Kontrolu (uygunsa)
Bu PR Arduino komutu veya payload kontratini etkilemiyor; kapsam disi.
- [ ] modules/arduino_serial/contract.py disinda elle Arduino payload yazilmadi
- [ ] Kritik komutlar gerektiginde /arduino/request kullaniyor
- [ ] Yeni komut ailesi builder + validator + test iceriyor

## Risk ve geri alma
Risk: Quiet-hours allowlist disinda kalan event efektleri beklenenden daha sakin davranabilir.
Geri alma: Bu PR commiti revert edilerek onceki efekt akisina donulebilir.

## Ilgili issue
Closes #N/A
