### PR TITLE
feat(neopixel): segment controls and persistent preset management

### DIFF
--- a/modules/neopixel/README.md
+++ b/modules/neopixel/README.md
@@ -124,3 +124,23 @@ runner.animate("ALTERNATING", emotions=["anger", "gratitude"], iterations=10)
 
 ## Gateway ile Kullanım
 Gateway çalışırken NeoPixel API uçları tek portta `/neopixel/*` altında sunulur. `interactions` modülü de gateway’de açıksa, kurallar NeoPixel efektlerini otomatik tetikler; modülü ayrı bir servis olarak çalıştırmaya gerek yoktur.
+
+## Segment Desteği (Göz/Gövde Ayrımı)
+NeoPixel API artık segment tanımlarını destekler:
+
+- `GET /neopixel/segments` -> tanımlı segment listesi
+- `POST /neopixel/fill?r_=0&g=0&b=255&segment=jewel` -> sadece segmente renk uygular
+- `POST /neopixel/segment/clear?name=stick` -> sadece segmenti temizler
+- `POST /neopixel/animate` body içinde `segment` alanı verilebilir
+
+## Preset Kütüphanesi
+
+- `GET /neopixel/presets` -> hazır preset isimleri
+- `POST /neopixel/preset/apply?name=owner_welcome` -> segment preset uygular
+- `GET /neopixel/preset/get?name=owner_welcome` -> preset içeriği
+- `POST /neopixel/preset/set` -> runtime preset ekle/güncelle
+- `DELETE /neopixel/preset/delete?name=owner_welcome` -> runtime preset sil
+
+Presetler `config/config.yml` içindeki `presets` bloğundan yüklenir.
+
+`config/config.yml` içinde `hardware.segments` tanımı ile eşlenir.

--- a/modules/neopixel/api/router.py
+++ b/modules/neopixel/api/router.py
@@ -32,6 +32,12 @@ class AnimateRequest(BaseModel):
     b: Optional[int] = Field(None, ge=0, le=255, description="Blue channel (0-255)")
     emotions: Optional[List[str]] = Field(None, description="Optional list of emotion names to pick colors from")
     iterations: Optional[int] = Field(None, description="How many iterations/repeats")
+    segment: Optional[str] = Field(None, description="Optional segment name (e.g. jewel, stick)")
+
+
+class PresetUpsertRequest(BaseModel):
+    name: str = Field(..., description="Preset name")
+    spec: dict = Field(..., description="Preset segment mapping")
 
 
 class EmotionsResponse(BaseModel):
@@ -118,14 +124,68 @@ def get_router(runner: NeoRunner) -> APIRouter:
     def healthz():
         return {"ok": True, "num_leds": runner.driver.num_leds}
 
+    @r.get("/segments")
+    def segments():
+        return {"ok": True, "segments": runner.list_segments()}
+
+    @r.get("/presets")
+    def presets():
+        return {"ok": True, "presets": runner.list_presets(), "version": runner.preset_version()}
+
+    @r.post("/preset/apply")
+    def apply_preset(name: str = Query(..., description="preset name")):
+        ok = runner.apply_preset(name)
+        if not ok:
+            return {"ok": False, "error": "unknown preset", "name": name}
+        return {"ok": True, "name": name}
+
+    @r.get("/preset/get")
+    def get_preset(name: str = Query(..., description="preset name")):
+        data = runner.get_preset(name)
+        if data is None:
+            return {"ok": False, "error": "unknown preset", "name": name}
+        return {"ok": True, "name": name, "spec": data, "version": runner.preset_version()}
+
+    @r.post("/preset/set")
+    def set_preset(
+        body: PresetUpsertRequest = Body(...),
+        persist: bool = Query(True, description="Persist to config file"),
+    ):
+        ok = runner.set_preset(body.name, body.spec, persist=persist)
+        if not ok:
+            return {"ok": False, "error": "invalid preset payload"}
+        return {"ok": True, "name": body.name, "persisted": bool(persist), "version": runner.preset_version()}
+
+    @r.delete("/preset/delete")
+    def delete_preset(
+        name: str = Query(..., description="preset name"),
+        persist: bool = Query(True, description="Persist to config file"),
+    ):
+        ok = runner.delete_preset(name, persist=persist)
+        if not ok:
+            return {"ok": False, "error": "unknown preset", "name": name}
+        return {"ok": True, "name": name, "persisted": bool(persist), "version": runner.preset_version()}
+
     @r.post("/clear")
     def clear():
         runner.clear()
         return {"ok": True}
 
     @r.post("/fill")
