### PR TITLE
feat(speak): liveliness sync for tone, emphasis, and pauses

### DIFF
--- a/modules/speak/README.md
+++ b/modules/speak/README.md
@@ -6,6 +6,7 @@ Küçük, tek sorumluluklu bileşenler (DryCode). Hem kütüphane hem servis ola
 - TTS motorları: pyttsx3 (offline), Piper (harici ikili/model; offline, doğal)
 - MAX98357A I2S amplifikatör üzerinden ses çıkışı (ALSA cihazı)
 - Harici ses çalma: base64 WAV veri oynatma
+- Konuşma sırasında canlılık senkronu: `/interactions/event` ve `/interactions/effect` ile LED tepkisi
 - Temiz API: `/speak/say` (TTS) ve `/speak/play` (codec + base64)
 - Modüler yapı: TTS, Player, Decoder ayrık ve test edilebilir
 
@@ -59,7 +60,31 @@ tts:
 		noise_scale: null
 		noise_w: null
 
+liveliness:
+	enabled: true
+	interactions_base_url: http://localhost:8080/interactions
+	speech_effect:
+		name: PULSE
+		tone_effect_map:
+			fast: COMET
+			neutral: PULSE
+			calm: BREATHE
+			tired: THEATER_CHASE
+		min_duration_ms: 400
+		max_duration_ms: 7000
+		chars_per_second: 16
+		force: false
+
 ```
+
+`liveliness.enabled: true` iken `speak` akışı otomatik olarak:
+- konuşma başında `speech.start` event gönderir,
+- metin uzunluğu ve tone bilgisine göre efekt süresi hesaplayıp `/interactions/effect` tetikler,
+- konuşma bitince `speech.end` event gönderir.
+
+`tone_effect_map` sayesinde konuşma tonu (`rate`/`volume`) farklı efektlere eşlenebilir.
+`emphasis_effect_map` ile `!` ve `?` gibi vurgu işaretleri için kısa ek efektler gönderilir.
+`rhythm` bloğu ile metin uzunluğuna göre beat sayısı hesaplanıp mikro efekt vuruşları üretilir.
 
 ## Donanım ve Kurulum Notları
 - MAX98357A I2S DAC ALSA’da bir çıkış cihayı olarak görünmelidir.

--- a/modules/speak/config/config.yml
+++ b/modules/speak/config/config.yml
@@ -35,4 +35,36 @@ tts:
     language: tr
     speaker_wav: null          # ses kopyalama için referans wav yolu (opsiyonel)
 
+liveliness:
+  enabled: true
+  interactions_base_url: http://localhost:8080/interactions
+  speech_effect:
+    name: PULSE
+    tone_effect_map:
+      fast: COMET
+      neutral: PULSE
+      calm: BREATHE
+      tired: THEATER_CHASE
+    emphasis_effect_map:
+      exclamation: COMET
+      question: TWINKLE
+    rhythm:
+      enabled: true
+      mode: clauses           # words | clauses
+      effect: PULSE
+      words_per_beat: 3
+      clauses_per_beat: 1
+      max_beats: 4
+      duration_ms: 150
+      max_pause_marks: 4
+      pause_effect_map:
+        ",": TWINKLE
+        ";": TWINKLE
+        ":": BREATHE
+        ".": BREATHE
+    min_duration_ms: 400
+    max_duration_ms: 7000
+    chars_per_second: 16
+    force: false
+
 # note: external compressed audio decoding removed; /speak/play expects base64 WAV

--- a/modules/speak/tests/test_liveliness_sync.py
+++ b/modules/speak/tests/test_liveliness_sync.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from modules.speak.xSpeakService import SpeakService
+
+
+@dataclass
+class _DummyPCM:
+    samplerate: int = 22050
+
+
+class _DummyTTS:
+    def synthesize(self, text: str, overrides=None):
+        return _DummyPCM()
+
+
+class _DummyPlayer:
+    def play_blocking(self, pcm):
+        return 1.25
+
+
+class _FakeSpeakService(SpeakService):
+    def __init__(self):
+        self.cfg = {"tts": {"engine": "dummy"}}
+        self.tts = _DummyTTS()
+        self.player = _DummyPlayer()
+        self._liveliness_cfg = {
+            "enabled": True,
+            "interactions_base_url": "http://localhost:8080/interactions",
+            "speech_effect": {
+                "name": "PULSE",
+                "tone_effect_map": {
+                    "fast": "COMET",
+                    "neutral": "PULSE",
+                    "calm": "BREATHE",
+                    "tired": "THEATER_CHASE",
+                },
+                "emphasis_effect_map": {
+                    "exclamation": "COMET",
+                    "question": "TWINKLE",
+                },
+                "rhythm": {
+                    "enabled": True,
+                    "mode": "clauses",
+                    "effect": "PULSE",
+                    "words_per_beat": 3,
+                    "clauses_per_beat": 1,
+                    "max_beats": 4,
+                    "duration_ms": 150,
+                    "max_pause_marks": 4,
+                    "pause_effect_map": {
+                        ",": "TWINKLE",
+                        ".": "BREATHE",
+                    },
+                },
+                "min_duration_ms": 400,
+                "max_duration_ms": 7000,
+                "chars_per_second": 16,
+                "force": False,
+            },
+        }
+        self.calls = []
+
+    def _post_interactions(self, endpoint: str, payload: dict) -> None:
+        self.calls.append((endpoint, payload))
+
+
+def test_speak_emits_liveliness_start_and_end():
+    svc = _FakeSpeakService()
+    res = svc.speak("Merhaba dunya", tone={"rate": 170})
+    assert res["ok"] is True
+    assert svc.calls[0][0] == "/event"
+    assert svc.calls[0][1]["type"] == "speech.start"
+    assert svc.calls[0][1]["data"]["tone_key"] == "neutral"
+    assert any(c[0] == "/effect" and c[1].get("name") == "PULSE" for c in svc.calls)
+    assert svc.calls[-1][0] == "/event"
+    assert svc.calls[-1][1]["type"] == "speech.end"
+
+
+def test_estimated_effect_duration_is_clamped():
+    svc = _FakeSpeakService()
+    d1 = svc._estimate_effect_duration_ms("x", {"rate": 400})
+    d2 = svc._estimate_effect_duration_ms("x" * 5000, {"rate": 80})
+    assert d1 >= 400
+    assert d2 <= 7000
+
+
+def test_tone_effect_mapping_for_fast_tone():
+    svc = _FakeSpeakService()
+    svc.speak("Hizli cevap", tone={"rate": 210})
+    assert svc.calls[0][1]["data"]["tone_key"] == "fast"
+    assert svc.calls[1][1]["name"] == "COMET"
+
+
+def test_emphasis_effects_are_emitted_for_punctuation():
+    svc = _FakeSpeakService()
+    svc.speak("Gercekten mi?!")
+    effect_names = [c[1].get("name") for c in svc.calls if c[0] == "/effect"]
+    assert "TWINKLE" in effect_names
+    assert "COMET" in effect_names
+
+
+def test_rhythm_beats_emit_multiple_pulse_effects():
+    svc = _FakeSpeakService()
+    svc.speak("Bir iki uc, dort bes alti, yedi sekiz dokuz.")
+    rhythm_effects = [c for c in svc.calls if c[0] == "/effect" and c[1].get("name") == "PULSE" and c[1].get("duration_ms") == 150]
+    assert len(rhythm_effects) >= 2
+
+
+def test_pause_marks_emit_pause_effects():
+    svc = _FakeSpeakService()
+    svc.speak("Merhaba, nasilsin.")
+    effect_names = [c[1].get("name") for c in svc.calls if c[0] == "/effect"]
+    assert "TWINKLE" in effect_names
+    assert "BREATHE" in effect_names

--- a/modules/speak/xSpeakService.py
+++ b/modules/speak/xSpeakService.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 import argparse
 import logging
+import re
 from typing import Optional
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover
+    requests = None  # type: ignore
 
 from modules.speak.config_loader import load_config
 from modules.speak.services.tts import TextToSpeech
@@ -28,6 +34,150 @@ class SpeakService:
         self.cfg = load_config(config_path)
         self.tts = TextToSpeech(self.cfg.get("tts", {}))
         self.player = AudioPlayer(self.cfg.get("audio_out", {}))
+        self._liveliness_cfg = self.cfg.get("liveliness", {}) or {}
+
+    def _post_interactions(self, endpoint: str, payload: dict) -> None:
+        if requests is None:
+            return
+        base = str(self._liveliness_cfg.get("interactions_base_url", "")).strip().rstrip("/")
+        if not base:
+            return
+        try:
+            requests.post(f"{base}{endpoint}", json=payload, timeout=0.5)
+        except Exception:
+            pass
+
+    def _estimate_effect_duration_ms(self, text: str, tone: Optional[dict]) -> int:
+        cfg = (self._liveliness_cfg.get("speech_effect") or {}) if isinstance(self._liveliness_cfg, dict) else {}
+        cps = float(cfg.get("chars_per_second", 16.0))
+        min_ms = int(cfg.get("min_duration_ms", 400))
+        max_ms = int(cfg.get("max_duration_ms", 7000))
+        text_len = max(1, len((text or "").strip()))
+        duration_ms = int((text_len / max(1.0, cps)) * 1000.0)
+        if tone and isinstance(tone, dict):
+            rate = tone.get("rate")
+            if isinstance(rate, (int, float)) and rate > 0:
+                # 170 ~= neutral baseline in this project.
+                duration_ms = int(duration_ms * (170.0 / float(rate)))
+        return max(min_ms, min(max_ms, duration_ms))
+
+    @staticmethod
+    def _resolve_tone_key(tone: Optional[dict]) -> str:
+        if not isinstance(tone, dict):
+            return "neutral"
+        rate = tone.get("rate")
+        volume = tone.get("volume")
+        if isinstance(rate, (int, float)):
+            if rate >= 190:
+                return "fast"
+            if rate <= 145:
+                return "tired"
+        if isinstance(volume, (int, float)) and float(volume) <= 0.7:
+            return "calm"
+        return "neutral"
+
+    def _resolve_effect_name_for_tone(self, tone: Optional[dict]) -> str:
+        cfg = self._liveliness_cfg.get("speech_effect", {}) or {}
+        tone_map = cfg.get("tone_effect_map", {}) if isinstance(cfg.get("tone_effect_map", {}), dict) else {}
+        key = self._resolve_tone_key(tone)
+        return str(tone_map.get(key, cfg.get("name", "PULSE")))
+
+    def _emit_speech_liveliness_start(self, text: str, tone: Optional[dict]) -> None:
+        if not bool(self._liveliness_cfg.get("enabled", False)):
+            return
+        tone_key = self._resolve_tone_key(tone)
+        exclamations = str(text or "").count("!")
+        questions = str(text or "").count("?")
+        self._post_interactions(
+            "/event",
+            {
+                "type": "speech.start",
+                "data": {
+                    "text_len": len(text or ""),
+                    "tone_key": tone_key,
+                    "exclamations": exclamations,
+                    "questions": questions,
+                },
+            },
+        )
+        effect_cfg = self._liveliness_cfg.get("speech_effect", {}) or {}
+        effect_name = self._resolve_effect_name_for_tone(tone)
+        duration_ms = self._estimate_effect_duration_ms(text, tone)
+        force = bool(effect_cfg.get("force", False))
+        self._post_interactions(
+            "/effect",
+            {"name": effect_name, "duration_ms": duration_ms, "force": force},
+        )
+        self._emit_speech_rhythm_beats(text, force=force)
+        emph_map = effect_cfg.get("emphasis_effect_map", {}) if isinstance(effect_cfg.get("emphasis_effect_map", {}), dict) else {}
+        if exclamations > 0:
+            name = str(emph_map.get("exclamation", "COMET"))
+            self._post_interactions("/effect", {"name": name, "duration_ms": 260, "force": force})
+        if questions > 0:
+            name = str(emph_map.get("question", "TWINKLE"))
+            self._post_interactions("/effect", {"name": name, "duration_ms": 240, "force": force})
+
+    def _emit_speech_rhythm_beats(self, text: str, force: bool = False) -> None:
+        effect_cfg = self._liveliness_cfg.get("speech_effect", {}) or {}
+        rhythm = effect_cfg.get("rhythm", {}) if isinstance(effect_cfg.get("rhythm", {}), dict) else {}
+        if not bool(rhythm.get("enabled", False)):
+            return
+        raw_text = str(text or "")
+        words = len([w for w in raw_text.split() if w.strip()])
+        clauses = max(1, len([p for p in re.split(r"[,;:.!?]+", raw_text) if p.strip()]))
+        if words <= 0 and clauses <= 0:
+            return
+
+        mode = str(rhythm.get("mode", "words")).strip().lower()
+        words_per_beat = max(1, int(rhythm.get("words_per_beat", 3)))
+        clauses_per_beat = max(1, int(rhythm.get("clauses_per_beat", 1)))
+        max_beats = max(0, int(rhythm.get("max_beats", 4)))
+        if mode == "clauses":
+            beat_count = min(max_beats, max(0, clauses // clauses_per_beat))
+        else:
+            beat_count = min(max_beats, max(0, words // words_per_beat))
+        if beat_count <= 0:
+            return
+        beat_name = str(rhythm.get("effect", "PULSE"))
+        beat_duration_ms = max(80, int(rhythm.get("duration_ms", 160)))
+        for _ in range(beat_count):
+            self._post_interactions("/effect", {"name": beat_name, "duration_ms": beat_duration_ms, "force": force})
+
+        pause_map = rhythm.get("pause_effect_map", {}) if isinstance(rhythm.get("pause_effect_map", {}), dict) else {}
+        if not pause_map:
+            return
+        max_pause_marks = max(0, int(rhythm.get("max_pause_marks", 4)))
+        if max_pause_marks <= 0:
+            return
+        punctuation_counts = {
+            ",": raw_text.count(","),
+            ";": raw_text.count(";"),
+            ":": raw_text.count(":"),
+            ".": raw_text.count("."),
+        }
+        used = 0
+        for mark, count in punctuation_counts.items():
+            if count <= 0:
+                continue
+            effect_name = str(pause_map.get(mark, "")).strip()
+            if not effect_name:
+                continue
+            emit_count = min(count, max_pause_marks - used)
+            if emit_count <= 0:
+                break
+            for _ in range(emit_count):
+                self._post_interactions(
+                    "/effect",
+                    {"name": effect_name, "duration_ms": max(80, beat_duration_ms - 30), "force": force},
+                )
+            used += emit_count
+            if used >= max_pause_marks:
+                break
+
+    def _emit_speech_liveliness_end(self, duration_sec: float) -> None:
+        if not bool(self._liveliness_cfg.get("enabled", False)):
+            return
+        self._post_interactions("/event", {"type": "speech.end", "data": {"duration_sec": duration_sec}})
 
     def speak(
         self,
@@ -49,8 +199,10 @@ class SpeakService:
             overrides["speaker_wav"] = speaker_wav
         if language:
             overrides["language"] = language
+        self._emit_speech_liveliness_start(text, tone)
         wav = self.tts.synthesize(text, overrides=overrides or None)
         dur = self.player.play_blocking(wav)
+        self._emit_speech_liveliness_end(dur)
         used_engine = overrides.get("engine") or self.cfg.get("tts", {}).get("engine")
         return {"ok": True, "engine": used_engine, "duration_sec": dur, "samplerate": wav.samplerate}
 


### PR DESCRIPTION
﻿## Ozet
Speak modulune ton, vurgu ve durak odakli liveliness senkronu eklendi. Konusma suresince interactions event/effect akisina ritmik ve punctuation temelli efektler eklenir.

## Degisiklik tipi
- [ ] Hata duzeltmesi
- [x] Yeni ozellik
- [ ] Refactor
- [x] Dokumantasyon guncellemesi
- [x] Test guncellemesi

## Etkilenen moduller
- modules/speak

## Dogrulama
- [ ] Lokal calistirma tamamlandi (python run_robot.py veya hedef modul calistirma)
- [x] Ilgili testler geciyor
- [x] Gerekli dokuman/konfig guncellemeleri yapildi

## Arduino Kontrat Kontrolu (uygunsa)
Bu PR Arduino komutu veya payload kontratini etkilemiyor; kapsam disi.
- [ ] modules/arduino_serial/contract.py disinda elle Arduino payload yazilmadi
- [ ] Kritik komutlar gerektiginde /arduino/request kullaniyor
- [ ] Yeni komut ailesi builder + validator + test iceriyor

## Risk ve geri alma
Risk: Efekt yogunlugu bazi metinlerde fazla gorunebilir; rhythm parametreleri tune gerektirebilir.
Geri alma: Bu PR commiti revert edilerek onceki sade speak akisina donulebilir.

## Ilgili issue
Closes #N/A
