### PR TITLE
fix: wakeword/ollama/vlm_bridge runtime resilience and LLM routing

### DIFF
--- a/modules/gateway/xGatewayService.py
+++ b/modules/gateway/xGatewayService.py
@@ -68,17 +68,17 @@ def create_app(config_path: str | None = None) -> FastAPI:
                     if hasattr(svc, "stop") and callable(getattr(svc, "stop")):
                         try:
                             svc.stop()
-                        except Exception:
+                        except BaseException:
                             pass
                     elif hasattr(svc, "shutdown") and callable(getattr(svc, "shutdown")):
                         try:
                             svc.shutdown()
-                        except Exception:
+                        except BaseException:
                             pass
                     elif hasattr(svc, "close") and callable(getattr(svc, "close")):
                         try:
                             svc.close()
-                        except Exception:
+                        except BaseException:
                             pass
                 except Exception:
                     pass

--- a/modules/ollama/api/router.py
+++ b/modules/ollama/api/router.py
@@ -2,7 +2,7 @@
 import logging
 import os
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 from typing import Optional, List, Dict, Any
 import requests
 
@@ -58,7 +58,12 @@ def get_router(cfg: dict) -> APIRouter:
 
     active_persona = str(cfg.get("persona", {}).get("default", "sentry"))
     persona_text = _load_persona_text(cfg, active_persona)
-    chat = OllamaChatService(client, persona_name=active_persona, max_history=6)
+    chat = OllamaChatService(
+        client,
+        persona_name=active_persona,
+        max_history=6,
+        use_persona_as_model=(provider_name == "ollama"),
+    )
     # Preload persona texts and optional urls placeholders
     _persona_cache: Dict[str, str] = {}
     base_persona_dir = str(cfg.get("persona", {}).get("dir", "modules/ollama/config/personalities"))
@@ -119,25 +124,34 @@ def get_router(cfg: dict) -> APIRouter:
         except Exception as exc:  # pragma: no cover - ağ hatası
             logger.warning("Failed to dispatch persona actions: %s", exc)
 
-    @r.get("/chat")
-    def chat_get(
-        query: str = Query(...),
-        apply_actions: Optional[bool] = None,
-        structured: bool = False,
-        source_lang: Optional[str] = None,
-        response_lang: Optional[str] = None,
-    ):
+    def _chat_response(
+        query: str,
+        apply_actions: Optional[bool],
+        source_lang: Optional[str],
+        response_lang: Optional[str],
+    ) -> Dict[str, Any]:
         source = translator.normalize_lang(source_lang, fallback=translator.cfg.default_source_lang)
         if source == "auto":
             source = translator.detect_language(query)
         target = translator.normalize_lang(response_lang or source, fallback=translator.cfg.default_source_lang)
         query_en = translator.to_bridge(query, source)
-        result = chat.chat(query_en)
+
+        try:
+            result = chat.chat(query_en)
+        except requests.HTTPError as exc:
+            logger.warning("LLM upstream request failed: %s", exc)
+            raise HTTPException(status_code=502, detail="LLM upstream request failed") from exc
+        except Exception as exc:
+            logger.exception("LLM chat failed: %s", exc)
+            raise HTTPException(status_code=500, detail="LLM chat failed") from exc
+
         answer_en = str(result.get("text", ""))
         localized_answer = translator.from_bridge(answer_en, target)
         result["text"] = localized_answer
+
         flag = default_apply if apply_actions is None else apply_actions
         _maybe_dispatch_actions(result, flag)
+
         translation_meta = {
             "enabled": bool(translator.cfg.enabled),
             "request_lang": source,
@@ -149,6 +163,16 @@ def get_router(cfg: dict) -> APIRouter:
         }
         return _format_chat_payload(result, translation=translation_meta)
 
+    @r.get("/chat")
+    def chat_get(
+        query: str = Query(...),
+        apply_actions: Optional[bool] = None,
+        structured: bool = False,
+        source_lang: Optional[str] = None,
+        response_lang: Optional[str] = None,
+    ):
+        return _chat_response(query, apply_actions, source_lang, response_lang)
+
     @r.post("/chat")
     def chat_post(
         query: str,
@@ -157,27 +181,7 @@ def get_router(cfg: dict) -> APIRouter:
         source_lang: Optional[str] = None,
         response_lang: Optional[str] = None,
     ):