-    def fill(r_: int = 0, g: int = 0, b: int = 0):
-        runner.fill(r_, g, b)
+    def fill(r_: int = 0, g: int = 0, b: int = 0, segment: Optional[str] = None):
+        if segment:
+            ok = runner.fill_segment(segment, r_, g, b)
+            if not ok:
+                return {"ok": False, "error": "unknown segment", "segment": segment}
+        else:
+            runner.fill(r_, g, b)
+        return {"ok": True}
+
+    @r.post("/segment/clear")
+    def clear_segment(name: str = Query(..., description="segment name")):
+        ok = runner.clear_segment(name)
+        if not ok:
+            return {"ok": False, "error": "unknown segment", "segment": name}
         return {"ok": True}
 
     @r.post("/rainbow")
@@ -210,7 +270,14 @@ def get_router(runner: NeoRunner) -> APIRouter:
     @r.post("/animate")
     def animate(body: AnimateRequest = Body(...)):
         color = _parse_color_fields(body)
-        runner.animate(body.name, emotions=body.emotions, iterations=body.iterations, color=color)
-        return {"ok": True, "name": body.name, "emotions": body.emotions, "color": color, "iterations": body.iterations}
+        runner.animate(body.name, emotions=body.emotions, iterations=body.iterations, color=color, segment=body.segment)
+        return {
+            "ok": True,
+            "name": body.name,
+            "emotions": body.emotions,
+            "color": color,
+            "iterations": body.iterations,
+            "segment": body.segment,
+        }
 
     return r

--- a/modules/neopixel/config/config.yml
+++ b/modules/neopixel/config/config.yml
@@ -9,6 +9,9 @@ hardware:
   backend: pi
   device: "/dev/spidev0.0"
   num_leds: 30
+  segments:
+    - { name: jewel, start: 0, count: 7 }
+    - { name: stick, start: 7, count: 23 }
   speed_khz: 800
   ws2812_spi_khz: 2400
   order: "GRB"  # GRB|RGB|BRG
@@ -30,3 +33,17 @@ defaults:
     b: 0
     wait: 0.05
     cycles: 10
+
+presets:
+  owner_welcome:
+    jewel: { effect: "PULSE", color: "#00AAFF" }
+    stick: { color: "#104070" }
+  calm_idle:
+    jewel: { color: "#2A6A8A" }
+    stick: { color: "#102030" }
+  curious_scan:
+    jewel: { effect: "TWINKLE", color: "#30E3CA" }
+    stick: { color: "#103838" }
+
+presets_meta:
+  version: 1

--- a/modules/neopixel/services/runner.py
+++ b/modules/neopixel/services/runner.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 import time
+from pathlib import Path
+from typing import Any
+
+import yaml
 
 try:
     from .driver import NeoDriver, NeoDriverConfig
@@ -33,10 +37,102 @@ except Exception:
 
 
 class NeoRunner:
-    def __init__(self, cfg: NeoDriverConfig):
+    def __init__(
+        self,
+        cfg: NeoDriverConfig,
+        segments: list[dict[str, Any]] | None = None,
+        presets: dict[str, Any] | None = None,
+        preset_store_path: str | None = None,
+        preset_version: int = 1,
+    ):
         self.driver = NeoDriver(cfg)
         # Emotions loader is optional; imported lazily to avoid cost
         self._emotion_store = None
