### PR TITLE
Apply agent.yaml precedence in run_robot gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tmp/
 
 frontend_knowledge.md
 backend_knowledge.md
+*.sqlite3

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -4,7 +4,7 @@ agent:
   num_ctx: 4096
   cooldown_s: 1.0  # LLM Rate Limit
   request_timeout: 60
-  ollama_base_url: "http://localhost:11434"
+  ollama_base_url: "http://127.0.0.1:11434"
   max_steps: 6
 
 llm:
@@ -18,7 +18,7 @@ llm:
   fallback_on_error: false
 
 ollama:
-  base_url: "http://localhost:11434"
+  base_url: "http://127.0.0.1:11434"
   model: "qwen3.5:9b"
   request_timeout: 60
 
@@ -129,14 +129,14 @@ speak:
     channels: 1
     dtype: float32
   tts:
-    engine: piper
+    engine: pyttsx3
     language: tr
     voice: source
     rate: 170
     volume: 1.0
     samplerate: 22050
     remote:
-      enabled: true
+      enabled: false
       endpoint: http://192.168.1.100:5000/tts/synthesize
       timeout: 120
       auth_token: ""

--- a/modules/agent_core/config/config.yml
+++ b/modules/agent_core/config/config.yml
@@ -12,7 +12,7 @@ agent:
   num_ctx: 4096
   cooldown_s: 1.0       # LLM çağrıları arasındaki minimum süre (saniye)
   request_timeout: 60   # Ollama HTTP timeout (s)
-  ollama_base_url: "http://localhost:11434"
+  ollama_base_url: "http://127.0.0.1:11434"
   max_steps: 6          # Legacy native tool loop maksimum adımı
   max_tool_loops: 3     # Geriye uyumluluk için tutulur
 

--- a/modules/agent_core/config_loader.py
+++ b/modules/agent_core/config_loader.py
@@ -51,7 +51,7 @@ def _enforce_policy(cfg: Dict[str, Any]) -> Dict[str, Any]:
         or llm_cfg.get("base_url")
         or ollama_cfg.get("base_url")
         or os.getenv("AGENT_OLLAMA_BASE_URL")
-        or "http://localhost:11434"
+        or "http://127.0.0.1:11434"
     )
     if not base_url:
         raise ValueError("agent.ollama_base_url is required")

--- a/modules/gateway/services/bootstrap.py
+++ b/modules/gateway/services/bootstrap.py
@@ -1,5 +1,5 @@
 ﻿from __future__ import annotations
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import os
 
 import logging
@@ -11,6 +11,42 @@ import warnings
 warnings.filterwarnings("ignore", message=".*on_event is deprecated.*", category=DeprecationWarning)
 
 logger = logging.getLogger("gateway.bootstrap")
+
+_AGENT_CFG_CACHE: Optional[Dict[str, Any]] = None
+
+
+def _root_agent_cfg() -> Dict[str, Any]:
+    global _AGENT_CFG_CACHE
+    if _AGENT_CFG_CACHE is not None:
+        return _AGENT_CFG_CACHE
+    try:
+        from modules.config_center.agent_yaml_loader import load_agent_config  # type: ignore
+
+        cfg = load_agent_config(None)
+        _AGENT_CFG_CACHE = cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        _AGENT_CFG_CACHE = {}
+    return _AGENT_CFG_CACHE
+
+
+def _agent_section(name: str) -> Dict[str, Any]:
+    cfg = _root_agent_cfg()
+    value = cfg.get(name, {}) if isinstance(cfg, dict) else {}
+    return value if isinstance(value, dict) else {}
+
+
+def _merge_with_agent_section(base_cfg: Dict[str, Any], section_name: str) -> Dict[str, Any]:
+    section = _agent_section(section_name)
+    if not section:
+        return base_cfg
+    try:
+        from modules.config_center.agent_yaml_loader import deep_merge  # type: ignore
+
+        return deep_merge(base_cfg, section)
+    except Exception:
+        merged = dict(base_cfg)
+        merged.update(section)
+        return merged
 
 
 def _should_autostart_services() -> bool:
