### PR TITLE
feat(autonomy): cinematic scene triggers for owner and vision

### DIFF
--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -11,6 +11,7 @@ from .memory import ShortTermMemory
 from .brain_parts.animations import AnimationSupportMixin
 from .brain_parts.owner_guard import OwnerGuardMixin
 from .brain_parts.responses import ResponseTagMixin
+from .brain_parts.scenes import SceneMixin
 from .brain_parts.timeline import TimelineMixin
 from .brain_parts.vision import VisionMixin
 from .brain_parts.vocal import VocalMixin
@@ -23,6 +24,7 @@ class AutonomyBrain(
     TimelineMixin,
     OwnerGuardMixin,
     ResponseTagMixin,
+    SceneMixin,
     VisionMixin,
     VocalMixin,
 ):

--- a/modules/autonomy/services/brain_parts/owner_guard.py
+++ b/modules/autonomy/services/brain_parts/owner_guard.py
@@ -283,7 +283,12 @@ class OwnerGuardMixin:
         greet_cooldown = max(10, self.owner_cfg.get("presence_timeout_s", 30) / 2)
         if timestamp - self.state.get("owner_last_greet", 0.0) > greet_cooldown:
             greeting = self.owner_cfg.get("greeting", "Baba! Gelmene çok sevindim.")
-            self._speak_with_mood(greeting.replace("{nickname}", affectionate), emotion="joy")
+            ran = self._run_scene(
+                "owner_return",
+                context={"name": self.owner_cfg.get("name", "Owner"), "nickname": affectionate},
+            )
+            if not ran:
+                self._speak_with_mood(greeting.replace("{nickname}", affectionate), emotion="joy")
             self.state["owner_last_greet"] = timestamp
         self.mood.modify("happiness", 10)
         self._report_attempts_to_owner()