+        self._segments: dict[str, tuple[int, int]] = {}
+        self._presets: dict[str, Any] = presets if isinstance(presets, dict) else {}
+        self._preset_store_path = Path(preset_store_path).resolve() if preset_store_path else None
+        self._preset_version = max(1, int(preset_version or 1))
+        self._init_segments(segments or [])
+
+    def _init_segments(self, segments: list[dict[str, Any]]) -> None:
+        for item in segments:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name", "")).strip().lower()
+            if not name:
+                continue
+            start = int(item.get("start", 0))
+            count = int(item.get("count", 0))
+            if count <= 0:
+                continue
+            end = start + count
+            start = max(0, min(self.driver.num_leds, start))
+            end = max(start, min(self.driver.num_leds, end))
+            if end > start:
+                self._segments[name] = (start, end)
+
+    def list_segments(self) -> list[dict[str, int | str]]:
+        out = []
+        for name, (start, end) in sorted(self._segments.items()):
+            out.append({"name": name, "start": start, "count": end - start})
+        return out
+
+    def list_presets(self) -> list[str]:
+        return sorted([str(k) for k in self._presets.keys()])
+
+    def preset_version(self) -> int:
+        return int(self._preset_version)
+
+    def get_preset(self, name: str) -> dict[str, Any] | None:
+        raw = self._presets.get(str(name))
+        if isinstance(raw, dict):
+            return dict(raw)
+        return None
+
+    def set_preset(self, name: str, spec: dict[str, Any], persist: bool = True) -> bool:
+        key = str(name or "").strip()
+        if not key or not isinstance(spec, dict):
+            return False
+        self._presets[key] = dict(spec)
+        if persist:
+            self._persist_presets()
+        return True
+
+    def delete_preset(self, name: str, persist: bool = True) -> bool:
+        key = str(name or "").strip()
+        if not key or key not in self._presets:
+            return False
+        del self._presets[key]
+        if persist:
+            self._persist_presets()
+        return True
+
+    def _persist_presets(self) -> bool:
+        if self._preset_store_path is None:
+            return False
+        try:
+            data: dict[str, Any] = {}
+            if self._preset_store_path.exists():
+                with open(self._preset_store_path, "r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f) or {}
+            if not isinstance(data, dict):
+                data = {}
+            self._preset_version += 1
+            meta = data.get("presets_meta") if isinstance(data.get("presets_meta"), dict) else {}
+            meta["version"] = self._preset_version
+            data["presets_meta"] = meta
+            data["presets"] = dict(self._presets)
+            self._preset_store_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._preset_store_path, "w", encoding="utf-8") as f:
+                yaml.safe_dump(data, f, sort_keys=False, allow_unicode=False)
+            return True
+        except Exception:
+            return False
+
+    def _segment_bounds(self, name: str | None) -> tuple[int, int] | None:
+        if not name:
+            return None
+        return self._segments.get(str(name).strip().lower())
 
     # Exposed operations
     def clear(self) -> None:
@@ -44,6 +140,52 @@ class NeoRunner:
 
     def fill(self, r: int, g: int, b: int) -> None:
         self.driver.fill(r, g, b)
+
+    def fill_segment(self, name: str, r: int, g: int, b: int) -> bool:
+        bounds = self._segment_bounds(name)
+        if bounds is None:
+            return False
+        start, end = bounds
+        for i in range(start, end):
+            self.driver.set(i, r, g, b)
+        self.driver.show()
+        return True
+
+    def clear_segment(self, name: str) -> bool:
+        return self.fill_segment(name, 0, 0, 0)
+
+    @staticmethod
+    def _parse_color(raw: Any) -> tuple[int, int, int] | None:
+        if isinstance(raw, (list, tuple)) and len(raw) == 3:
+            try:
+                return (int(raw[0]) & 255, int(raw[1]) & 255, int(raw[2]) & 255)
+            except Exception:
+                return None
+        if isinstance(raw, str):
+            s = raw.strip()
+            if s.startswith("#") and len(s) >= 7:
+                try:
+                    v = int(s[1:7], 16)
+                    return ((v >> 16) & 255, (v >> 8) & 255, v & 255)
+                except Exception:
+                    return None
+        return None
+
+    def apply_preset(self, name: str) -> bool:
+        preset = self._presets.get(str(name))
+        if not isinstance(preset, dict):
+            return False
+        for seg_name, spec in preset.items():
+            if not isinstance(spec, dict):
+                continue
+            color = self._parse_color(spec.get("color"))
+            effect = spec.get("effect")
+            if isinstance(effect, str) and effect:
+                self.animate(effect, color=color, segment=str(seg_name))
+                continue
+            if color is not None:
+                self.fill_segment(str(seg_name), color[0], color[1], color[2])
+        return True
 
     def rainbow(self, wait: float = 0.02, cycles: int = 3) -> None:
         n = self.driver.num_leds