@@ -36,7 +72,7 @@ def _should_autostart_services() -> bool:
 def _include_arduino(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.arduino_serial.xArduinoSerialService import xArduinoSerialService  # type: ignore
     from modules.arduino_serial.api.router import get_router as get_arduino_router  # type: ignore
-    ardu = xArduinoSerialService()
+    ardu = xArduinoSerialService(config_overrides=_agent_section("arduino_serial") or None)
     if _should_autostart_services():
         try:
             ardu.start()
@@ -70,7 +106,7 @@ def _include_neopixel(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.neopixel.config_loader import load_config as load_neo_cfg  # type: ignore
     from modules.neopixel.api.router import get_router as get_neopixel_router  # type: ignore
 
-    ncfg = load_neo_cfg(None)
+    ncfg = _merge_with_agent_section(load_neo_cfg(None), "neopixel")
     hw = ncfg.get("hardware", {})
     cfg_obj = NeoDriverConfig(
         device=str(hw.get("device", "/dev/spidev0.0")),
@@ -125,7 +161,7 @@ def _include_interactions(app: FastAPI, started: Dict[str, object], cfg: Dict[st
     from modules.interactions.api.router import get_router as get_inter_router  # type: ignore
     from modules.interactions.config_loader import load_config as load_inter_cfg  # type: ignore
     from modules.interactions.services.engine import InteractionEngine  # type: ignore
-    icfg = load_inter_cfg(None)
+    icfg = load_inter_cfg(None, overrides=_agent_section("interactions") or None)
     # Force interactions to talk to gateway's neopixel endpoint instead of standalone 8092
     try:
         port = int(cfg.get("server", {}).get("port", 8080))
@@ -209,7 +245,7 @@ def _include_camera(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.camera.config_loader import load_config as load_cam_cfg  # type: ignore
     from modules.camera.services.capture import CameraCapture, FramePublisher, CaptureConfig  # type: ignore
     from modules.camera.api import get_router as get_cam_router  # type: ignore
-    ccfg = load_cam_cfg(None)
+    ccfg = _merge_with_agent_section(load_cam_cfg(None), "camera")
     cap_cfg = CaptureConfig(
         backend=ccfg.get("backend", "auto"),
         source=ccfg.get("source", 0),
@@ -239,7 +275,12 @@ def _include_animate(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.animate.xAnimateService import xAnimateService  # type: ignore
     from modules.animate.api.router import get_router as get_anim_router  # type: ignore
     ardu = started.get("arduino")
-    anim = xAnimateService(serial=ardu) if ardu is not None else xAnimateService()
+    anim_overrides = _agent_section("animate") or None
+    anim = (
+        xAnimateService(serial=ardu, config_overrides=anim_overrides)
+        if ardu is not None
+        else xAnimateService(config_overrides=anim_overrides)
+    )
     if _should_autostart_services() and hasattr(anim, "start"):
         try:
             anim.start()
@@ -257,7 +298,7 @@ def _include_piservo(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.piservo.api.router import get_router as get_piservo_router  # type: ignore
     from modules.piservo.services.driver import ServoConfig  # type: ignore
     from modules.piservo.services.runner import EarRunner  # type: ignore
-    pcfg = load_piservo_cfg(None)
+    pcfg = _merge_with_agent_section(load_piservo_cfg(None), "piservo")
     left = ServoConfig(**pcfg.get("left", {"gpio": 12}))
     right = ServoConfig(**pcfg.get("right", {"gpio": 13}))
     ears = EarRunner(left_cfg=left, right_cfg=right)
@@ -269,7 +310,7 @@ def _include_piservo(app: FastAPI, started: Dict[str, object]) -> None:
 def _include_autonomy(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.autonomy.xAutonomyService import xAutonomyService  # type: ignore
     from modules.autonomy.api.router import get_router as get_autonomy_router  # type: ignore
-    svc = xAutonomyService()
+    svc = xAutonomyService(config_overrides=_agent_section("autonomy") or None)
     if _should_autostart_services():
         svc.start()
     else:
@@ -284,7 +325,7 @@ def _include_notifier(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.notifier.api.router import get_router as get_notifier_router  # type: ignore
     from modules.notifier.services.telegram_bot import build_telegram_bot  # type: ignore
 
-    ncfg = load_not_cfg(None)
+    ncfg = _merge_with_agent_section(load_not_cfg(None), "notifier")
     bot = build_telegram_bot(ncfg)
     app.include_router(get_notifier_router(ncfg, bot))
     polling_enabled = ncfg.get("telegram", {}).get("polling", {}).get("enabled", False)
@@ -388,39 +429,57 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
     # optional: mutagen
     if include.get("mutagen"):
         _try(lambda: app.include_router(__import__("modules.mutagen.api.router", fromlist=["get_router"]).get_router(
-            __import__("modules.mutagen.config_loader", fromlist=["load_config"]).load_config(None)
+            _merge_with_agent_section(
+                __import__("modules.mutagen.config_loader", fromlist=["load_config"]).load_config(None),
+                "mutagen",
+            )
         )), "mutagen")
         started["mutagen"] = True
 
     # optional: ota
     if include.get("ota"):
         _try(lambda: app.include_router(__import__("modules.ota.api.router", fromlist=["get_router"]).get_router(
-            __import__("modules.ota.config_loader", fromlist=["load_config"]).load_config(None)
+            _merge_with_agent_section(
+                __import__("modules.ota.config_loader", fromlist=["load_config"]).load_config(None),
+                "ota",
+            )
         )), "ota")
         started["ota"] = True
 
     # new optional modules
     if include.get("hardware"):
         _try(lambda: app.include_router(__import__("modules.hardware.api.router", fromlist=["get_router"]).get_router(
-            __import__("modules.hardware.config_loader", fromlist=["load_config"]).load_config(None)
+            _merge_with_agent_section(
+                __import__("modules.hardware.config_loader", fromlist=["load_config"]).load_config(None),
+                "hardware",
+            )
         )), "hardware")
         started["hardware"] = True
 
     if include.get("telemetry"):
         _try(lambda: app.include_router(__import__("modules.telemetry.api.router", fromlist=["get_router"]).get_router(
-            __import__("modules.telemetry.config_loader", fromlist=["load_config"]).load_config(None)
+            _merge_with_agent_section(
+                __import__("modules.telemetry.config_loader", fromlist=["load_config"]).load_config(None),
+                "telemetry",
+            )
         )), "telemetry")
         started["telemetry"] = True
 
     if include.get("diagnostics"):
         _try(lambda: app.include_router(__import__("modules.diagnostics.api.router", fromlist=["get_router"]).get_router(
-            __import__("modules.diagnostics.config_loader", fromlist=["load_config"]).load_config(None)
+            _merge_with_agent_section(
+                __import__("modules.diagnostics.config_loader", fromlist=["load_config"]).load_config(None),
+                "diagnostics",
+            )
         )), "diagnostics")
         started["diagnostics"] = True
 
     if include.get("state_manager"):
         def _mount_state():
-            cfg_sm = __import__("modules.state_manager.config_loader", fromlist=["load_config"]).load_config(None)
+            cfg_sm = _merge_with_agent_section(
+                __import__("modules.state_manager.config_loader", fromlist=["load_config"]).load_config(None),
+                "state_manager",
+            )
             StateStore = __import__("modules.state_manager.services.store", fromlist=["StateStore"]).StateStore
             get_router = __import__("modules.state_manager.api.router", fromlist=["get_router"]).get_router
             store = StateStore(
@@ -436,7 +495,10 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
 
     if include.get("scheduler"):
         def _mount_scheduler():
-            cfg_sc = __import__("modules.scheduler.config_loader", fromlist=["load_config"]).load_config(None)
+            cfg_sc = _merge_with_agent_section(
+                __import__("modules.scheduler.config_loader", fromlist=["load_config"]).load_config(None),
+                "scheduler",
+            )
             Scheduler = __import__("modules.scheduler.services.runner", fromlist=["Scheduler"]).Scheduler
             get_router = __import__("modules.scheduler.api.router", fromlist=["get_router"]).get_router
             sched = Scheduler(
@@ -457,13 +519,19 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
 
     if include.get("calibration"):
         _try(lambda: app.include_router(__import__("modules.calibration.api.router", fromlist=["get_router"]).get_router(
-            __import__("modules.calibration.config_loader", fromlist=["load_config"]).load_config(None)
+            _merge_with_agent_section(
+                __import__("modules.calibration.config_loader", fromlist=["load_config"]).load_config(None),
+                "calibration",
+            )
         )), "calibration")
         started["calibration"] = True
 
     if include.get("config_center"):
         _try(lambda: app.include_router(__import__("modules.config_center.api.router", fromlist=["get_router"]).get_router(
-            __import__("modules.config_center.config_loader", fromlist=["load_config"]).load_config(None)
+            _merge_with_agent_section(
+                __import__("modules.config_center.config_loader", fromlist=["load_config"]).load_config(None),
+                "config_center",
+            )
         )), "config_center")
         started["config_center"] = True
 

--- a/modules/gateway/xGatewayService.py
+++ b/modules/gateway/xGatewayService.py
@@ -164,4 +164,4 @@ def create_app(config_path: str | None = None) -> FastAPI:
 if __name__ == "__main__":
     import uvicorn
     cfg = load_config()
-    uvicorn.run(create_app(), host=str(cfg["server"]["host"]), port=int(cfg["server"]["port"]))
+    uvicorn.run(create_app(), host=str(cfg["server"]["host"]), port=int(cfg["server"]["port"]), log_config=None)

--- a/modules/ollama/api/router.py
+++ b/modules/ollama/api/router.py
@@ -90,7 +90,7 @@ def get_router(cfg: dict) -> APIRouter:
     def healthz():
         info: Dict[str, Any] = {"ok": True, "provider": provider_name, "model": model}
         if provider_name == "ollama":
-            info["base_url"] = str(cfg.get("ollama", {}).get("base_url", "http://localhost:11434"))
+            info["base_url"] = str(cfg.get("ollama", {}).get("base_url", "http://127.0.0.1:11434"))
         elif provider_name == "google_ai_studio":
             info["base_url"] = str(cfg.get("google_ai_studio", {}).get("base_url", "https://generativelanguage.googleapis.com"))
         return info

--- a/modules/ollama/config/config.yml
+++ b/modules/ollama/config/config.yml
@@ -4,7 +4,7 @@ server:
 llm:
   provider: ollama   # ollama | google_ai_studio
 ollama:
-  base_url: http://localhost:11434
+  base_url: http://127.0.0.1:11434
   model: qwen3.5:9b
   request_timeout: 60
 google_ai_studio:

--- a/modules/ollama/config_loader.py
+++ b/modules/ollama/config_loader.py
@@ -10,7 +10,7 @@ _REQUIRED_MODEL = "qwen3.5:9b"
 _DEFAULT_CFG: Dict[str, Any] = {
     "server": {"host": "0.0.0.0", "port": 8099},
     "llm": {"provider": "ollama", "single_model_mode": True},
-    "ollama": {"base_url": "http://localhost:11434", "model": _REQUIRED_MODEL, "request_timeout": 60.0},
+    "ollama": {"base_url": "http://127.0.0.1:11434", "model": _REQUIRED_MODEL, "request_timeout": 60.0},
     "google_ai_studio": {
         "api_key": "",
         "model": "gemini-1.5-flash",
@@ -77,7 +77,7 @@ def load_config(config_path: str | None = None) -> Dict[str, Any]:
         or llm_cfg.get("base_url")
         or ollama_global.get("base_url")
         or os.getenv("AGENT_OLLAMA_BASE_URL")
-        or "http://localhost:11434"
+        or "http://127.0.0.1:11434"
     )
     if not base_url:
         raise ValueError("agent.ollama_base_url is required")

--- a/modules/ollama/services/clients.py
+++ b/modules/ollama/services/clients.py
@@ -292,7 +292,7 @@ def create_llm_client(cfg: Dict[str, Any]) -> Tuple[LLMClientProtocol, str]:
         return GoogleAIStudioClient(api_key=api_key, model=model, base_url=base_url, request_timeout=timeout), "google_ai_studio"
 
     ocfg = cfg.get("ollama", {}) or {}
-    base_url = str(ocfg.get("base_url", "http://localhost:11434"))
+    base_url = str(ocfg.get("base_url", "http://127.0.0.1:11434"))
     model = str(ocfg.get("model", "llama3.2:3b"))
     timeout = float(ocfg.get("request_timeout", 60.0))
     return OllamaClient(base_url=base_url, model=model, request_timeout=timeout), "ollama"

--- a/modules/ollama/tests/test_config_loader_env.py
+++ b/modules/ollama/tests/test_config_loader_env.py
@@ -57,7 +57,7 @@ agent:
 llm:
   provider: google_ai_studio
 ollama:
-  base_url: "http://localhost:11434"
+  base_url: "http://127.0.0.1:11434"
   model: qwen3.5:9b
 ollama_service:
   persona:
@@ -79,7 +79,7 @@ agent:
 llm:
   provider: ollama
 ollama:
-  base_url: "http://localhost:11434"
+  base_url: "http://127.0.0.1:11434"
   model: qwen3.5:8b
 ollama_service:
   persona:

--- a/modules/speak/api/router.py
+++ b/modules/speak/api/router.py
@@ -26,6 +26,8 @@ def get_router(service: SpeakService) -> APIRouter:
         language = payload.get("language")
         if not text:
             return {"ok": False, "error": "text is empty"}
+        
+        logger.info("TTS >>> %s (engine=%s)", text, engine or "default")
         try:
             # Offload blocking TTS to thread to avoid event loop freeze
             return await asyncio.to_thread(

--- a/modules/speak/config/config.yml
+++ b/modules/speak/config/config.yml
@@ -11,7 +11,7 @@ audio_out:
   dtype: float32
 
 tts:
-  engine: piper      # pyttsx3 | piper | xtts | dummy
+  engine: pyttsx3      # pyttsx3 | piper | xtts | dummy
   language: tr
   voice: source         # optional voice id — default olarak kaynak sesi kullanılacak
   rate: 170

--- a/modules/speak/config_loader.py
+++ b/modules/speak/config_loader.py
@@ -5,6 +5,24 @@ from typing import Any, Dict
 from modules.config_center.agent_yaml_loader import load_agent_config, require_dict_section
 
 
+def _normalize_speak_section(section: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep agent.yaml as single source, with small compatibility aliases.
+
+    Supports legacy shorthand keys like `speak.engine` by mapping them into
+    `speak.tts.engine` when present.
+    """
+    out = deepcopy(section)
+    tts = out.get("tts") if isinstance(out.get("tts"), dict) else {}
+    out["tts"] = dict(tts)
+
+    # Compatibility: allow `speak.engine: xtts` as shorthand.
+    shorthand_engine = str(out.get("engine", "")).strip()
+    if shorthand_engine:
+        out["tts"]["engine"] = shorthand_engine
+
+    return out
+
+
 def load_config(override_path: str | os.PathLike | None = None) -> Dict[str, Any]:
     """Load speak config from central config/agent.yaml.
 
@@ -12,4 +30,4 @@ def load_config(override_path: str | os.PathLike | None = None) -> Dict[str, Any
     """
     root_cfg = load_agent_config(override_path)
     section = require_dict_section(root_cfg, "speak")
-    return deepcopy(section)
+    return _normalize_speak_section(section)

--- a/modules/speak/tests/test_config_loader.py
+++ b/modules/speak/tests/test_config_loader.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.speak.config_loader import load_config
+
+
+def test_load_config_supports_shorthand_engine_key(tmp_path: Path) -> None:
+    agent_cfg = tmp_path / "agent.yaml"
+    agent_cfg.write_text(
+        """
+speak:
+  engine: xtts
+  tts:
+    language: tr
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(str(agent_cfg))
+
+    assert cfg["tts"]["engine"] == "xtts"
+    assert cfg["tts"]["language"] == "tr"
+
+
+def test_load_config_shorthand_engine_overrides_nested_engine(tmp_path: Path) -> None:
+    agent_cfg = tmp_path / "agent.yaml"
+    agent_cfg.write_text(
+        """
+speak:
+  engine: xtts
+  tts:
+    engine: pyttsx3
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(str(agent_cfg))
+
+    assert cfg["tts"]["engine"] == "xtts"

--- a/modules/speak/xSpeakService.py
+++ b/modules/speak/xSpeakService.py
@@ -233,7 +233,7 @@ def main():
         cfg = load_config(args.config)
         host = str(cfg.get("server", {}).get("host", "0.0.0.0"))
         port = int(cfg.get("server", {}).get("port", 8083))
-        uvicorn.run(create_app(args.config), host=host, port=port)
+        uvicorn.run(create_app(args.config), host=host, port=port, log_config=None)
         return
 
     service = SpeakService(args.config)

--- a/modules/vlm_bridge/config_loader.py
+++ b/modules/vlm_bridge/config_loader.py
@@ -136,7 +136,7 @@ def _enforce_single_model_policy(cfg: Dict[str, Any], root_cfg: Dict[str, Any]) 
         or root_llm.get("base_url")
         or root_ollama.get("base_url")
         or os.getenv("AGENT_OLLAMA_BASE_URL")
-        or "http://localhost:11434"
+        or "http://127.0.0.1:11434"
     )
     if not base_url:
         raise ValueError("agent.ollama_base_url is required")

--- a/modules/vlm_bridge/services/llm_client.py
+++ b/modules/vlm_bridge/services/llm_client.py
@@ -13,7 +13,7 @@ except Exception:
 logger = logging.getLogger("vlm_bridge.llm")
 
 _DEFAULT_CHAT_ENDPOINT = "http://localhost:8080/ollama/chat"
-_DEFAULT_GENERATE_ENDPOINT = "http://localhost:11434/api/generate"
+_DEFAULT_GENERATE_ENDPOINT = "http://127.0.0.1:11434/api/generate"
 _CHAT_COOLDOWN_UNTIL: Dict[str, float] = {}
 
 

--- a/modules/vlm_bridge/tests/test_config_loader.py
+++ b/modules/vlm_bridge/tests/test_config_loader.py
@@ -43,11 +43,11 @@ def test_vlm_config_loader_rejects_non_ollama_provider(tmp_path: Path):
         """
 agent:
   model: qwen3.5:9b
-  ollama_base_url: "http://localhost:11434"
+  ollama_base_url: "http://127.0.0.1:11434"
 llm:
   provider: google_ai_studio
 ollama:
-  base_url: "http://localhost:11434"
+  base_url: "http://127.0.0.1:11434"
   model: qwen3.5:9b
 vlm_bridge:
   llm:
@@ -66,12 +66,12 @@ def test_vlm_config_loader_rejects_non_qwen3_5_9b_model(tmp_path: Path):
         """
 agent:
   model: llama3.1:8b
-  ollama_base_url: "http://localhost:11434"
+  ollama_base_url: "http://127.0.0.1:11434"
 llm:
   provider: ollama
   model: llama3.1:8b
 ollama:
-  base_url: "http://localhost:11434"
+  base_url: "http://127.0.0.1:11434"
   model: llama3.1:8b
 vlm_bridge:
   llm:

--- a/modules/vlm_bridge/xVlmBridgeService.py
+++ b/modules/vlm_bridge/xVlmBridgeService.py
@@ -50,4 +50,4 @@ def create_app(config_path: str | None = None) -> FastAPI:
 if __name__ == "__main__":
     import uvicorn
     cfg = load_config()
-    uvicorn.run(create_app(), host=str(cfg["server"]["host"]), port=int(cfg["server"]["port"]))
+    uvicorn.run(create_app(), host=str(cfg["server"]["host"]), port=int(cfg["server"]["port"]), log_config=None)


### PR DESCRIPTION
## Özet
run_robot üzerinden açılan gateway akışında agent.yaml bölümleri artık LLM ve TTS seçimi için öncelikli kaynak oluyor; merkezi ayarlar run-time bootstrapping sırasında modül varsayılanlarının üstüne yazılıyor.

## Değişiklik tipi
- Fix
- Config update
- Test update

## Etkilenen modüller
- `modules/gateway`
- `modules/agent_core`
- `modules/ollama`
- `modules/speak`
- `modules/vlm_bridge`

## Doğrulama
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` ile hedefli pytest çalıştırıldı ve geçti
- `run_robot.py` ile gateway ayağa kaldırıldı ve `/state/get` üzerinden agent.yaml override davranışı doğrulandı

## Risk ve geri alma
- Bu değişiklik yalnızca `run_robot`/gateway bootstrap yolunu etkiler; standalone başlatılan modüller değişmeden kalır.
- Geri alma için ilgili commitler branch üzerinden tek tek revert edilebilir.

## Arduino Kontrat Kontrolü
- `modules/arduino_serial/contract.py` değişmedi
- Elle Arduino payload yazımı eklenmedi
- Kritik komut akışları bu değişiklikte dokunulmadı