### PR TITLE
feat: add modular remote multimodal vision server

### DIFF
--- a/tools/remote_multimodal_server/README.md
+++ b/tools/remote_multimodal_server/README.md
@@ -1,0 +1,85 @@
+# Remote Multimodal Vision Server
+
+PC-side inference server for SentryBOT, structured similarly to `remote_tts_server`.
+
+## Project Layout
+
+- `app.py` - entrypoint for uvicorn import mode
+- `server.py` - compatibility launcher (`python server.py`)
+- `remote_multimodal/config.py` - runtime env config
+- `remote_multimodal/models.py` - request/response models
+- `remote_multimodal/backends.py` - optional backend initialization
+- `remote_multimodal/engine.py` - multimodal analysis pipeline
+- `remote_multimodal/server.py` - FastAPI routes
+
+## Features
+
+- Face/person detection
+- Optional face identity (`face_recognition`)
+- Optional age/emotion estimation (`deepface`)
+- Object detection (`ultralytics` YOLO if installed, OpenCV fallback otherwise)
+- Hybrid vision reasoning: OpenCV/YOLO + Qwen VLM (Ollama)
+- Motion score + scene change score
+- Hazard hints from object labels
+- Optional advanced caption backend (`transformers`)
+
+## Run
+
+```bash
+pip install -r requirements.txt
+python server.py
+```
+
+Default: `http://0.0.0.0:8091`
+
+## Endpoints
+
+- `GET /healthz`
+- `POST /vision/analyze`
+- `POST /vision/register_face`
+
+## Environment Variables
+
+- `MM_HOST` (default `0.0.0.0`)
+- `MM_PORT` (default `8091`)
+- `MM_AUTH_TOKEN` (default `changeme`)
+- `MM_YOLO_MODEL` (default `yolov8n.pt`)
+- `MM_FACE_DB` (default `known_faces.json`)
+- `MM_DETECTOR_BACKEND` (`auto|yolo|opencv`, default `auto`)
+- `MM_RUNTIME_PROFILE` (`ultra_fast|balanced|max_accuracy`, default `balanced`)
+- `MM_YOLO_CONF` (default profile-based)
+- `MM_YOLO_IMGSZ` (default profile-based)
+- `MM_MOTION_THRESHOLD` (default profile-based)
+- `MM_SCENE_CHANGE_THRESHOLD` (default profile-based)
+- `MM_ENABLE_FACE_RECOGNITION` (`true|false`, default `true`)
+- `MM_ENABLE_AGE_EMOTION` (`true|false`, default `true`)
+- `MM_ENABLE_QWEN_VLM` (`true|false`, default `true`)
+- `MM_QWEN_ENDPOINT` (default `http://127.0.0.1:11434/api/chat`)
+- `MM_QWEN_PRIMARY_MODEL` (default `qwen2.5vl:7b`)
+- `MM_QWEN_FALLBACK_MODEL` (default `qwen3-vl:8b`)
+- `MM_QWEN_TIMEOUT` (default `8.0`)
+- `MM_QWEN_NUM_PREDICT` (default `192`)
+- `MM_QWEN_NUM_CTX` (default `2048`)
+- `MM_QWEN_TEMPERATURE` (default `0.1`)
+- `MM_ENABLE_ADVANCED_CAPTION` (`true|false`, default `false`)
+- `MM_ADVANCED_CAPTION_MODEL` (default `microsoft/Florence-2-base`)
+
+## Recommended Advanced Stack
+
+For your selected profile (`balanced`) with Qwen + OpenCV:
+
+- Detector: YOLO (`ultralytics`)
+- Scene reasoning: Qwen VLM via Ollama (`qwen2.5vl:7b`, fallback `qwen3-vl:8b`)
+- Face identity: `face_recognition`
+- Age/emotion: `deepface`
+- Optional caption/reasoning: `transformers` image-to-text backend
+
+## Robot-side config (`modules/vlm_bridge/config/config.yml`)
+
+```yaml
+remote_multimodal:
+  enabled: true
+  endpoint: "http://PC_IP:8091/vision/analyze"
+  timeout_s: 6.0
+  auth_token: "YOUR_TOKEN"
+```

--- a/tools/remote_multimodal_server/app.py
+++ b/tools/remote_multimodal_server/app.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from remote_multimodal.server import create_app, run_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    run_app()