-        source = translator.normalize_lang(source_lang, fallback=translator.cfg.default_source_lang)
-        if source == "auto":
-            source = translator.detect_language(query)
-        target = translator.normalize_lang(response_lang or source, fallback=translator.cfg.default_source_lang)
-        query_en = translator.to_bridge(query, source)
-        result = chat.chat(query_en)
-        answer_en = str(result.get("text", ""))
-        localized_answer = translator.from_bridge(answer_en, target)
-        result["text"] = localized_answer
-        flag = default_apply if apply_actions is None else apply_actions
-        _maybe_dispatch_actions(result, flag)
-        translation_meta = {
-            "enabled": bool(translator.cfg.enabled),
-            "request_lang": source,
-            "bridge_lang": translator.BRIDGE_LANG,
-            "response_lang": target,
-            "query_bridge": query_en,
-            "answer_bridge": answer_en,
-            "auto_detected": bool(source_lang and str(source_lang).strip().lower() == "auto"),
-        }
-        return _format_chat_payload(result, translation=translation_meta)
+        return _chat_response(query, apply_actions, source_lang, response_lang)
 
     @r.post("/translate")
     def translate(text: str, source_lang: str = "auto", target_lang: str = "en"):
@@ -257,15 +261,27 @@ def get_router(cfg: dict) -> APIRouter:
             base_model = str(cfg.get("ollama", {}).get("model", "qwen3.5:2b"))
             modelfile = f'FROM {base_model}\nSYSTEM """\n{raw_content}\n"""'
 
-        # Create/Update the model in Ollama
-        success = client.create_model(name, modelfile)
-        if not success:
-            logger.error(f"Failed to create model for persona {name}")
+        success = False
+        if provider_name == "ollama":
+            # Create/Update persona model only for Ollama provider.
+            success = client.create_model(name, modelfile)
+            if not success:
+                logger.error(f"Failed to create model for persona {name}")
             
         persona_text = raw_content
         _persona_cache[name] = persona_text
-        chat = OllamaChatService(client, persona_name=active_persona, max_history=6)
-        return {"ok": True, "active": name, "model_created": success}
+        chat = OllamaChatService(
+            client,
+            persona_name=active_persona,
+            max_history=6,
+            use_persona_as_model=(provider_name == "ollama"),
+        )
+        return {
+            "ok": True,
+            "active": name,
+            "provider": provider_name,
+            "model_created": success if provider_name == "ollama" else None,
+        }
 
     @r.post("/persona/create_from_url")
     def create_persona_from_url(name: str, url: str):

--- a/modules/ollama/services/chat.py
+++ b/modules/ollama/services/chat.py
@@ -8,10 +8,17 @@ logger = logging.getLogger("ollama.chat")
 
 
 class OllamaChatService:
-    def __init__(self, client: LLMClientProtocol, persona_name: str = "sentry", max_history: int = 6) -> None:
+    def __init__(
+        self,
+        client: LLMClientProtocol,
+        persona_name: str = "sentry",
+        max_history: int = 6,
+        use_persona_as_model: bool = True,
+    ) -> None:
         self.client = client
         self.persona_name = persona_name
         self.memory = ChatMemory(max_turns=max_history)
+        self.use_persona_as_model = bool(use_persona_as_model)
 
     def chat(
         self,
@@ -29,8 +36,8 @@ class OllamaChatService:
         messages.extend(self.memory.as_list())
         messages.append({"role": "user", "content": query})
         
-        # We use the persona name as the model name
-        res = self.client.chat(messages, format=response_format, model=self.persona_name)
+        model_name = self.persona_name if self.use_persona_as_model else None
+        res = self.client.chat(messages, format=response_format, model=model_name)
         raw_text = str(res.get("message", {}).get("content", ""))
         
         # Native unstructured conversation

--- a/modules/ollama/services/clients.py
+++ b/modules/ollama/services/clients.py
@@ -13,6 +13,27 @@ except Exception:  # pragma: no cover
 
 logger = logging.getLogger("ollama.clients")
 
+_GOOGLE_API_KEY_PLACEHOLDERS = {
+    "your-google-api-key",
+    "your_google_api_key",
+    "your-api-key",
+    "changeme",
+    "replace_me",
+    "replace-with-your-key",
+}
+
+
+def _sanitize_google_api_key(raw_value: Any) -> str:
+    value = str(raw_value or "").strip()
+    if not value:
+        return ""
+    lowered = value.lower()
+    if lowered in _GOOGLE_API_KEY_PLACEHOLDERS:
+        return ""
+    if "your-google-api-key" in lowered:
+        return ""
+    return value
+
 
 class OllamaClient:
     def __init__(self, base_url: str, model: str, request_timeout: float = 60.0) -> None:
@@ -205,7 +226,14 @@ class GoogleAIStudioClient:
         options: Optional[Dict[str, Any]] = None,
         model: Optional[str] = None,
     ) -> Dict[str, Any]:
-        selected_model = model or self.model
+        selected_model = str(model or self.model).strip() or self.model
+        # Guard against accidental persona-name override (e.g. "sentry").
+        if model and not selected_model.lower().startswith("gemini"):
+            logger.warning(
+                "Ignoring non-Gemini model override for Google provider: %s",
+                selected_model,
+            )
+            selected_model = self.model
         system_instruction, contents = self._to_gemini_parts(messages)
 
         if not contents:
@@ -253,7 +281,9 @@ def create_llm_client(cfg: Dict[str, Any]) -> Tuple[LLMClientProtocol, str]:
 
     if provider in {"google", "google_ai_studio", "gemini"}:
         gcfg = cfg.get("google_ai_studio", {}) or {}
-        api_key = str(gcfg.get("api_key", "")).strip() or str(os.environ.get("GOOGLE_API_KEY", "")).strip()
+        api_key = _sanitize_google_api_key(gcfg.get("api_key", ""))
+        if not api_key:
+            api_key = _sanitize_google_api_key(os.environ.get("GOOGLE_API_KEY", ""))
         model = str(gcfg.get("model", "gemini-1.5-flash")).strip() or "gemini-1.5-flash"
         base_url = str(gcfg.get("base_url", "https://generativelanguage.googleapis.com")).strip()
         timeout = float(gcfg.get("request_timeout", 60.0))

--- a/modules/ollama/tests/test_chat_service_model_selection.py
+++ b/modules/ollama/tests/test_chat_service_model_selection.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from modules.ollama.services.chat import OllamaChatService
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.models = []
+
+    def chat(self, messages, format=None, *, options=None, model=None):
+        self.models.append(model)
+        return {"message": {"content": "ok"}}
+
+
+def test_chat_uses_persona_model_by_default():
+    fake = _FakeClient()
+    svc = OllamaChatService(fake, persona_name="sentry")
+
+    result = svc.chat("hello")
+
+    assert result["text"] == "ok"
+    assert fake.models[-1] == "sentry"
+
+
+def test_chat_can_skip_persona_model_override():
+    fake = _FakeClient()
+    svc = OllamaChatService(fake, persona_name="sentry", use_persona_as_model=False)
+
+    result = svc.chat("hello")
+
+    assert result["text"] == "ok"
+    assert fake.models[-1] is None

--- a/modules/ollama/tests/test_clients_google_key_validation.py
+++ b/modules/ollama/tests/test_clients_google_key_validation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from modules.ollama.services.clients import create_llm_client
+
+
+def _google_cfg(api_key: str):
+    return {
+        "llm": {"provider": "google_ai_studio"},
+        "google_ai_studio": {
+            "api_key": api_key,
+            "model": "gemini-1.5-flash",
+            "base_url": "https://generativelanguage.googleapis.com",
+            "request_timeout": 30,
+        },
+    }
+
+
+def test_placeholder_google_api_key_is_rejected():
+    with pytest.raises(RuntimeError):
+        create_llm_client(_google_cfg("your-google-api-key"))
+
+
+def test_valid_google_api_key_is_accepted():
+    client, provider = create_llm_client(_google_cfg("AIza-test-key"))
+
+    assert provider == "google_ai_studio"
+    assert client.model == "gemini-1.5-flash"

--- a/modules/vlm_bridge/README.md
+++ b/modules/vlm_bridge/README.md
@@ -43,6 +43,11 @@ Kamera akışını işleyen yerel (Pi5) veya uzak (dizüstü / sunucu) görünt�
 ## Blind Mode (Assistive)
 Aktifken semantik sahne özeti (Ollama varsa LLM tabanlı) ve kişilere özel selam gönderir. Uzak modda gelen sonuçlar üzerinden de çalışır.
 
+## VLM LLM Kaynağı
+- Varsayılan uç: `http://localhost:8080/ollama/chat`
+- Böylece VLM Bridge, Ollama modülünde aktif olan provider/model (örn. ollama veya google_ai_studio) üzerinden yanıt alır.
+- Geriye dönük olarak `ollama.endpoint` değeri `.../api/generate` ise eski doğrudan generate akışı da desteklenir.
+
 ## LLM Action Dispatch
 - `config.actions.endpoint`: Genelde `http://<autonomy>/autonomy/apply_actions`. Boşsa özellik kapanır.
 - `config.actions.default_apply`: `true` iken her tespit turu için semantik özet oluşturulur, `[cmd:*]` ve `[[lights …]]` etiketleri otomatik olarak Autonomy’ye iletilir.

--- a/modules/vlm_bridge/config/config.yml
+++ b/modules/vlm_bridge/config/config.yml
@@ -57,8 +57,9 @@ robot:
   host: "localhost"  # Change to Robot IP when running remotely
 
 ollama:
-  endpoint: "http://localhost:11435/api/generate"
-  model: "llama3"
+  endpoint: "http://localhost:8080/ollama/chat"
+  model: "llama3.2:3b"
+  timeout: 5.0
 
 speak:
   endpoint: "http://localhost:8083/speak/say"

--- a/modules/vlm_bridge/config_loader.py
+++ b/modules/vlm_bridge/config_loader.py
@@ -36,8 +36,9 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "accept_results": True,
     },
     "ollama": {
-        "endpoint": "http://localhost:11435/api/generate",
+        "endpoint": "http://localhost:8080/ollama/chat",
         "model": "llama3",
+        "timeout": 5.0,
     },
     "speak": {
         "endpoint": "http://localhost:8083/speak/say",
@@ -48,6 +49,32 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "timeout": 1.5,
     },
 }
