### PR TITLE
web: serve Graph Explorer at Pages root

### DIFF
--- a/.github/workflows/pages-graph-explorer.yml
+++ b/.github/workflows/pages-graph-explorer.yml
@@ -10,32 +10,18 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
+  contents: write
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload static site artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          path: ./tools/graph-explorer
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./tools/graph-explorer

--- a/.github/workflows/pages-graph-explorer.yml
+++ b/.github/workflows/pages-graph-explorer.yml
@@ -1,0 +1,41 @@
+name: Publish Graph Explorer to Pages
+
+on:
+  push:
+    branches:
+      - feat/publish-index-gh-pages
+    paths:
+      - 'tools/graph-explorer/**'
+      - '.github/workflows/pages-graph-explorer.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./tools/graph-explorer
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SentryBOT Graph Explorer Redirect</title>
+  <meta http-equiv="refresh" content="0; url=tools/graph-explorer/index" />
+  <script>
+    // Keep the redirect relative so it works for both project and custom-domain Pages.
+    window.location.replace("tools/graph-explorer/index");
+  </script>
+</head>
+<body>
+  <p>
+    Redirecting to Graph Explorer...
+    <a href="tools/graph-explorer/index">Open manually</a>
+  </p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Pages workflow for Graph Explorer (.github/workflows/pages-graph-explorer.yml)
- switch deployment to gh-pages branch publish mode (compatible with branch-based Pages)
- add root index.html redirect to 	ools/graph-explorer/index for root endpoint routing

## Validation
- workflow run #2 completed successfully on eat/publish-index-gh-pages
- origin/gh-pages:index.html contains Graph Explorer HTML title
- root endpoint now serves Graph Explorer after Pages source/build update

## Notes
- no changes were made directly on dev
- all changes are isolated to this feature branch