--- a/tools/remote_multimodal_server/remote_multimodal/__init__.py
+++ b/tools/remote_multimodal_server/remote_multimodal/__init__.py
@@ -1,0 +1,3 @@
+from .server import create_app, run_app
+
+__all__ = ["create_app", "run_app"]

--- a/tools/remote_multimodal_server/remote_multimodal/backends.py
+++ b/tools/remote_multimodal_server/remote_multimodal/backends.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from .config import RuntimeConfig
+
+logger = logging.getLogger("remote_multimodal.backends")
+
+
+class Backends:
+    def __init__(self, cfg: RuntimeConfig) -> None:
+        self.yolo: Optional[Any] = None
+        self.face_recognition: Optional[Any] = None
+        self.deepface: Optional[Any] = None
+        self.caption_pipe: Optional[Any] = None
+        self._init(cfg)
+
+    def _init(self, cfg: RuntimeConfig) -> None:
+        if cfg.detector_backend in {"auto", "yolo"}:
+            try:
+                from ultralytics import YOLO  # type: ignore
+
+                self.yolo = YOLO(cfg.yolo_model)
+                logger.info("YOLO loaded: %s", cfg.yolo_model)
+            except Exception as exc:
+                logger.info("YOLO unavailable: %s", exc)
+
+        if cfg.enable_face_recognition:
+            try:
+                import face_recognition  # type: ignore
+
+                self.face_recognition = face_recognition
+                logger.info("face_recognition loaded.")
+            except Exception as exc:
+                logger.info("face_recognition unavailable: %s", exc)
+
+        if cfg.enable_age_emotion:
+            try:
+                from deepface import DeepFace  # type: ignore
+
+                self.deepface = DeepFace
+                logger.info("DeepFace loaded.")
+            except Exception as exc:
+                logger.info("DeepFace unavailable: %s", exc)
+
+        # Optional image-level caption backend (can be upgraded on remote GPU host).
+        if cfg.enable_advanced_caption:
+            try:
+                from transformers import pipeline  # type: ignore
+
+                self.caption_pipe = pipeline(
+                    task="image-to-text",
+                    model=cfg.advanced_caption_model,
+                )
+                logger.info("Caption model loaded: %s", cfg.advanced_caption_model)
+            except Exception as exc:
+                logger.info("Advanced caption backend unavailable: %s", exc)

--- a/tools/remote_multimodal_server/remote_multimodal/config.py
+++ b/tools/remote_multimodal_server/remote_multimodal/config.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+def bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
+class RuntimeConfig(BaseModel):
+    host: str = "0.0.0.0"
+    port: int = 8091
+    auth_token: str = "changeme"
+    face_db_path: str = "known_faces.json"
+    yolo_model: str = "yolov8n.pt"
+    detector_backend: str = "auto"  # auto | yolo | opencv
+    runtime_profile: str = "balanced"  # ultra_fast | balanced | max_accuracy
+    yolo_conf: float = 0.25
+    yolo_imgsz: int = 640
+    motion_threshold: float = 0.08
+    scene_change_threshold: float = 0.35
+    enable_face_recognition: bool = True
+    enable_age_emotion: bool = True
+    enable_qwen_vlm: bool = True
+    qwen_endpoint: str = "http://127.0.0.1:11434/api/chat"
+    qwen_primary_model: str = "qwen2.5vl:7b"
+    qwen_fallback_model: str = "qwen3-vl:8b"
+    qwen_timeout_s: float = 8.0
+    qwen_num_predict: int = 192
+    qwen_num_ctx: int = 2048
+    qwen_temperature: float = 0.1
+    enable_advanced_caption: bool = False
+    advanced_caption_model: str = "microsoft/Florence-2-base"
+
+
+def load_runtime_config() -> RuntimeConfig:
+    base_dir = Path(__file__).resolve().parent.parent
+    return RuntimeConfig(
+        host=str(os.getenv("MM_HOST", "0.0.0.0")).strip() or "0.0.0.0",
+        port=int(os.getenv("MM_PORT", "8091")),
+        auth_token=str(os.getenv("MM_AUTH_TOKEN", "changeme")).strip() or "changeme",
+        face_db_path=str(os.getenv("MM_FACE_DB", str(base_dir / "known_faces.json"))).strip(),
+        yolo_model=str(os.getenv("MM_YOLO_MODEL", "yolov8n.pt")).strip() or "yolov8n.pt",
+        detector_backend=str(os.getenv("MM_DETECTOR_BACKEND", "auto")).strip().lower() or "auto",
+        runtime_profile=str(os.getenv("MM_RUNTIME_PROFILE", "balanced")).strip().lower() or "balanced",
+        yolo_conf=float(os.getenv("MM_YOLO_CONF", "0.25")),
+        yolo_imgsz=int(os.getenv("MM_YOLO_IMGSZ", "640")),
+        motion_threshold=float(os.getenv("MM_MOTION_THRESHOLD", "0.08")),
+        scene_change_threshold=float(os.getenv("MM_SCENE_CHANGE_THRESHOLD", "0.35")),
+        enable_face_recognition=bool_env("MM_ENABLE_FACE_RECOGNITION", True),
+        enable_age_emotion=bool_env("MM_ENABLE_AGE_EMOTION", True),
+        enable_qwen_vlm=bool_env("MM_ENABLE_QWEN_VLM", True),
+        qwen_endpoint=str(
+            os.getenv("MM_QWEN_ENDPOINT", "http://127.0.0.1:11434/api/chat")
+        ).strip()
+        or "http://127.0.0.1:11434/api/chat",
+        qwen_primary_model=str(os.getenv("MM_QWEN_PRIMARY_MODEL", "qwen2.5vl:7b")).strip()
+        or "qwen2.5vl:7b",
+        qwen_fallback_model=str(os.getenv("MM_QWEN_FALLBACK_MODEL", "qwen3-vl:8b")).strip()
+        or "qwen3-vl:8b",
+        qwen_timeout_s=float(os.getenv("MM_QWEN_TIMEOUT", "8.0")),
+        qwen_num_predict=int(os.getenv("MM_QWEN_NUM_PREDICT", "192")),
+        qwen_num_ctx=int(os.getenv("MM_QWEN_NUM_CTX", "2048")),
+        qwen_temperature=float(os.getenv("MM_QWEN_TEMPERATURE", "0.1")),
+        enable_advanced_caption=bool_env("MM_ENABLE_ADVANCED_CAPTION", False),
+        advanced_caption_model=str(
+            os.getenv("MM_ADVANCED_CAPTION_MODEL", "microsoft/Florence-2-base")
+        ).strip(),
+    )