@@ -102,10 +244,18 @@ class NeoRunner:
         emotions: list[str] | None = None,
         iterations: int | None = None,
         color: tuple[int, int, int] | None = None,
+        segment: str | None = None,
     ) -> None:
         name_lower = name.lower().strip()
         cols = self._colors_from_emotions(emotions)
         c1 = color if color is not None else (cols[0] if cols else None)
+
+        # Segment target currently supports deterministic color output.
+        if segment:
+            if c1 is None:
+                c1 = (255, 255, 255)
+            if self.fill_segment(segment, *c1):
+                return
 
         # Try to run animation on the hardware (Pi driver) for any name.
         r, g, b = c1 if c1 else (255, 255, 255)

--- a/modules/neopixel/tests/test_segments.py
+++ b/modules/neopixel/tests/test_segments.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+from pathlib import Path
+
+import yaml
+
+from modules.neopixel.services.driver import NeoDriverConfig
+from modules.neopixel.services.runner import NeoRunner
+
+
+class _FakeDriver:
+    def __init__(self, n: int):
+        self.num_leds = n
+        self.buf = [(0, 0, 0)] * n
+        self.shows = 0
+
+    def clear(self):
+        self.buf = [(0, 0, 0)] * self.num_leds
+
+    def set(self, idx: int, r: int, g: int, b: int):
+        self.buf[idx] = (r, g, b)
+
+    def show(self):
+        self.shows += 1
+
+    def fill(self, r: int, g: int, b: int):
+        self.buf = [(r, g, b)] * self.num_leds
+
+    def animate(self, name: str, r: int = 255, g: int = 255, b: int = 255, iterations: int = 0, speed_ms: int = 50):
+        return False
+
+
+def test_fill_segment_applies_only_target_range():
+    runner = NeoRunner(
+        NeoDriverConfig(num_leds=10),
+        segments=[{"name": "jewel", "start": 0, "count": 3}, {"name": "stick", "start": 3, "count": 7}],
+    )
+    runner.driver = _FakeDriver(10)
+
+    ok = runner.fill_segment("jewel", 9, 8, 7)
+    assert ok is True
+    assert runner.driver.buf[:3] == [(9, 8, 7), (9, 8, 7), (9, 8, 7)]
+    assert runner.driver.buf[3:] == [(0, 0, 0)] * 7
+
+
+def test_animate_segment_falls_back_to_segment_fill():
+    runner = NeoRunner(NeoDriverConfig(num_leds=6), segments=[{"name": "jewel", "start": 0, "count": 2}])
+    runner.driver = _FakeDriver(6)
+    runner.animate("PULSE", color=(10, 20, 30), segment="jewel")
+    assert runner.driver.buf[0] == (10, 20, 30)
+    assert runner.driver.buf[1] == (10, 20, 30)
+    assert runner.driver.buf[2:] == [(0, 0, 0)] * 4
+
+
+def test_apply_preset_sets_segment_colors():
+    runner = NeoRunner(
+        NeoDriverConfig(num_leds=8),
+        segments=[{"name": "jewel", "start": 0, "count": 2}, {"name": "stick", "start": 2, "count": 6}],
+        presets={"calm": {"jewel": {"color": [1, 2, 3]}, "stick": {"color": "#040506"}}},
+    )
+    runner.driver = _FakeDriver(8)
+    ok = runner.apply_preset("calm")
+    assert ok is True
+    assert runner.driver.buf[0] == (1, 2, 3)
+    assert runner.driver.buf[1] == (1, 2, 3)
+    assert runner.driver.buf[2] == (4, 5, 6)
+
+
+def test_apply_unknown_preset_returns_false():
+    runner = NeoRunner(NeoDriverConfig(num_leds=4), segments=[], presets={})
+    assert runner.apply_preset("missing") is False
+
+
+def test_runtime_preset_crud():
+    runner = NeoRunner(NeoDriverConfig(num_leds=4), segments=[], presets={})
+    v0 = runner.preset_version()
+    assert runner.set_preset("temp", {"jewel": {"color": [1, 2, 3]}}) is True
+    assert runner.preset_version() == v0
+    data = runner.get_preset("temp")
+    assert isinstance(data, dict)
+    assert "jewel" in data
+    assert runner.delete_preset("temp") is True
+    assert runner.get_preset("temp") is None
+
+
+def test_preset_persistence_writes_yaml_and_increments_version(tmp_path: Path):
+    cfg_path = tmp_path / "neo.yml"
+    cfg_path.write_text(
+        "server:\n"
+        "  host: 0.0.0.0\n"
+        "presets_meta:\n"
+        "  version: 4\n"
+        "presets: {}\n",
+        encoding="utf-8",
+    )
+    runner = NeoRunner(
+        NeoDriverConfig(num_leds=4),
+        segments=[],
+        presets={},
+        preset_store_path=str(cfg_path),
+        preset_version=4,
+    )
+
+    assert runner.set_preset("demo", {"jewel": {"color": [7, 8, 9]}}, persist=True) is True
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert saved["presets"]["demo"]["jewel"]["color"] == [7, 8, 9]
+    assert saved["presets_meta"]["version"] == 5
+    assert runner.preset_version() == 5