--- a/modules/autonomy/services/brain_parts/scenes.py
+++ b/modules/autonomy/services/brain_parts/scenes.py
@@ -1,0 +1,169 @@
+"""Scene orchestration helpers for coordinated multi-modal behaviors."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List
+
+logger = logging.getLogger("autonomy.scenes")
+
+
+class SceneMixin:
+    """Runs small action timelines combining light/motion/speech."""
+
+    def _get_scene_def(self, scene_name: str) -> Dict[str, Any] | None:
+        scenes = self.config.get("scenes", {}) if isinstance(self.config, dict) else {}
+        if not isinstance(scenes, dict):
+            return None
+        raw = scenes.get(scene_name)
+        if isinstance(raw, dict):
+            return raw
+        return None
+
+    def _run_scene(self, scene_name: str, context: Dict[str, Any] | None = None) -> bool:
+        scene = self._get_scene_def(scene_name)
+        if not scene:
+            return False
+
+        steps = scene.get("steps", [])
+        if not isinstance(steps, list) or not steps:
+            return False
+
+        ctx = dict(context or {})
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            typ = str(step.get("type", "")).strip().lower()
+            if not typ:
+                continue
+            try:
+                self._run_scene_step(typ, step, ctx)
+            except Exception as exc:  # pragma: no cover - best effort scene
+                logger.debug("Scene step failed (%s): %s", typ, exc)
+        return True
+
+    def _run_scene_step(self, typ: str, step: Dict[str, Any], context: Dict[str, Any]) -> None:
+        if typ == "event":
+            event_type = str(step.get("name", "")).strip()
+            if event_type:
+                self.client.push_interaction_event(event_type, dict(context))
+            return
+
+        if typ == "effect":
+            name = str(step.get("name", "COMET"))
+            duration_ms = int(step.get("duration_ms", 700))
+            force = bool(step.get("force", False))
+            self.client.set_interaction_effect(name=name, duration_ms=duration_ms, force=force)
+            return
+
+        if typ == "effect_burst":
+            name = str(step.get("name", "COMET"))
+            duration_ms = int(step.get("duration_ms", 220))
+            count = max(1, int(step.get("count", 2)))
+            interval_ms = max(0, int(step.get("interval_ms", 80)))
+            force = bool(step.get("force", False))
+            for idx in range(count):
+                self.client.set_interaction_effect(name=name, duration_ms=duration_ms, force=force)
+                if idx < count - 1 and interval_ms > 0:
+                    time.sleep(interval_ms / 1000.0)
+            return
+
+        if typ == "base":
+            name = str(step.get("name", "BREATHE"))
+            color = step.get("color")
+            self.client.set_interaction_base(name=name, color=color)
+            return
+
+        if typ == "segment_fill":
+            segment = str(step.get("segment", "")).strip()
+            color = self._parse_color(step.get("color"))
+            if segment and color:
+                self.client.fill_neopixel_segment_color(segment, color[0], color[1], color[2])
+            return
+
+        if typ == "segment_anim":
+            segment = str(step.get("segment", "")).strip()
+            name = str(step.get("name", "PULSE")).strip()
+            color = self._parse_color(step.get("color"))
+            emotions = step.get("emotions")
+            if isinstance(emotions, str):
+                emotions = [emotions]
+            iterations = step.get("iterations")
+            if segment and name:
+                self.client.set_neopixel_segment_effect(
+                    segment=segment,
+                    effect=name,
+                    color=color,
+                    emotions=emotions if isinstance(emotions, list) else None,
+                    iterations=iterations,
+                )
+            return
+
+        if typ == "preset":
+            preset_name = str(step.get("name", "")).strip()
+            if preset_name:
+                self.client.apply_neopixel_preset(preset_name)
+            return
+
+        if typ == "anim":
+            name = str(step.get("name", ""))
+            if name:
+                speed = float(step.get("speed", 1.0))
+                loop = bool(step.get("loop", False))
+                self._trigger_animation(name, speed=speed, loop=loop)
+            return
+
+        if typ == "head":
+            pan = step.get("pan")
+            tilt = step.get("tilt")
+            if pan is None and tilt is None:
+                return
+            cur_pan = int(self.state.get("current_pan", 90))
+            cur_tilt = int(self.state.get("current_tilt", 90))
+            target_pan = max(0, min(180, int(float(pan)))) if pan is not None else cur_pan
+            target_tilt = max(0, min(180, int(float(tilt)))) if tilt is not None else cur_tilt
+            self.state["current_pan"] = target_pan
+            self.state["current_tilt"] = target_tilt
+            self.client.move_head(target_pan, target_tilt)
+            return
+
+        if typ == "speak":
+            text_tmpl = str(step.get("text", "")).strip()
+            if text_tmpl:
+                text = self._render_scene_text(text_tmpl, context)
+                emotion = step.get("emotion")
+                if emotion is None:
+                    self._speak_with_mood(text)
+                else:
+                    self._speak_with_mood(text, emotion=str(emotion))
+            return
+
+        if typ == "sleep":
+            ms = int(step.get("duration_ms", 0))
+            if ms > 0:
+                time.sleep(ms / 1000.0)
+            return
+
+    @staticmethod
+    def _render_scene_text(template: str, context: Dict[str, Any]) -> str:
+        text = template
+        for key, value in context.items():
+            text = text.replace("{" + str(key) + "}", str(value))
+        return text
+
+    @staticmethod
+    def _parse_color(raw: Any) -> tuple[int, int, int] | None:
+        if isinstance(raw, (list, tuple)) and len(raw) == 3:
+            try:
+                return (int(raw[0]) & 255, int(raw[1]) & 255, int(raw[2]) & 255)
+            except Exception:
+                return None
+        if isinstance(raw, str):
+            s = raw.strip()
+            if s.startswith("#") and len(s) >= 7:
+                try:
+                    v = int(s[1:7], 16)
+                    return ((v >> 16) & 255, (v >> 8) & 255, v & 255)
+                except Exception:
+                    return None
+        return None

--- a/modules/autonomy/services/brain_parts/vision.py
+++ b/modules/autonomy/services/brain_parts/vision.py
@@ -39,7 +39,7 @@ class VisionMixin:
             return
         now = time.time()
         self._current_people[name] = now
-        cooldown = self._vision_cfg.get("person_cooldown_s", 25)
+        cooldown = self._compute_person_cooldown(result)
         last_seen = self._people_last_seen.get(name, 0.0)
         if now - last_seen < cooldown:
             return
@@ -58,7 +58,13 @@ class VisionMixin:
             utterance = self._compose_greeting_for_person(name, result)
             if utterance:
                 emotion = "joy" if name != "Unknown" else "curiosity"
-                self._speak_with_mood(utterance, emotion=emotion)
+                scene_name = self._pick_vision_scene(name, result)
+                ran = self._run_scene(
+                    scene_name,
+                    context={"name": name, "greeting": utterance, "emotion": emotion},
+                )
+                if not ran:
+                    self._speak_with_mood(utterance, emotion=emotion)
                 self.memory.add_event(f"{name} ile konuştum: {utterance}")
         if self._is_owner_name(name):
             self._on_owner_seen(now)
@@ -104,7 +110,49 @@ class VisionMixin:
         if self._trigger_animation("vision_focus"):
             return
         self.client.push_interaction_event("vision.focus", {"label": result.get("label")})
-        jitter = random.randint(-5, 5)
-        target = max(0, min(180, self.state["current_pan"] + jitter))
+        cfg = self._vision_cfg.get("focus", {}) if isinstance(self._vision_cfg.get("focus", {}), dict) else {}
+        min_j = int(cfg.get("jitter_min", -3))
+        max_j = int(cfg.get("jitter_max", 3))
+        deadband = int(cfg.get("deadband_deg", 2))
+        smooth = float(cfg.get("smoothing", 0.55))
+
+        current = int(self.state.get("current_pan", 90))
+        jitter = random.randint(min_j, max_j)
+        proposed = max(0, min(180, current + jitter))
+        if abs(proposed - current) < max(0, deadband):
+            return
+
+        target = int(round((current * smooth) + (proposed * (1.0 - smooth))))
+        self.state["current_pan"] = target
         self.client.move_head(target, self.state["current_tilt"])
         self._blink_fallback()
+
+    def _compute_person_cooldown(self, result: Dict[str, Any]) -> float:
+        base = float(self._vision_cfg.get("person_cooldown_s", 25))
+        dyn = self._vision_cfg.get("dynamic_cooldown", {}) if isinstance(self._vision_cfg.get("dynamic_cooldown", {}), dict) else {}
+        if not bool(dyn.get("enabled", False)):
+            return base
+        near_dist = float(dyn.get("near_distance_m", 1.2))
+        far_dist = float(dyn.get("far_distance_m", 3.0))
+        near_mul = float(dyn.get("near_multiplier", 0.6))
+        far_mul = float(dyn.get("far_multiplier", 1.3))
+        dist = result.get("distance_m")
+        if not isinstance(dist, (int, float)):
+            return base
+        if dist <= near_dist:
+            return max(2.0, base * near_mul)
+        if dist >= far_dist:
+            return max(2.0, base * far_mul)
+        return base
+
+    def _pick_vision_scene(self, name: str, result: Dict[str, Any]) -> str:
+        if self._is_owner_name(name):
+            return "vision_greeting_owner"
+        dist = result.get("distance_m")
+        if name == "Unknown":
+            if isinstance(dist, (int, float)) and dist <= 1.2:
+                return "vision_greeting_unknown_close"
+            return "vision_greeting_unknown"
+        if isinstance(dist, (int, float)) and dist <= 1.2:
+            return "vision_greeting_known_close"
+        return "vision_greeting_known"

--- a/modules/autonomy/tests/test_scene_orchestrator.py
+++ b/modules/autonomy/tests/test_scene_orchestrator.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from modules.autonomy.services.brain_parts.scenes import SceneMixin
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def push_interaction_event(self, event_type, data=None):
+        self.calls.append(("event", event_type, data))
+
+    def set_interaction_effect(self, name, duration_ms=800, force=False):
+        self.calls.append(("effect", name, int(duration_ms), bool(force)))
+
+    def set_interaction_base(self, name, color=None):
+        self.calls.append(("base", name, color))
+
+    def move_head(self, pan, tilt):
+        self.calls.append(("head", int(pan), int(tilt)))
+
+    def fill_neopixel_segment_color(self, segment, r, g, b):
+        self.calls.append(("segment_fill", str(segment), int(r), int(g), int(b)))
+
+    def set_neopixel_segment_effect(self, segment, effect, color=None, emotions=None, iterations=None):
+        self.calls.append(("segment_anim", str(segment), str(effect), color, emotions, iterations))
+
+    def apply_neopixel_preset(self, name):
+        self.calls.append(("preset", str(name)))
+
+
+class _FakeBrain(SceneMixin):
+    def __init__(self):
+        self.client = _FakeClient()
+        self.state = {"current_pan": 90, "current_tilt": 90}
+        self.config = {
+            "scenes": {
+                "vision_greeting_known": {
+                    "steps": [
+                        {"type": "event", "name": "scene.start"},
+                        {"type": "preset", "name": "owner_welcome"},
+                        {"type": "effect", "name": "COMET", "duration_ms": 300},
+                        {"type": "effect_burst", "name": "COMET", "duration_ms": 120, "count": 2, "interval_ms": 0},
+                        {"type": "segment_anim", "segment": "jewel", "name": "PULSE", "color": "#00AAFF", "iterations": 1},
+                        {"type": "head", "pan": 100, "tilt": 95},
+                        {"type": "speak", "text": "Merhaba {name}", "emotion": "joy"},
+                        {"type": "segment_fill", "segment": "stick", "color": [1, 2, 3]},
+                        {"type": "base", "name": "BREATHE", "color": "#00AAFF"},
+                    ]
+                }
+            }
+        }
+        self.spoken = []
+        self.anims = []
+
+    def _trigger_animation(self, name: str, speed: float = 1.0, loop: bool = False) -> bool:
+        self.anims.append((name, speed, loop))
+        return True
+
+    def _speak_with_mood(self, text: str, emotion: str | None = None) -> None:
+        self.spoken.append((text, emotion))
+
+
+def test_scene_runs_all_core_steps():
+    b = _FakeBrain()
+    ok = b._run_scene("vision_greeting_known", {"name": "Emir"})
+    assert ok is True
+    assert ("preset", "owner_welcome") in b.client.calls
+    assert ("effect", "COMET", 300, False) in b.client.calls
+    burst_count = len([c for c in b.client.calls if c[:2] == ("effect", "COMET") and c[2] == 120])
+    assert burst_count == 2
+    assert any(c[0] == "segment_anim" and c[1] == "jewel" for c in b.client.calls)
+    assert ("segment_fill", "stick", 1, 2, 3) in b.client.calls
+    assert ("head", 100, 95) in b.client.calls
+    assert ("base", "BREATHE", "#00AAFF") in b.client.calls
+    assert b.spoken == [("Merhaba Emir", "joy")]
+
+
+def test_scene_missing_returns_false():
+    b = _FakeBrain()
+    assert b._run_scene("does_not_exist", {}) is False

--- a/modules/autonomy/tests/test_vision_focus_tuning.py
+++ b/modules/autonomy/tests/test_vision_focus_tuning.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from modules.autonomy.services.brain_parts.vision import VisionMixin
+
+
+class _FocusClient:
+    def __init__(self):
+        self.moves = []
+        self.events = []
+
+    def push_interaction_event(self, event_type, data=None):
+        self.events.append((event_type, data))
+
+    def move_head(self, pan, tilt):
+        self.moves.append((int(pan), int(tilt)))
+
+
+class _FocusBrain(VisionMixin):
+    def __init__(self):
+        self.client = _FocusClient()
+        self._vision_cfg = {
+            "focus": {"jitter_min": 1, "jitter_max": 1, "deadband_deg": 2, "smoothing": 0.5},
+            "dynamic_cooldown": {"enabled": True, "near_distance_m": 1.2, "far_distance_m": 3.0, "near_multiplier": 0.6, "far_multiplier": 1.3},
+            "person_cooldown_s": 20,
+        }
+        self.owner_cfg = {}
+        self.state = {"current_pan": 90, "current_tilt": 90}
+
+    def _trigger_animation(self, name: str, speed: float = 1.0, loop: bool = False) -> bool:
+        return False
+
+    def _blink_fallback(self):
+        return None
+
+    def _is_owner_name(self, name: str | None) -> bool:
+        return str(name or "").lower() == "owner"
+
+
+def test_focus_deadband_skips_tiny_motion():
+    brain = _FocusBrain()
+    brain._focus_on_target({"label": "person"})
+    assert brain.client.moves == []
+
+
+def test_focus_moves_when_over_deadband():
+    brain = _FocusBrain()
+    brain._vision_cfg["focus"] = {"jitter_min": 4, "jitter_max": 4, "deadband_deg": 2, "smoothing": 0.5}
+    brain._focus_on_target({"label": "person"})
+    assert len(brain.client.moves) == 1
+    # with smoothing=0.5 and proposed 94 from 90, expected rounded 92
+    assert brain.client.moves[0][0] == 92
+
+
+def test_dynamic_cooldown_uses_distance_bands():
+    brain = _FocusBrain()
+    assert brain._compute_person_cooldown({"distance_m": 0.8}) == 12.0
+    assert brain._compute_person_cooldown({"distance_m": 3.5}) == 26.0
+    assert brain._compute_person_cooldown({"distance_m": 2.0}) == 20.0
+
+
+def test_scene_picker_prefers_owner_then_close_variants():
+    brain = _FocusBrain()
+    assert brain._pick_vision_scene("owner", {"distance_m": 2.0}) == "vision_greeting_owner"
+    assert brain._pick_vision_scene("Unknown", {"distance_m": 0.9}) == "vision_greeting_unknown_close"
+    assert brain._pick_vision_scene("Ali", {"distance_m": 0.9}) == "vision_greeting_known_close"


### PR DESCRIPTION
﻿## Ozet
Autonomy sahne paketi owner-return ve vision greeting akislari icin sinematik sahne tetiklemeleri ekler. Scene mixin iskeleti baglanir ve odak ayarlarini test eden ek testler dahil edilir.

## Degisiklik tipi
- [ ] Hata duzeltmesi
- [x] Yeni ozellik
- [ ] Refactor
- [ ] Dokumantasyon guncellemesi
- [x] Test guncellemesi

## Etkilenen moduller
- modules/autonomy

## Dogrulama
- [ ] Lokal calistirma tamamlandi (python run_robot.py veya hedef modul calistirma)
- [x] Ilgili testler geciyor
- [ ] Gerekli dokuman/konfig guncellemeleri yapildi

## Arduino Kontrat Kontrolu (uygunsa)
Bu PR Arduino komutu veya payload kontratini etkilemiyor; kapsam disi.
- [ ] modules/arduino_serial/contract.py disinda elle Arduino payload yazilmadi
- [ ] Kritik komutlar gerektiginde /arduino/request kullaniyor
- [ ] Yeni komut ailesi builder + validator + test iceriyor

## Risk ve geri alma
Risk: Sahne adim siralari ve event tetikleme zamanlamasi davranis ritmini etkileyebilir.
Geri alma: Scene trigger commitleri revert edilerek standart konusma/tepki akisina donulebilir.

## Ilgili issue
Closes #N/A