--- a/tools/remote_multimodal_server/remote_multimodal/engine.py
+++ b/tools/remote_multimodal_server/remote_multimodal/engine.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+from .backends import Backends
+from .config import RuntimeConfig
+from .models import KnownFace, known_face_from_dict, known_face_to_dict
+from .qwen_client import QwenVlmClient
+
+logger = logging.getLogger("remote_multimodal.engine")
+
+
+class MultiModalEngine:
+    def __init__(self, cfg: RuntimeConfig) -> None:
+        self.cfg = cfg
+        self._apply_profile_defaults()
+        self.backends = Backends(cfg)
+        self.qwen = QwenVlmClient(cfg)
+        self._lock = threading.Lock()
+        self._prev_gray: Optional[np.ndarray] = None
+        self._prev_hist: Optional[np.ndarray] = None
+        self._known_faces: List[KnownFace] = []
+        self._db_path = Path(cfg.face_db_path)
+        self._face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + "haarcascade_frontalface_default.xml")
+        self._body_hog = cv2.HOGDescriptor()
+        self._body_hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())
+        self._load_face_db()
+
+    def _apply_profile_defaults(self) -> None:
+        profile = str(self.cfg.runtime_profile or "balanced").strip().lower()
+        if profile == "ultra_fast":
+            self.cfg.yolo_conf = 0.35
+            self.cfg.yolo_imgsz = 416
+            self.cfg.motion_threshold = 0.1
+            self.cfg.scene_change_threshold = 0.4
+            self.cfg.enable_age_emotion = False
+            self.cfg.enable_advanced_caption = False
+            self.cfg.qwen_num_predict = min(self.cfg.qwen_num_predict, 120)
+            self.cfg.qwen_timeout_s = min(self.cfg.qwen_timeout_s, 5.0)
+        elif profile == "max_accuracy":
+            self.cfg.yolo_conf = 0.2
+            self.cfg.yolo_imgsz = 960
+            self.cfg.motion_threshold = 0.06
+            self.cfg.scene_change_threshold = 0.3
+            self.cfg.qwen_num_predict = max(self.cfg.qwen_num_predict, 256)
+            self.cfg.qwen_timeout_s = max(self.cfg.qwen_timeout_s, 10.0)
+        else:
+            # balanced
+            self.cfg.yolo_conf = 0.25
+            self.cfg.yolo_imgsz = 640
+            self.cfg.motion_threshold = 0.08
+            self.cfg.scene_change_threshold = 0.35
+            self.cfg.qwen_num_predict = max(160, min(self.cfg.qwen_num_predict, 224))
+            self.cfg.qwen_timeout_s = max(6.0, min(self.cfg.qwen_timeout_s, 9.0))
+
+    def _load_face_db(self) -> None:
+        if not self._db_path.exists():
+            return
+        try:
+            raw = json.loads(self._db_path.read_text(encoding="utf-8"))
+            if isinstance(raw, list):
+                self._known_faces = [f for f in (known_face_from_dict(x) for x in raw) if f is not None]
+        except Exception as exc:
+            logger.warning("Failed to load face db: %s", exc)
+
+    def _save_face_db(self) -> None:
+        try:
+            payload = [known_face_to_dict(f) for f in self._known_faces]
+            self._db_path.write_text(json.dumps(payload, ensure_ascii=True), encoding="utf-8")
+        except Exception as exc:
+            logger.warning("Failed to save face db: %s", exc)
+
+    @staticmethod
+    def decode_image(image_b64: str) -> np.ndarray:
+        raw = base64.b64decode(image_b64)
+        arr = np.frombuffer(raw, dtype=np.uint8)
+        frame = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+        if frame is None:
+            raise ValueError("invalid image_b64")
+        return frame
+
+    def detect_objects(self, frame: np.ndarray) -> List[Dict[str, Any]]:
+        if self.backends.yolo is not None:
+            try:
+                res = self.backends.yolo.predict(
+                    frame,
+                    verbose=False,
+                    conf=float(self.cfg.yolo_conf),
+                    imgsz=int(self.cfg.yolo_imgsz),
+                )
+                if res:
+                    r0 = res[0]
+                    boxes = getattr(r0, "boxes", None)
+                    names = getattr(r0, "names", {}) or {}
+                    if boxes is not None:
+                        xyxy = boxes.xyxy.cpu().numpy().astype(int)
+                        conf = boxes.conf.cpu().numpy()
+                        cls = boxes.cls.cpu().numpy().astype(int)
+                        out: List[Dict[str, Any]] = []
+                        for i in range(len(xyxy)):
+                            x1, y1, x2, y2 = [int(v) for v in xyxy[i]]
+                            label = str(names.get(int(cls[i]), f"class_{int(cls[i])}"))
+                            out.append(
+                                {
+                                    "label": label,
+                                    "confidence": round(float(conf[i]), 3),
+                                    "bbox": [x1, y1, x2, y2],
+                                }
+                            )
+                        return out
+            except Exception as exc:
+                logger.debug("YOLO detect failed: %s", exc)
+
+        rects, weights = self._body_hog.detectMultiScale(
+            frame,
+            winStride=(8, 8),
+            padding=(8, 8),
+            scale=1.05,
+        )
+        out: List[Dict[str, Any]] = []
+        for i, (x, y, w, h) in enumerate(rects):
+            out.append(
+                {
+                    "label": "person",
+                    "confidence": round(float(weights[i]) if i < len(weights) else 0.4, 3),
+                    "bbox": [int(x), int(y), int(x + w), int(y + h)],
+                }
+            )
+        return out
+
+    def detect_faces(self, frame: np.ndarray) -> List[List[int]]:
+        fr = self.backends.face_recognition
+        if fr is not None:
+            try:
+                rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                locs = fr.face_locations(rgb, model="hog")
+                return [[int(l[3]), int(l[0]), int(l[1]), int(l[2])] for l in locs]
+            except Exception:
+                pass
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        faces = self._face_cascade.detectMultiScale(gray, scaleFactor=1.12, minNeighbors=5, minSize=(56, 56))
+        return [[int(x), int(y), int(x + w), int(y + h)] for (x, y, w, h) in faces]
+
+    def recognize_person(self, frame: np.ndarray, face_box: List[int]) -> Tuple[str, float]:
+        fr = self.backends.face_recognition
+        if fr is None:
+            return "Unknown", 0.0
+        x1, y1, x2, y2 = face_box
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        try:
+            enc = fr.face_encodings(rgb, [(y1, x2, y2, x1)])
+            if not enc:
+                return "Unknown", 0.0
+            vec = enc[0]
+            best_name = "Unknown"
+            best_dist = 999.0
+            for known in self._known_faces:
+                dist = np.linalg.norm(np.array(known.embedding) - vec)
+                if dist < best_dist:
+                    best_dist = float(dist)
+                    best_name = known.name
+            if best_dist < 0.55:
+                conf = max(0.0, min(1.0, 1.0 - (best_dist / 0.75)))
+                return best_name, conf
+            return "Unknown", max(0.0, min(0.5, 1.0 - (best_dist / 1.2)))
+        except Exception:
+            return "Unknown", 0.0
+
+    def estimate_age_emotion(self, face_img: np.ndarray) -> Tuple[Optional[int], Optional[str]]:
+        deepface = self.backends.deepface
+        if deepface is None:
+            return None, None
+        try:
+            analysis = deepface.analyze(face_img, actions=["age", "emotion"], enforce_detection=False)
+            data = analysis[0] if isinstance(analysis, list) and analysis else analysis
+            age = int(data.get("age")) if isinstance(data, dict) and data.get("age") is not None else None
+            emotion = str(data.get("dominant_emotion")) if isinstance(data, dict) and data.get("dominant_emotion") else None
+            return age, emotion
+        except Exception:
+            return None, None
+
+    def motion_scene_change(self, frame: np.ndarray) -> Tuple[float, float]:
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        gray = cv2.GaussianBlur(gray, (7, 7), 0)
+        hist = cv2.calcHist([gray], [0], None, [64], [0, 256])
+        cv2.normalize(hist, hist)
+        motion = 0.0
+        scene = 0.0
+        with self._lock:
+            if self._prev_gray is not None:
+                diff = cv2.absdiff(gray, self._prev_gray)
+                motion = float(np.mean(diff) / 255.0)
+            if self._prev_hist is not None:
+                corr = cv2.compareHist(hist, self._prev_hist, cv2.HISTCMP_CORREL)
+                scene = max(0.0, min(1.0, 1.0 - float(corr)))
+            self._prev_gray = gray
+            self._prev_hist = hist
+        return motion, scene
+
+    def _caption(self, frame: np.ndarray) -> Optional[str]:
+        pipe = self.backends.caption_pipe
+        if pipe is None:
+            return None
+        try:
+            rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            out = pipe(rgb)
+            if isinstance(out, list) and out and isinstance(out[0], dict):
+                text = str(out[0].get("generated_text", "")).strip()
+                return text or None
+        except Exception:
+            return None
+        return None
+
+    def analyze(self, image_b64: str) -> Dict[str, Any]:
+        frame = self.decode_image(image_b64)
+        h, w = frame.shape[:2]
+        objects = self.detect_objects(frame)
+        faces = self.detect_faces(frame)
+        motion, scene_change = self.motion_scene_change(frame)
+        qwen_out = self.qwen.analyze_frame(frame)
+
+        people: List[Dict[str, Any]] = []
+        for fb in faces:
+            x1, y1, x2, y2 = fb
+            x1 = max(0, min(w - 1, x1))
+            y1 = max(0, min(h - 1, y1))
+            x2 = max(0, min(w, x2))
+            y2 = max(0, min(h, y2))
+            if x2 <= x1 or y2 <= y1:
+                continue
+            crop = frame[y1:y2, x1:x2]
+            name, conf = self.recognize_person(frame, [x1, y1, x2, y2])
+            age, emotion = self.estimate_age_emotion(crop)
+            rec_level = 2 if name != "Unknown" else 0
+            people.append(
+                {
+                    "name": name,
+                    "confidence": round(float(conf), 3),
+                    "bbox": [x1, y1, x2, y2],
+                    "emotion": emotion,
+                    "age": age,
+                    "recognition_level": rec_level,
+                    "relationship": "known" if rec_level >= 2 else "unknown",
+                }
+            )
+
+        hazards = []
+        for o in objects:
+            lbl = str(o.get("label", "")).lower()
+            if lbl in {"knife", "fire", "scissors"}:
+                hazards.append({"type": lbl, "severity": "high", "bbox": o.get("bbox")})
+        for hz in qwen_out.get("hazards", []) if qwen_out.get("ok") else []:
+            hz_name = str(hz).strip().lower()
+            if hz_name and hz_name not in {str(x.get("type", "")).lower() for x in hazards}:
+                hazards.append({"type": hz_name, "severity": "medium", "bbox": None})
+
+        caption = self._caption(frame)
+        qwen_summary = str(qwen_out.get("summary", "")).strip() if qwen_out.get("ok") else ""
+        summary = qwen_summary or caption or f"{len(people)} person, {len(objects)} objects."
+        if scene_change > self.cfg.scene_change_threshold:
+            summary += " Scene changed."
+        if motion > self.cfg.motion_threshold:
+            summary += " Motion detected."
+        if hazards:
+            summary += " Hazard present."
+        persona_interpretation = (
+            str(qwen_out.get("persona_interpretation", "")).strip() if qwen_out.get("ok") else ""
+        ) or summary.strip()
+        suggested_focus = (
+            str(qwen_out.get("suggested_focus", "")).strip() if qwen_out.get("ok") else ""
+        )
+        focus_type = "person" if people else "scene"
+        if suggested_focus in {"person", "face", "human"}:
+            focus_type = "person"
+        elif suggested_focus in {"hazard", "danger", "object"} and hazards:
+            focus_type = "hazard"
+
+        importance = 0.35 + (0.2 if people else 0.0) + (0.15 if scene_change > self.cfg.scene_change_threshold else 0.0) + (0.1 if motion > self.cfg.motion_threshold else 0.0) + (0.3 if hazards else 0.0)
+        if qwen_out.get("ok"):
+            importance += 0.1
+        return {
+            "ok": True,
+            "summary": summary.strip(),
+            "persona_interpretation": persona_interpretation,
+            "objects": objects,
+            "people": people,
+            "hazards": hazards,
+            "motion": {"score": round(motion, 3), "detected": motion > self.cfg.motion_threshold},
+            "scene_change": {"score": round(scene_change, 3), "changed": scene_change > self.cfg.scene_change_threshold},
+            "interesting_events": ["scene_changed"] if scene_change > self.cfg.scene_change_threshold else [],
+            "recommended_focus": {"type": focus_type, "reason": "hybrid_cv_qwen"},
+            "importance_score": round(min(1.0, max(0.0, importance)), 3),
+            "frame_size": {"w": int(w), "h": int(h)},
+            "backend_info": {
+                "yolo": bool(self.backends.yolo is not None),
+                "face_recognition": bool(self.backends.face_recognition is not None),
+                "deepface": bool(self.backends.deepface is not None),
+                "advanced_caption": bool(self.backends.caption_pipe is not None),
+                "qwen_vlm": bool(qwen_out.get("ok")),
+                "qwen_model": qwen_out.get("model", ""),
+            },
+        }
+
+    def register_face(self, name: str, image_b64: str) -> Dict[str, Any]:
+        fr = self.backends.face_recognition
+        if fr is None:
+            return {"ok": False, "error": "face_recognition backend unavailable"}
+        frame = self.decode_image(image_b64)
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        locs = fr.face_locations(rgb, model="hog")
+        if not locs:
+            return {"ok": False, "error": "no face detected"}
+        enc = fr.face_encodings(rgb, [locs[0]])
+        if not enc:
+            return {"ok": False, "error": "face encoding failed"}
+        embedding = enc[0].tolist()
+        self._known_faces = [f for f in self._known_faces if f.name.lower() != name.lower()]
+        self._known_faces.append(KnownFace(name=name, embedding=embedding))
+        self._save_face_db()
+        return {"ok": True, "name": name, "known_faces": len(self._known_faces)}