--- a/modules/neopixel/xNeopixelService.py
+++ b/modules/neopixel/xNeopixelService.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import os
+from pathlib import Path
 from fastapi import FastAPI
 
 try:
@@ -20,6 +22,10 @@ except Exception:
 
 
 def create_app(config_path: str | None = None) -> FastAPI:
+    default_cfg = Path(__file__).parent / "config" / "config.yml"
+    resolved_cfg_path = Path(config_path) if config_path else Path(os.getenv("NEO_CONFIG", default_cfg))
+    if not resolved_cfg_path.exists():
+        resolved_cfg_path = default_cfg
     cfg = load_config(config_path)
 
     hw = cfg.get("hardware", {})
@@ -32,7 +38,14 @@ def create_app(config_path: str | None = None) -> FastAPI:
         order=str(hw.get("order", "GRB")),
     )
 
-    runner = NeoRunner(drv_cfg)
+    preset_meta = cfg.get("presets_meta", {}) if isinstance(cfg.get("presets_meta", {}), dict) else {}
+    runner = NeoRunner(
+        drv_cfg,
+        segments=hw.get("segments", []),
+        presets=cfg.get("presets", {}),
+        preset_store_path=str(resolved_cfg_path),
+        preset_version=int(preset_meta.get("version", 1)),
+    )
 
     app = FastAPI()
     app.include_router(get_router(runner))


### PR DESCRIPTION
﻿## Ozet
Neopixel modulune segment bazli kontrol ve persistent preset yonetimi eklendi. API katmani preset CRUD ve uygulama endpointleri ile genisletildi, preset metadata version takibi eklendi.

## Degisiklik tipi
- [ ] Hata duzeltmesi
- [x] Yeni ozellik
- [ ] Refactor
- [x] Dokumantasyon guncellemesi
- [x] Test guncellemesi

## Etkilenen moduller
- modules/neopixel

## Dogrulama
- [ ] Lokal calistirma tamamlandi (python run_robot.py veya hedef modul calistirma)
- [x] Ilgili testler geciyor
- [x] Gerekli dokuman/konfig guncellemeleri yapildi

## Arduino Kontrat Kontrolu (uygunsa)
Bu PR Arduino komutu veya payload kontratini etkilemiyor; kapsam disi.
- [ ] modules/arduino_serial/contract.py disinda elle Arduino payload yazilmadi
- [ ] Kritik komutlar gerektiginde /arduino/request kullaniyor
- [ ] Yeni komut ailesi builder + validator + test iceriyor

## Risk ve geri alma
Risk: Preset persistence yazimi hatali payloadlarda beklenmeyen konfig uretimi yapabilir.
Geri alma: Bu PR commiti revert edilerek eski endpoint setine ve volatile preset davranisina donulebilir.

## Ilgili issue
Closes #N/A