+
+
+def _sync_model_from_ollama_module(cfg: Dict[str, Any]) -> None:
+    """Keep VLM bridge LLM model aligned with the currently configured Ollama module model."""
+    try:
+        from modules.ollama.config_loader import load_config as load_ollama_config  # type: ignore
+    except Exception:
+        return
+
+    try:
+        ollama_cfg = load_ollama_config(None)
+    except Exception:
+        return
+
+    if not isinstance(ollama_cfg, dict):
+        return
+
+    model = str((ollama_cfg.get("ollama", {}) or {}).get("model", "")).strip()
+    if not model:
+        return
+
+    section = cfg.get("ollama")
+    if not isinstance(section, dict):
+        cfg["ollama"] = {"model": model}
+        return
+    section["model"] = model
 
 def load_config(base_dir: Optional[str] = None, overrides: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     cfg: Dict[str, Any] = dict(DEFAULT_CONFIG)
@@ -65,4 +92,6 @@ def load_config(base_dir: Optional[str] = None, overrides: Optional[Dict[str, An
             break
     if overrides:
         cfg.update({k: v for k, v in overrides.items() if v is not None})
+
+    _sync_model_from_ollama_module(cfg)
     return cfg

--- a/modules/vlm_bridge/services/cascade_loader.py
+++ b/modules/vlm_bridge/services/cascade_loader.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import tempfile
+from typing import Optional
+
+import cv2
+
+_CASCADE_FILENAME = "haarcascade_frontalface_default.xml"
+
+
+def _is_ascii_path(path: str) -> bool:
+    try:
+        path.encode("ascii")
+        return True
+    except UnicodeEncodeError:
+        return False
+
+
+def _copy_to_ascii_temp(src_path: str, logger: logging.Logger) -> Optional[str]:
+    if not src_path or not os.path.exists(src_path):
+        return None
+
+    try:
+        with open(src_path, "rb") as f:
+            raw = f.read()
+    except Exception as exc:
+        logger.warning("Failed to read cascade source file: %s", exc)
+        return None
+
+    digest = hashlib.sha1(raw).hexdigest()[:12]
+    temp_dir = os.path.join(tempfile.gettempdir(), "sentrybot_cv")
+    os.makedirs(temp_dir, exist_ok=True)
+    dst_path = os.path.join(temp_dir, f"{digest}_{_CASCADE_FILENAME}")
+
+    if not os.path.exists(dst_path):
+        try:
+            with open(dst_path, "wb") as f:
+                f.write(raw)
+        except Exception as exc:
+            logger.warning("Failed to write cascade fallback file: %s", exc)
+            return None
+
+    return dst_path
+
+
+def _load_cascade(path: str):
+    cascade = cv2.CascadeClassifier(path)
+    if cascade is not None and not cascade.empty():
+        return cascade
+    return None
+
+
+def load_frontal_face_cascade(logger: Optional[logging.Logger] = None):
+    """Load frontal face cascade with a Windows non-ASCII path fallback."""
+    log = logger or logging.getLogger("vlm_bridge.cascade")
+    source_path = os.path.join(cv2.data.haarcascades, _CASCADE_FILENAME)
+
+    candidate_paths = []
+    if _is_ascii_path(source_path):
+        candidate_paths.append(source_path)
+    else:
+        fallback_path = _copy_to_ascii_temp(source_path, log)
+        if fallback_path:
+            candidate_paths.append(fallback_path)
+        # Keep original path as last resort.
+        candidate_paths.append(source_path)
+
+    for candidate in candidate_paths:
+        try:
+            cascade = _load_cascade(candidate)
+            if cascade is not None:
+                if candidate != source_path:
+                    log.info("Loaded Haar cascade via ASCII fallback path: %s", candidate)
+                return cascade
+        except Exception as exc:
+            log.debug("Cascade load failed for '%s': %s", candidate, exc)
+
+    log.warning("Could not load Haar cascade from: %s", source_path)
+    return cv2.CascadeClassifier()

--- a/modules/vlm_bridge/services/face_manager.py
+++ b/modules/vlm_bridge/services/face_manager.py
@@ -8,6 +8,11 @@ from typing import Dict, List, Optional, Tuple
 import cv2
 import numpy as np
 
+try:
+    from .cascade_loader import load_frontal_face_cascade
+except Exception:
+    from services.cascade_loader import load_frontal_face_cascade  # type: ignore
+
 logger = logging.getLogger("vlm_bridge.face_manager")
 
 
@@ -37,9 +42,7 @@ class FaceManager:
         self._known_descriptors: Dict[str, np.ndarray] = {}
 
         self._ensure_data_dir()
-        self._cascade = cv2.CascadeClassifier(
-            os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml")
-        )
+        self._cascade = load_frontal_face_cascade(logger)
         self._orb = cv2.ORB_create(nfeatures=700)
         self._flann = cv2.FlannBasedMatcher(
             dict(algorithm=6, table_number=6, key_size=12, multi_probe_level=1),

--- a/modules/vlm_bridge/services/llm_client.py
+++ b/modules/vlm_bridge/services/llm_client.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Optional
+
+try:
+    import httpx  # type: ignore
+except Exception:
+    httpx = None
+
+logger = logging.getLogger("vlm_bridge.llm")
+
+_DEFAULT_CHAT_ENDPOINT = "http://localhost:8080/ollama/chat"
+_DEFAULT_GENERATE_ENDPOINT = "http://localhost:11435/api/generate"
+_CHAT_COOLDOWN_UNTIL: Dict[str, float] = {}
+
+
+def _normalize_endpoint(cfg: Dict[str, Any]) -> str:
+    endpoint = str((cfg or {}).get("endpoint", "")).strip()
+    return endpoint or _DEFAULT_CHAT_ENDPOINT
+
+
+def _is_legacy_generate_endpoint(endpoint: str) -> bool:
+    return endpoint.rstrip("/").endswith("/api/generate")
+
+
+def _has_real_secret(value: Any) -> bool:
+    token = str(value or "").strip()
+    if not token:
+        return False
+    lowered = token.lower()
+    if lowered in {"your-google-api-key", "changeme", "replace_me", "replace-with-your-key"}:
+        return False
+    if "your-google-api-key" in lowered:
+        return False
+    return True
+
+
+def _provider_hint() -> Dict[str, Any]:
+    hint: Dict[str, Any] = {
+        "provider": "",
+        "google_key_ready": False,
+    }
+    try:
+        from modules.ollama.config_loader import load_config as load_ollama_config  # type: ignore
+    except Exception:
+        return hint
+
+    try:
+        cfg = load_ollama_config(None)
+    except Exception:
+        return hint
+
+    if not isinstance(cfg, dict):
+        return hint
+
+    llm_cfg = cfg.get("llm", {}) if isinstance(cfg.get("llm", {}), dict) else {}
+    google_cfg = cfg.get("google_ai_studio", {}) if isinstance(cfg.get("google_ai_studio", {}), dict) else {}
+
+    provider = str(llm_cfg.get("provider", "")).strip().lower()
+    hint["provider"] = provider
+    hint["google_key_ready"] = _has_real_secret(google_cfg.get("api_key"))
+    return hint
+
+
+def _is_in_cooldown(endpoint: str) -> bool:
+    until = float(_CHAT_COOLDOWN_UNTIL.get(endpoint, 0.0))
+    return until > time.time()
+
+
+def _mark_cooldown(endpoint: str, seconds: float) -> None:
+    _CHAT_COOLDOWN_UNTIL[endpoint] = time.time() + max(1.0, float(seconds))
+
+
+def generate_text(
+    prompt: str,
+    ollama_cfg: Dict[str, Any],
+    *,
+    timeout: float = 5.0,
+    response_lang: str = "tr",
+) -> Optional[str]:
+    if httpx is None:
+        return None
+
+    text = str(prompt or "").strip()
+    if not text:
+        return None
+
+    endpoint = _normalize_endpoint(ollama_cfg)
+    cooldown_s = float((ollama_cfg or {}).get("cooldown_on_failure_s", 30.0))
+
+    hint = _provider_hint()
+    provider = str(hint.get("provider", "") or "").strip().lower()
+
+    # Google provider selected but key is missing/placeholder: skip remote call and fall back.
+    if (
+        provider in {"google", "google_ai_studio", "gemini"}
+        and not bool(hint.get("google_key_ready"))
+        and not _is_legacy_generate_endpoint(endpoint)
+    ):
+        return None
+
+    try:
+        with httpx.Client(timeout=float(timeout)) as client:
+            if _is_legacy_generate_endpoint(endpoint):
+                model = str((ollama_cfg or {}).get("model", "llama3")).strip() or "llama3"
+                resp = client.post(
+                    endpoint,
+                    json={"model": model, "prompt": text, "stream": False},
+                )
+                if resp.status_code != 200:
+                    return None
+                data = resp.json()
+                out = str(data.get("response", "")).strip()
+                return out or None
+
+            chat_url = endpoint or _DEFAULT_CHAT_ENDPOINT
+            if _is_in_cooldown(chat_url):
+                return None
+            # Ollama router's chat_post currently reads scalar args as query params.
+            resp = client.post(
+                chat_url,
+                params={
+                    "query": text,
+                    "apply_actions": "false",
+                    "response_lang": response_lang,
+                },
+            )
+            if resp.status_code != 200:
+                _mark_cooldown(chat_url, cooldown_s)
+                return None
+            data = resp.json()
+            out = str(data.get("answer") or data.get("text") or "").strip()
+            _CHAT_COOLDOWN_UNTIL.pop(chat_url, None)
+            return out or None
+    except Exception as exc:
+        if not _is_legacy_generate_endpoint(endpoint):
+            _mark_cooldown(endpoint, cooldown_s)
+        logger.debug("VLM LLM request failed: %s", exc)
+        return None
+
+
+def default_ollama_endpoint() -> str:
+    return _DEFAULT_CHAT_ENDPOINT
+
+
+def default_generate_endpoint() -> str:
+    return _DEFAULT_GENERATE_ENDPOINT

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -18,6 +18,11 @@ except Exception:
         FaceManager = None  # type: ignore
 
 try:
+    from .cascade_loader import load_frontal_face_cascade
+except Exception:
+    from services.cascade_loader import load_frontal_face_cascade  # type: ignore
+
+try:
     from .semantic_describer import SemanticDescriber
 except Exception:
     from services.semantic_describer import SemanticDescriber  # type: ignore
@@ -31,6 +36,11 @@ try:
     from .action_dispatcher import VisionActionDispatcher
 except Exception:
     from services.action_dispatcher import VisionActionDispatcher  # type: ignore
+
+try:
+    from .llm_client import generate_text
+except Exception:
+    from services.llm_client import generate_text  # type: ignore
 
 
 logger = logging.getLogger("vlm_bridge")
@@ -75,9 +85,7 @@ class VisionProcessor:
         self.camera_source = vision_cfg.get("camera_source", 0)
         self.conf_threshold = float(vision_cfg.get("confidence_threshold", 0.5))
 
-        self._face_cascade = cv2.CascadeClassifier(
-            os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml")
-        )
+        self._face_cascade = load_frontal_face_cascade(logger)
 
         self.face_manager = None
         if self.processing_mode == "local" and FaceManager is not None:
@@ -694,22 +702,9 @@ class VisionProcessor:
         return f"Merhaba {name}, seni gordugume sevindim."
 
     def _ollama_followup(self, name: str) -> Optional[str]:
-        try:
-            import httpx  # type: ignore
-        except Exception:
-            return None
-
         rec = self.memory.get_person(name) or {}
         last_sum = (rec.get("last_summary") or {}).get("text")
         prompt = f"{name} ile karsilastin. {('Ozet: ' + last_sum) if last_sum else ''} Turkce kisa ve sicak bir cumle soyle."
-        url = self.config.get("ollama", {}).get("endpoint", "http://localhost:11435/api/generate")
-        model = self.config.get("ollama", {}).get("model", "llama3")
-        try:
-            with httpx.Client(timeout=4.0) as client:
-                resp = client.post(url, json={"model": model, "prompt": prompt, "stream": False})
-            if resp.status_code == 200:
-                data = resp.json()
-                return data.get("response")
-        except Exception:
-            return None
-        return None
+        llm_cfg = self.config.get("ollama", {}) if isinstance(self.config.get("ollama", {}), dict) else {}
+        timeout = float(llm_cfg.get("timeout", 4.0))
+        return generate_text(prompt, llm_cfg, timeout=timeout, response_lang="tr")

--- a/modules/vlm_bridge/services/semantic_describer.py
+++ b/modules/vlm_bridge/services/semantic_describer.py
@@ -13,9 +13,9 @@ from typing import List, Dict, Any, Optional
 logger = logging.getLogger("vlm_bridge.semantic")
 
 try:
-    import httpx  # type: ignore
+    from .llm_client import generate_text
 except Exception:
-    httpx = None  # Fallback
+    from services.llm_client import generate_text  # type: ignore
 
 class SemanticDescriber:
     def __init__(self, config: Dict[str, Any]):
@@ -42,24 +42,14 @@ class SemanticDescriber:
         )
 
     def llm_summarize(self, objects: List[Dict[str, Any]]) -> Optional[str]:
-        if httpx is None:
-            return None
         now = time.time()
         if now - self.last_llm_call < self.llm_interval_s:
             return None
         self.last_llm_call = now
         prompt = self.build_prompt(objects)
-        url = self.config.get("ollama", {}).get("endpoint", "http://localhost:11435/api/generate")
-        model = self.config.get("ollama", {}).get("model", "llama3")
-        try:
-            with httpx.Client(timeout=5.0) as client:
-                resp = client.post(url, json={"model": model, "prompt": prompt, "stream": False})
-            if resp.status_code == 200:
-                data = resp.json()
-                return data.get("response")
-        except Exception as e:
-            logger.debug(f"LLM summarize error: {e}")
-        return None
+        llm_cfg = self.config.get("ollama", {}) if isinstance(self.config.get("ollama", {}), dict) else {}
+        timeout = float(llm_cfg.get("timeout", 5.0))
+        return generate_text(prompt, llm_cfg, timeout=timeout, response_lang="tr")
 
     def fallback_summary(self, objects: List[Dict[str, Any]]) -> str:
         counts = {}

--- a/modules/vlm_bridge/tests/test_llm_client.py
+++ b/modules/vlm_bridge/tests/test_llm_client.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from modules.vlm_bridge.services.llm_client import generate_text
+
+
+class _DummyResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _DummyClient:
+    def __init__(self, recorder: dict, response: _DummyResponse, timeout: float):
+        self.recorder = recorder
+        self.response = response
+        self.timeout = timeout
+
+    def __enter__(self):
+        self.recorder["timeout"] = self.timeout
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json=None, params=None):
+        self.recorder["url"] = url
+        self.recorder["json"] = json
+        self.recorder["params"] = params
+        return self.response
+
+
+def test_generate_text_legacy_generate_endpoint(monkeypatch):
+    recorder = {}
+
+    class _Httpx:
+        @staticmethod
+        def Client(timeout):
+            return _DummyClient(
+                recorder,
+                _DummyResponse(200, {"response": "kisa ozet"}),
+                timeout,
+            )
+
+    monkeypatch.setattr("modules.vlm_bridge.services.llm_client.httpx", _Httpx, raising=False)
+    monkeypatch.setattr(
+        "modules.vlm_bridge.services.llm_client._provider_hint",
+        lambda: {"provider": "ollama", "google_key_ready": True},
+        raising=False,
+    )
+
+    out = generate_text(
+        "sahneyi ozetle",
+        {"endpoint": "http://localhost:11435/api/generate", "model": "llama3.2:3b"},
+        timeout=3.0,
+    )
+
+    assert out == "kisa ozet"
+    assert recorder["url"].endswith("/api/generate")
+    assert recorder["json"]["model"] == "llama3.2:3b"
+    assert recorder["params"] is None
+
+
+def test_generate_text_gateway_chat_endpoint(monkeypatch):
+    recorder = {}
+
+    class _Httpx:
+        @staticmethod
+        def Client(timeout):
+            return _DummyClient(
+                recorder,
+                _DummyResponse(200, {"answer": "merhaba"}),
+                timeout,
+            )
+
+    monkeypatch.setattr("modules.vlm_bridge.services.llm_client.httpx", _Httpx, raising=False)
+    monkeypatch.setattr(
+        "modules.vlm_bridge.services.llm_client._provider_hint",
+        lambda: {"provider": "ollama", "google_key_ready": True},
+        raising=False,
+    )
+    from modules.vlm_bridge.services import llm_client as _llm
+    _llm._CHAT_COOLDOWN_UNTIL.clear()
+
+    out = generate_text(
+        "sahneyi ozetle",
+        {"endpoint": "http://localhost:8080/ollama/chat"},
+        timeout=2.5,
+        response_lang="tr",
+    )
+
+    assert out == "merhaba"
+    assert recorder["url"].endswith("/ollama/chat")
+    assert recorder["json"] is None
+    assert recorder["params"]["apply_actions"] == "false"
+    assert recorder["params"]["response_lang"] == "tr"
+
+
+def test_generate_text_skips_chat_when_google_key_missing(monkeypatch):
+    called = {"post": 0}
+
+    class _Httpx:
+        @staticmethod
+        def Client(timeout):
+            class _C:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def post(self, url, json=None, params=None):
+                    called["post"] += 1
+                    return _DummyResponse(200, {"answer": "olmamalı"})
+
+            return _C()
+
+    monkeypatch.setattr("modules.vlm_bridge.services.llm_client.httpx", _Httpx, raising=False)
+    monkeypatch.setattr(
+        "modules.vlm_bridge.services.llm_client._provider_hint",
+        lambda: {"provider": "google_ai_studio", "google_key_ready": False},
+        raising=False,
+    )
+
+    out = generate_text("deneme", {"endpoint": "http://localhost:8080/ollama/chat"})
+
+    assert out is None
+    assert called["post"] == 0
+
+
+def test_generate_text_chat_uses_cooldown_after_failure(monkeypatch):
+    recorder = {"post_calls": 0}
+
+    class _Httpx:
+        @staticmethod
+        def Client(timeout):
+            class _C:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def post(self, url, json=None, params=None):
+                    recorder["post_calls"] += 1
+                    return _DummyResponse(500, {})
+
+            return _C()
+
+    monkeypatch.setattr("modules.vlm_bridge.services.llm_client.httpx", _Httpx, raising=False)
+    monkeypatch.setattr(
+        "modules.vlm_bridge.services.llm_client._provider_hint",
+        lambda: {"provider": "ollama", "google_key_ready": True},
+        raising=False,
+    )
+    from modules.vlm_bridge.services import llm_client as _llm
+    _llm._CHAT_COOLDOWN_UNTIL.clear()
+
+    cfg = {
+        "endpoint": "http://localhost:8080/ollama/chat",
+        "cooldown_on_failure_s": 60,
+    }
+    first = generate_text("ilk", cfg)
+    second = generate_text("ikinci", cfg)
+
+    assert first is None
+    assert second is None
+    assert recorder["post_calls"] == 1

--- a/modules/wakeword/services/openwakeword_runner.py
+++ b/modules/wakeword/services/openwakeword_runner.py
@@ -101,18 +101,11 @@ class OpenWakewordRunner:
             raise ValueError("openwakeword.model_paths is required")
         self._labels = list(model_paths.keys())
         inference_framework = str(cfg.get("inference_framework", "onnx")).strip().lower() or "onnx"
-        # Instantiate model in a backward/forward-compatible way depending on
-        # the installed openwakeword API. Try several common constructor
-        # signatures and fall back to positional if necessary.
-        import inspect
-
+        # Instantiate model in a backward/forward-compatible way.
+        # Prefer kwargs so inference_framework maps correctly even when
+        # upstream uses a permissive (*args, **kwargs) constructor.
         paths_list = list(model_paths.values())
         model_ctor = OpenWakeWordModel
-        ctor_sig = None
-        try:
-            ctor_sig = inspect.signature(model_ctor)
-        except Exception:
-            ctor_sig = None
 
         def _try_ctor(kwargs=None, args=None):
             kwargs = kwargs or {}
@@ -126,19 +119,13 @@ class OpenWakewordRunner:
         # Preferred: explicit wakeword_models + inference_framework
         tried = []
         last_exc = None
-        candidates = []
-        if ctor_sig is not None:
-            params = set(ctor_sig.parameters.keys())
-            if 'wakeword_models' in params:
-                candidates.append({'kwargs': {'wakeword_models': paths_list, 'inference_framework': inference_framework}})
-            if 'model_paths' in params:
-                candidates.append({'kwargs': {'model_paths': paths_list, 'inference_framework': inference_framework}})
-            if 'models' in params:
-                candidates.append({'kwargs': {'models': paths_list, 'inference_framework': inference_framework}})
-        # Try common alternatives (no kwargs)
-        candidates.append({'args': [paths_list, inference_framework]})
-        candidates.append({'args': [paths_list]})
-        candidates.append({'kwargs': {'wakeword_models': paths_list}})
+        candidates = [
+            {'kwargs': {'wakeword_models': paths_list, 'inference_framework': inference_framework}},
+            {'kwargs': {'model_paths': paths_list, 'inference_framework': inference_framework}},
+            {'kwargs': {'models': paths_list, 'inference_framework': inference_framework}},
+            {'kwargs': {'wakeword_models': paths_list}},
+            {'args': [paths_list]},
+        ]
 
         for cand in candidates:
             try:


### PR DESCRIPTION
## Özet
Bu PR, runtime stabilitesini artıran ve VLM-LLM akışını tek merkezden yöneten düzeltmeleri içerir.
- Wakeword tarafında OpenWakeWord kurulumunda constructor parametre eşleşmesi sağlamlaştırıldı (ONNX init/fallback kaynaklı sorunlar azaltıldı).
- Ollama modülünde provider/model yönlendirmesi güvenli hale getirildi; Google key doğrulaması ve upstream hata yüzeyleme iyileştirildi.
- VLM bridge, varsayılan olarak gateway /ollama/chat üzerinden aktif provider/model ile konuşacak şekilde güncellendi; başarısız çağrılar için cooldown fallback eklendi.
- Windows non-ASCII yol sorunlarına karşı Haar cascade yükleme fallback’i eklendi.
- Gateway kapanışında gürültülü kesinti hataları azaltıldı.

## Değişiklik tipi
- [x] Hata düzeltmesi
- [x] Yeni özellik
- [ ] Refactor
- [x] Dokümantasyon güncellemesi
- [x] Test güncellemesi

## Etkilenen modüller
- modules/wakeword
- modules/ollama
- modules/vlm_bridge
- modules/gateway

## Doğrulama
- [x] Lokal çalıştırma tamamlandı (python run_robot.py veya hedef modül çalıştırma)
- [x] İlgili testler geçiyor
- [x] Gerekli doküman/konfig güncellemeleri yapıldı

Çalıştırılan testler:
- pytest modules/ollama/tests/test_chat_service_model_selection.py modules/ollama/tests/test_clients_google_key_validation.py modules/vlm_bridge/tests/test_llm_client.py -q
- pytest modules/wakeword/tests/test_smoke.py -q

## Arduino Kontrat Kontrolü (uygunsa)
- [x] modules/arduino_serial/contract.py dışında elle Arduino payload yazılmadı
- [x] Kritik komutlar gerektiğinde /arduino/request kullanıyor
- [x] Yeni komut ailesi builder + validator + test içeriyor

Not: Bu PR Arduino komut sözleşmesini değiştirmiyor; ilgili maddeler etkilenmedi/ihlal edilmedi.

## Risk ve geri alma
- Risk: VLM özet üretim yolu artık gateway chat endpoint’ine daha bağımlı; endpoint erişilemezse cooldown nedeniyle geçici olarak LLM özeti atlanır.
- Geri alma: Problemli commit(ler) geri alınarak önceki pi/generate akışına dönülebilir.

## İlgili issue
Closes #N/A