--- a/tools/remote_multimodal_server/remote_multimodal/models.py
+++ b/tools/remote_multimodal_server/remote_multimodal/models.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class AnalyzeRequest(BaseModel):
+    image_b64: str
+
+
+class RegisterFaceRequest(BaseModel):
+    name: str
+    image_b64: str
+
+
+@dataclass
+class KnownFace:
+    name: str
+    embedding: List[float]
+    created_at: float = field(default_factory=time.time)
+
+
+def known_face_to_dict(face: KnownFace) -> Dict[str, Any]:
+    return {
+        "name": face.name,
+        "embedding": list(face.embedding),
+        "created_at": float(face.created_at),
+    }
+
+
+def known_face_from_dict(data: Dict[str, Any]) -> Optional[KnownFace]:
+    if not isinstance(data, dict):
+        return None
+    name = str(data.get("name", "")).strip()
+    emb = data.get("embedding")
+    if not name or not isinstance(emb, list) or not emb:
+        return None
+    try:
+        vec = [float(v) for v in emb]
+    except Exception:
+        return None
+    created_at = float(data.get("created_at", time.time()))
+    return KnownFace(name=name, embedding=vec, created_at=created_at)

--- a/tools/remote_multimodal_server/remote_multimodal/qwen_client.py
+++ b/tools/remote_multimodal_server/remote_multimodal/qwen_client.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import cv2
+import requests
+
+from .config import RuntimeConfig
+
+logger = logging.getLogger("remote_multimodal.qwen_client")
+
+
+class QwenVlmClient:
+    def __init__(self, cfg: RuntimeConfig) -> None:
+        self.enabled = bool(cfg.enable_qwen_vlm)
+        self.endpoint = str(cfg.qwen_endpoint or "").strip()
+        self.primary_model = str(cfg.qwen_primary_model or "").strip()
+        self.fallback_model = str(cfg.qwen_fallback_model or "").strip()
+        self.timeout_s = float(cfg.qwen_timeout_s)
+        self.num_predict = int(cfg.qwen_num_predict)
+        self.num_ctx = int(cfg.qwen_num_ctx)
+        self.temperature = float(cfg.qwen_temperature)
+        self._session = requests.Session()
+
+    def analyze_frame(self, frame: Any) -> Dict[str, Any]:
+        if not self.enabled or not self.endpoint or not self.primary_model:
+            return {"ok": False, "error": "qwen disabled"}
+        image_b64 = self._encode_frame(frame)
+        for model in self._models():
+            result = self._call_model(model=model, image_b64=image_b64)
+            if result.get("ok"):
+                return result
+        return {"ok": False, "error": "qwen request failed"}
+
+    def _models(self) -> List[str]:
+        models = [self.primary_model]
+        if self.fallback_model and self.fallback_model != self.primary_model:
+            models.append(self.fallback_model)
+        return models
+
+    @staticmethod
+    def _encode_frame(frame: Any) -> str:
+        ok, buf = cv2.imencode(".jpg", frame, [int(cv2.IMWRITE_JPEG_QUALITY), 72])
+        if not ok:
+            raise ValueError("frame encode failed")
+        return base64.b64encode(buf.tobytes()).decode("ascii")
+
+    def _call_model(self, model: str, image_b64: str) -> Dict[str, Any]:
+        payload = {
+            "model": model,
+            "stream": False,
+            "format": "json",
+            "options": {
+                "temperature": self.temperature,
+                "num_ctx": self.num_ctx,
+                "num_predict": self.num_predict,
+            },
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a robot vision co-processor. Return strict compact JSON with keys: "
+                        "summary, persona_interpretation, hazards, suggested_focus, confidence. "
+                        "hazards must be an array of short strings."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Analyze the scene for human-robot interaction. "
+                        "Focus on safety, people intent, and immediate actions."
+                    ),
+                    "images": [image_b64],
+                },
+            ],
+        }
+        try:
+            resp = self._session.post(self.endpoint, json=payload, timeout=self.timeout_s)
+            resp.raise_for_status()
+            body = resp.json()
+            content = str(((body.get("message") or {}).get("content")) or "").strip()
+            parsed = self._parse_json_text(content)
+            if not parsed:
+                return {"ok": False, "error": "qwen invalid json", "model": model}
+            return {
+                "ok": True,
+                "model": model,
+                "summary": str(parsed.get("summary", "")).strip(),
+                "persona_interpretation": str(parsed.get("persona_interpretation", "")).strip(),
+                "hazards": parsed.get("hazards", []),
+                "suggested_focus": str(parsed.get("suggested_focus", "")).strip(),
+                "confidence": float(parsed.get("confidence", 0.0) or 0.0),
+            }
+        except Exception as exc:
+            logger.debug("Qwen call failed for %s: %s", model, exc)
+            return {"ok": False, "error": "qwen request error", "model": model}
+
+    @staticmethod
+    def _parse_json_text(content: str) -> Optional[Dict[str, Any]]:
+        text = content.strip()
+        if not text:
+            return None
+        if text.startswith("```"):
+            text = text.strip("`")
+            if text.lower().startswith("json"):
+                text = text[4:].strip()
+        try:
+            data = json.loads(text)
+            return data if isinstance(data, dict) else None
+        except Exception:
+            pass
+        start = text.find("{")
+        end = text.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                data = json.loads(text[start : end + 1])
+                return data if isinstance(data, dict) else None
+            except Exception:
+                return None
+        return None

