### PR TITLE
ci: fix 403 on main gh-pages deploy

### DIFF
--- a/.github/workflows/deploy-tools-to-gh-pages.yml
+++ b/.github/workflows/deploy-tools-to-gh-pages.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
 
 jobs:


### PR DESCRIPTION
Summary: fix main workflow permissions.contents from read to write so peaceiris/actions-gh-pages can push gh-pages. Root cause: GITHUB_TOKEN lacked write scope. Validation: repo workflow default permission set to write and workflow file updated.