--- a/tools/remote_multimodal_server/remote_multimodal/server.py
+++ b/tools/remote_multimodal_server/remote_multimodal/server.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, Header, HTTPException
+
+from .config import RuntimeConfig, load_runtime_config
+from .engine import MultiModalEngine
+from .models import AnalyzeRequest, RegisterFaceRequest
+
+logger = logging.getLogger("remote_multimodal_server")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(name)s | %(message)s")
+
+
+def create_app(runtime_cfg: Optional[RuntimeConfig] = None) -> FastAPI:
+    cfg = runtime_cfg or load_runtime_config()
+    engine = MultiModalEngine(cfg)
+    app = FastAPI(title="SentryBOT Remote Multimodal Vision Server", version="0.2.0")
+
+    def _require_auth(token: Optional[str]) -> None:
+        if cfg.auth_token and cfg.auth_token != "changeme" and token != cfg.auth_token:
+            raise HTTPException(status_code=401, detail="invalid auth token")
+
+    @app.get("/healthz")
+    def healthz() -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "auth_enabled": bool(cfg.auth_token and cfg.auth_token != "changeme"),
+            "config": {
+                "runtime_profile": cfg.runtime_profile,
+                "detector_backend": cfg.detector_backend,
+                "yolo_model": cfg.yolo_model,
+                "yolo_conf": cfg.yolo_conf,
+                "yolo_imgsz": cfg.yolo_imgsz,
+                "motion_threshold": cfg.motion_threshold,
+                "scene_change_threshold": cfg.scene_change_threshold,
+                "face_db_path": cfg.face_db_path,
+                "enable_face_recognition": cfg.enable_face_recognition,
+                "enable_age_emotion": cfg.enable_age_emotion,
+                "enable_qwen_vlm": cfg.enable_qwen_vlm,
+                "qwen_endpoint": cfg.qwen_endpoint,
+                "qwen_primary_model": cfg.qwen_primary_model,
+                "qwen_fallback_model": cfg.qwen_fallback_model,
+                "qwen_timeout_s": cfg.qwen_timeout_s,
+                "enable_advanced_caption": cfg.enable_advanced_caption,
+                "advanced_caption_model": cfg.advanced_caption_model,
+            },
+        }
+
+    @app.post("/vision/analyze")
+    def analyze(req: AnalyzeRequest, x_auth_token: Optional[str] = Header(default=None)) -> Dict[str, Any]:
+        _require_auth(x_auth_token)
+        return engine.analyze(req.image_b64)
+
+    @app.post("/vision/register_face")
+    def register_face(req: RegisterFaceRequest, x_auth_token: Optional[str] = Header(default=None)) -> Dict[str, Any]:
+        _require_auth(x_auth_token)
+        name = str(req.name or "").strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="name required")
+        return engine.register_face(name=name, image_b64=req.image_b64)
+
+    return app
+
+
+def run_app() -> None:
+    import uvicorn
+
+    cfg = load_runtime_config()
+    uvicorn.run("app:app", host=cfg.host, port=cfg.port)

--- a/tools/remote_multimodal_server/requirements.txt
+++ b/tools/remote_multimodal_server/requirements.txt
@@ -1,0 +1,14 @@
+fastapi
+uvicorn
+opencv-python
+numpy
+pydantic
+requests
+
+# Optional accelerators (install on powerful remote host):
+# ultralytics           # YOLO object/person detection
+# face_recognition      # face embedding + identity matching
+# deepface              # age / emotion estimation
+# qwen2.5vl / qwen3-vl  # served via Ollama endpoint
+# transformers          # advanced image caption / reasoning backends
+# torch                 # required by many advanced backends

--- a/tools/remote_multimodal_server/server.py
+++ b/tools/remote_multimodal_server/server.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from remote_multimodal.server import create_app, run_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    run_app()


### PR DESCRIPTION
## Summary
- add a modular 	ools/remote_multimodal_server package with runtime config, typed models, backend loading, a Qwen VLM client, and multimodal analysis engine
- expose FastAPI endpoints for health checks, scene analysis, and face registration
- document setup, runtime env vars, and integration expectations in the server README

## Test plan
- [ ] Run pip install -r tools/remote_multimodal_server/requirements.txt
- [ ] Start server with python tools/remote_multimodal_server/server.py
- [ ] Call GET /healthz and verify a healthy response
- [ ] Send a sample image payload to POST /vision/analyze and verify structured output

Made with [Cursor](https://cursor.com)