### PR TITLE
feat: add living vision pipeline to vlm_bridge

### DIFF
--- a/modules/vlm_bridge/api/router.py
+++ b/modules/vlm_bridge/api/router.py
@@ -86,6 +86,25 @@ def get_router(processor: Any, ardu: Optional[Any] = None) -> APIRouter:
             "profiles": profiles,
         }
 
+    @r.get("/profile", tags=["control"], summary="Get realtime latency profile")
+    def get_profile():
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if hasattr(processor, "get_realtime_profile_status"):
+            return processor.get_realtime_profile_status()
+        return {"ok": False, "error": "profile control not available"}
+
+    @r.post("/profile/switch", tags=["control"], summary="Switch realtime latency profile")
+    def switch_profile(body: dict):
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        mode = str((body or {}).get("mode", "")).strip().lower()
+        if not mode:
+            raise HTTPException(status_code=400, detail="mode required")
+        if hasattr(processor, "apply_realtime_profile"):
+            return processor.apply_realtime_profile(mode)
+        return {"ok": False, "error": "profile control not available"}
+
     @r.post("/mode", tags=["control"], summary="Set processing mode and/or mode flags")
     def set_mode(body: dict):
         if not processor:
@@ -256,4 +275,231 @@ def get_router(processor: Any, ardu: Optional[Any] = None) -> APIRouter:
             raise HTTPException(status_code=503, detail="Vision processor not initialized")
         return {"people": processor.memory.list_people()}
 
+    # -----------------------------------------------------------------
+    # Living Vision Agent endpoints
+    # -----------------------------------------------------------------
+
+    @r.get("/context/latest", tags=["vision"], summary="Get latest visual context cache")
+    def get_context_latest():
+        """Return the latest cached VisionFrameContext if available."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        ctx = processor.get_latest_visual_context()
+        if ctx is None:
+            return {"available": False, "context": None, "reason": "No context cached yet"}
+        return {"available": True, "context": ctx}
+
+    @r.post("/context/refresh", tags=["vision"], summary="Refresh visual context (trigger VLM analysis)")
+    def refresh_context():
+        """Trigger a fresh VLM analysis of the current camera frame."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+
+        if hasattr(processor, "refresh_visual_context"):
+            ctx = processor.refresh_visual_context()
+        else:
+            ctx = processor.get_latest_visual_context()
+        return {"ok": True, "context_available": ctx is not None, "context": ctx}
+
+    @r.post("/ask", tags=["vision"], summary="Ask the VLM a question about the current scene")
+    def ask_vlm(body: dict):
+        """Ask the VLM a question about the current camera view."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        
+        question = body.get("question", "").strip()
+        if not question:
+            raise HTTPException(status_code=400, detail="question required")
+        
+        # Try to get current frame first
+        frame = None
+        with processor._frame_lock:
+            if processor._latest_raw_frame is not None:
+                frame = processor._latest_raw_frame.copy()
+        
+        # If no current frame from stream, try one-shot capture
+        if frame is None and not processor._is_http_camera_source():
+            try:
+                import cv2
+                cap = cv2.VideoCapture(processor.camera_source)
+                if cap.isOpened():
+                    ret, frame = cap.read()
+                    cap.release()
+                    if not ret:
+                        frame = None
+            except Exception:
+                pass
+        
+        if frame is None:
+            # Fallback to cached context
+            ctx = processor.get_latest_visual_context()
+            if ctx:
+                return {"ok": True, "answer": ctx.get("persona_interpretation", ctx.get("summary", "Görüntü işlenemedi."))}
+            return {"ok": False, "answer": "Kamera görüntüsü alınamadı."}
+        
+        # Call VLM if available
+        if processor.vlm_client:
+            try:
+                answer = processor.vlm_client.ask_about_scene(frame, question, force=True)
+                if answer:
+                    if hasattr(processor, "refresh_visual_context"):
+                        processor.refresh_visual_context(question=question)
+                    return {"ok": True, "answer": answer}
+            except Exception:
+                pass
+        
+        # Fallback: context interpretation
+        ctx = processor.get_latest_visual_context()
+        if ctx:
+            summary = ctx.get("persona_interpretation", ctx.get("summary", "Cevap alınamadı."))
+            return {"ok": True, "answer": f"Görüntü işleme gecikti; elimdeki son görüntüye göre {summary}"}
+        
+        return {"ok": False, "answer": "VLM sistemi şu an kullanılamıyor."}
+
+    @r.post("/person/remember", tags=["vision"], summary="Remember/store person with relationship")
+    def remember_person(body: dict):
+        """Save or update a person in the identity memory."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if not processor.person_identity:
+            raise HTTPException(status_code=501, detail="Person identity system not available")
+        
+        name = body.get("name", "").strip()
+        relationship = body.get("relationship", "known")
+        recognition_level = body.get("recognition_level", 2)
+        
+        if not name:
+            raise HTTPException(status_code=400, detail="name required")
+        
+        rec = processor.person_identity.remember_person(
+            name, relationship=relationship, recognition_level=int(recognition_level)
+        )
+        return {
+            "ok": True,
+            "person_id": rec.person_id,
+            "name": rec.name,
+            "recognition_level": rec.recognition_level,
+            "relationship": rec.relationship,
+        }
+
+    @r.post("/person/relationship", tags=["vision"], summary="Update person's relationship/recognition level")
+    def update_person_relationship(body: dict):
+        """Update a person's relationship or recognition level."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if not processor.person_identity:
+            raise HTTPException(status_code=501, detail="Person identity system not available")
+        
+        person_id = body.get("person_id", "").strip()
+        name = body.get("name", "").strip()
+        relationship = body.get("relationship", "")
+        recognition_level = body.get("recognition_level", -1)
+        
+        if not person_id and not name:
+            raise HTTPException(status_code=400, detail="person_id or name required")
+        
+        # Support lookup by either person_id or name
+        if name and not person_id:
+            # Try to find by name
+            records = processor.person_identity._records
+            for rec in records.values():
+                if rec.name.lower() == name.lower():
+                    person_id = rec.person_id
+                    break
+        
+        if person_id:
+            rec = processor.person_identity._records.get(person_id)
+            if rec:
+                if relationship:
+                    rec.relationship = relationship
+                if recognition_level >= 0:
+                    rec.recognition_level = min(5, max(0, int(recognition_level)))
+                processor.person_identity._save_unlocked()
+                return {"ok": True, "person_id": rec.person_id, "name": rec.name}
+        
+        return {"ok": False, "error": "person not found"}
+
+    @r.get("/person/{name}", tags=["vision"], summary="Get person memory record by name")
+    def get_person(name: str):
+        """Retrieve a person's memory record."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if not processor.person_identity:
+            raise HTTPException(status_code=501, detail="Person identity system not available")
+        
+        rec = processor.person_identity.recognize(name)
+        if rec is None:
+            return {"ok": False, "error": "person not found"}
+        return {"ok": True, "person": rec.to_dict() if hasattr(rec, "to_dict") else rec}
+
+    @r.get("/people", tags=["vision"], summary="List all remembered people")
+    def list_people():
+        """List all people in the identity memory."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if not processor.person_identity:
+            return {"people": []}
+        
+        people = []
+        for rec in processor.person_identity._records.values():
+            people.append({
+                "person_id": rec.person_id,
+                "name": rec.name,
+                "recognition_level": rec.recognition_level,
+                "relationship": rec.relationship,
+                "seen_count": rec.seen_count,
+                "last_seen": rec.last_seen,
+            })
+        return {"people": people}
+
+    @r.post("/focus/person", tags=["vision"], summary="Focus head on specific person")
+    def focus_person(body: dict):
+        """Request the robot to look at a specific person."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        
+        name = body.get("name", "").strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="name required")
+        
+        if hasattr(processor, "latest_results"):
+            for item in list(getattr(processor, "latest_results", []) or []):
+                if str(item.get("name", "")).strip().lower() == name.lower():
+                    bbox = item.get("bbox") or []
+                    if len(bbox) == 4:
+                        try:
+                            x1, y1, x2, y2 = [int(v) for v in bbox]
+                            cx = int((x1 + x2) / 2)
+                            cy = int((y1 + y2) / 2)
+                            pan = max(35, min(145, int(90 + ((cx - 320) / 320) * 45)))
+                            tilt = max(65, min(125, int(90 + ((cy - 240) / 240) * 30)))
+                            if hasattr(processor, "head_arbiter") and processor.head_arbiter is not None:
+                                from modules.vlm_bridge.services.head_control_arbiter import HeadCommand
+                                result = processor.head_arbiter.request_move(
+                                    HeadCommand(pan=float(pan), tilt=float(tilt), source="agent_core", priority=65, ttl_s=1.0)
+                                )
+                                return {"ok": bool(result.get("ok")), "focus_target": name, "head": result}
+                            processor._send_track(pan=pan, tilt=tilt, drive=0)
+                            return {"ok": True, "focus_target": name, "pan": pan, "tilt": tilt}
+                        except Exception:
+                            pass
+        return {"ok": False, "error": "person_not_visible", "focus_target": name}
+
+    @r.post("/follow/owner/start", tags=["vision"], summary="Start owner follow mode")
+    def owner_follow_start():
+        """Enable owner-specific follow mode (higher priority)."""
+        if not processor:
+            raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        
+        result = processor.start_follow(person="owner")
+        return result if isinstance(result, dict) else {"ok": True}
+
+    @r.get("/head/status", tags=["vision"], summary="Get current head (pan/tilt) position")
+    def head_status():
+        """Return the current head servo position."""
+        if processor and hasattr(processor, "head_arbiter") and processor.head_arbiter is not None:
+            return processor.head_arbiter.get_status()
+        return {"pan": 90, "tilt": 90}
+
     return r
+

--- a/modules/vlm_bridge/config/config.yml
+++ b/modules/vlm_bridge/config/config.yml
@@ -49,9 +49,45 @@ vision:
     heartbeat_interval_s: 30
     idle_lookaround_s: 60
 
+# Visual context caching
+visual_context:
+  enabled: true
+  cache_history_size: 5
+  importance_threshold: 0.3  # Only speak about contexts with importance >= this
+
+# Living Vision Agent configuration
+vision_llm:
+  enabled: true
+  base_url: "http://REMOTE_OLLAMA:11434"  # Remote Ollama HTTP API
+  model: "qwen3-vl:8b"                    # Q4 quantized, ~5GB VRAM on 24GB GPU
+  timeout_s: 18
+  max_image_width: 640
+  jpeg_quality: 70
+  min_interval_s: 4
+  active_question_timeout_s: 15
+  num_predict: 256                         # JSON çıktı için yeterli, hız kazancı
+  num_ctx: 2048                            # VLM context (image tokens dominate)
+
+person_identity:
+  store_path: "modules/vlm_bridge/data/person_identity.json"
+  recognition_levels:
+    0: "unknown"
+    1: "seen_before"
+    2: "familiar"
+    3: "friend"
+    4: "family"
+    5: "owner"
+  owner_name: ""  # Will be set by remember_person tool
+
 remote:
   auth_token: "changeme"  # Set a secure token in production or override
   accept_results: true     # Allow POST /vlm/results ingestion
+
+remote_multimodal:
+  enabled: false
+  endpoint: "http://PC_IP:8091/vision/analyze"
+  timeout_s: 6.0
+  auth_token: "changeme"
 
 robot:
   host: "localhost"  # Change to Robot IP when running remotely
@@ -59,8 +95,8 @@ robot:
 ollama:
   endpoint: "http://localhost:8080/ollama/chat"
   model: "qwen3.5:9b"
-  timeout: 12.0
-  num_predict: 160
+  timeout: 10.0
+  num_predict: 100
 
 llm:
   provider: "ollama"                 # ollama | google_ai_studio

--- a/modules/vlm_bridge/config_loader.py
+++ b/modules/vlm_bridge/config_loader.py
@@ -9,7 +9,7 @@ from modules.config_center.agent_yaml_loader import deep_merge, load_agent_confi
 DEFAULT_CONFIG: Dict[str, Any] = {
     "server": {"host": "0.0.0.0", "port": 8101},
     "vision": {
-        "processing_mode": "local",  # local | remote
+        "processing_mode": "remote",  # local | remote (remote-first default)
         "camera_source": "http://127.0.0.1:8080/camera/video",
         "blind_mode": {"enabled": False, "interval_seconds": 5.0},
         "confidence_threshold": 0.5,

--- a/modules/vlm_bridge/services/head_control_arbiter.py
+++ b/modules/vlm_bridge/services/head_control_arbiter.py
@@ -1,0 +1,159 @@
+"""Head control arbiter for SentryBOT.
+
+All pan/tilt requests go through this arbiter which enforces:
+* Priority ordering (safety > owner > speaker > agent > idle)
+* Servo clamping (safe range)
+* Rate limiting (max N commands/s)
+* Deadband (suppress tiny movements)
+* Smooth interpolation
+* Source locking (e.g. owner follow lock)
+* Duplicate suppression
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger("vlm_bridge.head_arbiter")
+
+
+@dataclass
+class HeadCommand:
+    pan: float
+    tilt: float
+    source: str = "autonomy"
+    priority: int = 30
+    ttl_s: float = 2.0
+    created_at: float = 0.0
+
+    def __post_init__(self):
+        if self.created_at <= 0:
+            self.created_at = time.time()
+
+    @property
+    def expired(self) -> bool:
+        return time.time() > self.created_at + self.ttl_s
+
+
+_SOURCE_PRIORITY = {
+    "manual": 100, "safety": 95, "owner_follow": 85,
+    "active_speaker": 75, "agent_core": 65, "vlm_interest": 50,
+    "autonomy": 30, "idle": 20,
+}
+
+
+class HeadControlArbiter:
+    """Thread-safe head movement arbiter with priority and clamping."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        cfg = config or {}
+        follow_cfg = cfg.get("follow", cfg)
+
+        self.min_pan = float(follow_cfg.get("min_pan", 35))
+        self.max_pan = float(follow_cfg.get("max_pan", 145))
+        self.min_tilt = float(follow_cfg.get("min_tilt", 65))
+        self.max_tilt = float(follow_cfg.get("max_tilt", 125))
+        self.center_pan = float(follow_cfg.get("center_pan", 90))
+        self.center_tilt = float(follow_cfg.get("center_tilt", 90))
+        self.deadband_deg = float(follow_cfg.get("deadband_deg", 2.0))
+        self.smooth_alpha = float(follow_cfg.get("smooth_alpha", 0.5))
+        self.max_rate_hz = float(follow_cfg.get("max_rate_hz", 10.0))
+
+        self._lock = threading.Lock()
+        self._current_pan = self.center_pan
+        self._current_tilt = self.center_tilt
+        self._last_cmd_time: float = 0.0
+        self._last_pan_sent: float = self.center_pan
+        self._last_tilt_sent: float = self.center_tilt
+        self._source_lock: Optional[str] = None
+        self._source_lock_until: float = 0.0
+        self._move_fn: Optional[Callable] = None
+
+    def set_move_callback(self, fn: Callable) -> None:
+        self._move_fn = fn
+
+    def request_move(self, cmd: HeadCommand) -> Dict[str, Any]:
+        with self._lock:
+            return self._evaluate(cmd)
+
+    def move(self, pan: float, tilt: float, source: str = "autonomy", priority: int = 30) -> Dict[str, Any]:
+        return self.request_move(HeadCommand(pan=pan, tilt=tilt, source=source, priority=priority))
+
+    def lock_source(self, source: str, duration_s: float = 30.0) -> None:
+        with self._lock:
+            self._source_lock = source
+            self._source_lock_until = time.time() + duration_s
+
+    def unlock(self) -> None:
+        with self._lock:
+            self._source_lock = None
+            self._source_lock_until = 0.0
+
+    @property
+    def current_position(self) -> Dict[str, float]:
+        with self._lock:
+            return {"pan": self._current_pan, "tilt": self._current_tilt}
+
+    def get_status(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "pan": self._current_pan, "tilt": self._current_tilt,
+                "source_lock": self._source_lock,
+                "lock_remaining_s": max(0, self._source_lock_until - time.time()),
+            }
+
+    def _evaluate(self, cmd: HeadCommand) -> Dict[str, Any]:
+        now = time.time()
+        if cmd.expired:
+            return {"ok": False, "reason": "expired"}
+
+        # Source lock check
+        if self._source_lock and self._source_lock_until > now:
+            locked_pri = _SOURCE_PRIORITY.get(self._source_lock, 0)
+            cmd_pri = cmd.priority or _SOURCE_PRIORITY.get(cmd.source, 0)
+            if cmd_pri < locked_pri and cmd.source != self._source_lock:
+                return {"ok": False, "reason": "source_locked", "locked_by": self._source_lock}
+        elif self._source_lock and self._source_lock_until <= now:
+            self._source_lock = None
+
+        # Rate limit
+        min_interval = 1.0 / max(1, self.max_rate_hz)
+        if now - self._last_cmd_time < min_interval:
+            return {"ok": False, "reason": "rate_limited"}
+
+        # Clamp
+        pan = max(self.min_pan, min(self.max_pan, cmd.pan))
+        tilt = max(self.min_tilt, min(self.max_tilt, cmd.tilt))
+
+        # Deadband
+        if (abs(pan - self._last_pan_sent) < self.deadband_deg and
+                abs(tilt - self._last_tilt_sent) < self.deadband_deg):
+            return {"ok": False, "reason": "deadband"}
+
+        # Smooth interpolation
+        pan = self._current_pan * self.smooth_alpha + pan * (1 - self.smooth_alpha)
+        tilt = self._current_tilt * self.smooth_alpha + tilt * (1 - self.smooth_alpha)
+        pan = max(self.min_pan, min(self.max_pan, round(pan, 1)))
+        tilt = max(self.min_tilt, min(self.max_tilt, round(tilt, 1)))
+
+        # Execute
+        self._current_pan = pan
+        self._current_tilt = tilt
+        self._last_pan_sent = pan
+        self._last_tilt_sent = tilt
+        self._last_cmd_time = now
+
+        if self._move_fn:
+            try:
+                self._move_fn(pan, tilt)
+            except Exception as exc:
+                logger.warning("Head move callback failed: %s", exc)
+                return {"ok": False, "reason": "move_error", "error": str(exc)}
+
+        return {"ok": True, "pan": pan, "tilt": tilt}
+
+__all__ = ["HeadControlArbiter", "HeadCommand"]

--- a/modules/vlm_bridge/services/llm_client.py
+++ b/modules/vlm_bridge/services/llm_client.py
@@ -180,7 +180,7 @@ def generate_text(
 
             if _is_direct_ollama_chat_endpoint(endpoint):
                 model = str((ollama_cfg or {}).get("model", "qwen3.5:9b")).strip() or "qwen3.5:9b"
-                num_predict = int((ollama_cfg or {}).get("num_predict", 160) or 160)
+                num_predict = int((ollama_cfg or {}).get("num_predict", 100) or 100)
                 resp = client.post(
                     endpoint,
                     json={

--- a/modules/vlm_bridge/services/ollama_vlm_client.py
+++ b/modules/vlm_bridge/services/ollama_vlm_client.py
@@ -1,0 +1,318 @@
+"""Remote Ollama VLM client for SentryBOT.
+
+Sends camera frames to a remote Ollama instance running a vision-language
+model (e.g. ``qwen3-vl:8b``) and parses structured scene observations.
+
+Design constraints:
+* RPi5 only does local OpenCV; heavy VLM runs on a remote GPU server.
+* We cannot install extra services on the remote — only Ollama HTTP API.
+* Network traffic must be controlled: frames are resized + JPEG compressed
+  before sending, and a minimum interval prevents request flooding.
+* At most one in-flight VLM request at a time.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+import re
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("vlm_bridge.ollama_vlm")
+
+# ── Defaults ──────────────────────────────────────────────────────────
+_DEFAULT_BASE_URL = "http://127.0.0.1:11434"
+_DEFAULT_MODEL = "qwen3-vl:8b"
+_DEFAULT_TIMEOUT = 30.0
+_DEFAULT_MAX_WIDTH = 640
+_DEFAULT_JPEG_QUALITY = 70
+_DEFAULT_MIN_INTERVAL = 5.0
+
+
+def _resize_and_encode(
+    frame,
+    max_width: int = _DEFAULT_MAX_WIDTH,
+    jpeg_quality: int = _DEFAULT_JPEG_QUALITY,
+) -> str:
+    """Resize an OpenCV frame and return a base64-encoded JPEG string."""
+    try:
+        import cv2
+        import numpy as np
+    except ImportError:
+        raise RuntimeError("OpenCV (cv2) is required for frame encoding")
+
+    if frame is None or not isinstance(frame, np.ndarray):
+        raise ValueError("Invalid frame")
+
+    h, w = frame.shape[:2]
+    if w > max_width:
+        scale = max_width / w
+        new_w = max_width
+        new_h = int(h * scale)
+        frame = cv2.resize(frame, (new_w, new_h), interpolation=cv2.INTER_AREA)
+
+    ok, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality])
+    if not ok:
+        raise RuntimeError("JPEG encoding failed")
+
+    return base64.b64encode(buf.tobytes()).decode("ascii")
+
+
+def _parse_vlm_json(text: str) -> Dict[str, Any]:
+    """Best-effort JSON extraction from VLM output.
+
+    The model may wrap JSON in markdown fences or mix prose with JSON.
+    We try several strategies before falling back to a text-only result.
+    """
+    text = text.strip()
+    raw_text = text
+
+    # Strategy 1: direct JSON parse
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            parsed.setdefault("raw_text", raw_text)
+            return parsed
+        return {"raw_text": raw_text, "value": parsed}
+    except Exception:
+        pass
+
+    # Strategy 2: extract from markdown code fences
+    fence_match = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+    if fence_match:
+        try:
+            parsed = json.loads(fence_match.group(1).strip())
+            if isinstance(parsed, dict):
+                parsed.setdefault("raw_text", raw_text)
+                return parsed
+            return {"raw_text": raw_text, "value": parsed}
+        except Exception:
+            pass
+
+    # Strategy 3: find first { ... } block
+    brace_match = re.search(r"\{.*\}", text, re.DOTALL)
+    if brace_match:
+        try:
+            parsed = json.loads(brace_match.group(0))
+            if isinstance(parsed, dict):
+                parsed.setdefault("raw_text", raw_text)
+                return parsed
+            return {"raw_text": raw_text, "value": parsed}
+        except Exception:
+            pass
+
+    # Strategy 4: regex key-value extraction
+    result: Dict[str, Any] = {"raw_text": raw_text}
+    for pattern in [
+        r'"(\w+)"\s*:\s*"([^"]*)"',
+        r'"(\w+)"\s*:\s*(\[[^\]]*\])',
+        r'"(\w+)"\s*:\s*(\d+(?:\.\d+)?)',
+    ]:
+        for m in re.finditer(pattern, text):
+            key = m.group(1)
+            val = m.group(2)
+            try:
+                result[key] = json.loads(val)
+            except Exception:
+                result[key] = val
+
+    return result
+
+
+# ── VLM scene analysis prompt ────────────────────────────────────────
+_SCENE_PROMPT_TR = (
+    "Sen bir robotun göz sistemisin. Kameranın gördüğü sahneyi analiz et.\n"
+    "JSON formatında yanıt ver. Şu alanları doldur:\n"
+    "{\n"
+    '  "summary": "Sahnenin kısa Türkçe özeti (2-3 cümle)",\n'
+    '  "objects": [{"label": "nesne adı", "distance_m": tahmini_mesafe}],\n'
+    '  "people": [{"name": "bilinmiyorsa Unknown", "appearance": "kısa açıklama", "distance_m": tahmini}],\n'
+    '  "hazards": [{"type": "tehlike türü", "severity": "low|medium|high", "distance_m": tahmini}],\n'
+    '  "interesting": ["dikkat çekici detaylar"],\n'
+    '  "recommended_focus": {"type": "person|object|hazard", "reason": "neden odaklanmalı"}\n'
+    "}\n"
+    "Sadece JSON döndür, başka açıklama ekleme. Türkçe yaz."
+)
+
+_QUESTION_PROMPT_TR = (
+    "Sen bir robotun göz sistemisin. Kameranın gördüğü sahneyi analiz et "
+    "ve şu soruyu yanıtla:\n\n"
+    "Soru: {question}\n\n"
+    "Türkçe, doğal ve kısa yanıt ver. Görmediğin şeyi tahmin etme, "
+    "\"göremiyorum\" de."
+)
+
+
+class OllamaVLMClient:
+    """HTTP client for remote Ollama VLM inference.
+
+    Thread-safe; enforces at most one in-flight request.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        cfg = config or {}
+        self.base_url = str(cfg.get("base_url", _DEFAULT_BASE_URL)).rstrip("/")
+        self.model = str(cfg.get("model", _DEFAULT_MODEL))
+        self.timeout = float(cfg.get("timeout_s", _DEFAULT_TIMEOUT))
+        self.max_image_width = int(cfg.get("max_image_width", _DEFAULT_MAX_WIDTH))
+        self.jpeg_quality = int(cfg.get("jpeg_quality", _DEFAULT_JPEG_QUALITY))
+        self.min_interval_s = float(cfg.get("min_interval_s", _DEFAULT_MIN_INTERVAL))
+        self.num_predict = int(cfg.get("num_predict", 256))
+        self.num_ctx = int(cfg.get("num_ctx", 2048))
+
+        self._lock = threading.Lock()
+        self._in_flight = False
+        self._last_call: float = 0.0
+        self._call_count: int = 0
+        self._error_count: int = 0
+
+    # ── Public API ────────────────────────────────────────────────────
+
+    def analyze_frame(
+        self,
+        frame,
+        *,
+        custom_prompt: str = "",
+        force: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Send a frame to the remote VLM for scene analysis.
+
+        Args:
+            frame: OpenCV numpy array (BGR).
+            custom_prompt: Override the default scene analysis prompt.
+            force: Bypass minimum interval check.
+
+        Returns:
+            Parsed JSON dict, or None if rate-limited / error.
+        """
+        now = time.time()
+
+        with self._lock:
+            if self._in_flight:
+                logger.debug("VLM call skipped: request already in flight")
+                return None
+            if not force and (now - self._last_call) < self.min_interval_s:
+                logger.debug("VLM call skipped: rate limit (%.1fs remaining)",
+                             self.min_interval_s - (now - self._last_call))
+                return None
+            self._in_flight = True
+            self._last_call = now
+
+        try:
+            image_b64 = _resize_and_encode(
+                frame,
+                max_width=self.max_image_width,
+                jpeg_quality=self.jpeg_quality,
+            )
+        except Exception as exc:
+            logger.warning("Frame encoding failed: %s", exc)
+            with self._lock:
+                self._in_flight = False
+            return None
+
+        prompt = custom_prompt or _SCENE_PROMPT_TR
+        start = time.time()
+
+        try:
+            result = self._call_ollama(prompt, image_b64)
+            latency = (time.time() - start) * 1000
+            if result:
+                result["_latency_ms"] = round(latency, 1)
+                self._call_count += 1
+                logger.info("VLM analysis completed in %.0fms", latency)
+            return result
+        except Exception as exc:
+            self._error_count += 1
+            logger.warning("VLM analysis failed: %s", exc)
+            return None
+        finally:
+            with self._lock:
+                self._in_flight = False
+
+    def ask_about_scene(
+        self,
+        frame,
+        question: str,
+        force: bool = True,
+    ) -> Optional[str]:
+        """Ask a specific question about what the camera sees.
+
+        Returns natural language answer string.
+        """
+        prompt = _QUESTION_PROMPT_TR.format(question=question)
+        result = self.analyze_frame(frame, custom_prompt=prompt, force=force)
+        if result is None:
+            return None
+        # For question mode, we expect raw text not JSON
+        return result.get("raw_text") or result.get("summary") or str(result)
+
+    def is_available(self) -> bool:
+        """Quick health check against the remote Ollama server."""
+        try:
+            import requests
+            resp = requests.get(f"{self.base_url}/api/tags", timeout=3.0)
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {
+            "base_url": self.base_url,
+            "model": self.model,
+            "call_count": self._call_count,
+            "error_count": self._error_count,
+            "in_flight": self._in_flight,
+            "last_call_age_s": round(time.time() - self._last_call, 1) if self._last_call else None,
+        }
+
+    # ── Internal ──────────────────────────────────────────────────────
+
+    def _call_ollama(self, prompt: str, image_b64: str) -> Optional[Dict[str, Any]]:
+        """Make the actual HTTP request to Ollama /api/chat."""
+        import requests
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": prompt,
+                    "images": [image_b64],
+                }
+            ],
+            "stream": False,
+            "options": {
+                "temperature": 0.3,
+                "num_predict": self.num_predict,
+                "num_ctx": self.num_ctx,
+            },
+        }
+
+        resp = requests.post(
+            f"{self.base_url}/api/chat",
+            json=payload,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Extract text content
+        content = ""
+        if isinstance(data, dict):
+            msg = data.get("message", {})
+            if isinstance(msg, dict):
+                content = str(msg.get("content", ""))
+            elif isinstance(data.get("response"), str):
+                content = data["response"]
+
+        if not content:
+            return None
+
+        return _parse_vlm_json(content)
+
+
+__all__ = ["OllamaVLMClient"]

--- a/modules/vlm_bridge/services/person_identity.py
+++ b/modules/vlm_bridge/services/person_identity.py
@@ -1,0 +1,280 @@
+"""Extended person identity and memory for SentryBOT.
+
+Wraps existing PeopleMemory and FaceManager with recognition levels (0-5),
+relationship tracking, and persistent JSON storage.
+
+Recognition levels:
+  0 = unknown
+  1 = seen before (low confidence)
+  2 = familiar / recurring
+  3 = friend
+  4 = family / inner circle
+  5 = owner
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("vlm_bridge.person_identity")
+
+_DEFAULT_STORE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "data", "person_identity.json"
+)
+
+RECOGNITION_LABELS = {
+    0: "unknown",
+    1: "seen_before",
+    2: "familiar",
+    3: "friend",
+    4: "family",
+    5: "owner",
+}
+
+RELATIONSHIP_TYPES = frozenset({
+    "owner", "family", "friend", "known", "stranger", "unknown",
+})
+
+
+@dataclass
+class PersonMemoryRecord:
+    person_id: str = field(default_factory=lambda: uuid.uuid4().hex[:10])
+    name: str = "Unknown"
+    recognition_level: int = 0
+    relationship: str = "unknown"
+    face_descriptors: List[Dict[str, Any]] = field(default_factory=list)
+    appearance_notes: List[str] = field(default_factory=list)
+    voice_notes: List[str] = field(default_factory=list)
+    conversation_notes: List[str] = field(default_factory=list)
+    last_seen: str = ""
+    first_seen: str = ""
+    seen_count: int = 0
+    trust_score: float = 0.0
+    owner_priority: bool = False
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "PersonMemoryRecord":
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in d.items() if k in known}
+        return cls(**filtered)
+
+
+class PersonIdentityManager:
+    """Manages person recognition, relationship levels, and persistence.
+
+    Thread-safe. Wraps existing FaceManager/PeopleMemory without breaking them.
+    """
+
+    def __init__(
+        self,
+        store_path: str = "",
+        face_manager: Optional[Any] = None,
+        people_memory: Optional[Any] = None,
+    ) -> None:
+        self._store_path = store_path or _DEFAULT_STORE
+        self._face_manager = face_manager
+        self._people_memory = people_memory
+        self._lock = threading.Lock()
+        self._records: Dict[str, PersonMemoryRecord] = {}
+        self._name_index: Dict[str, str] = {}  # name.lower() -> person_id
+        self._load()
+
+    # ── Public API ────────────────────────────────────────────────────
+
+    def recognize(
+        self, name: str, confidence: float = 0.0, face_score: float = 0.0,
+    ) -> PersonMemoryRecord:
+        """Look up or create a person record by name."""
+        with self._lock:
+            name_key = name.strip().lower() if name else "unknown"
+            pid = self._name_index.get(name_key)
+            if pid and pid in self._records:
+                rec = self._records[pid]
+                rec.seen_count += 1
+                rec.last_seen = time.strftime("%Y-%m-%dT%H:%M:%S")
+                if confidence > 0:
+                    rec.trust_score = min(1.0, rec.trust_score * 0.9 + confidence * 0.1)
+                if face_score > 0:
+                    rec.face_descriptors.append({
+                        "score": float(face_score),
+                        "ts": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    })
+                    if len(rec.face_descriptors) > 50:
+                        rec.face_descriptors = rec.face_descriptors[-50:]
+                self._auto_upgrade_level(rec)
+                self._save_unlocked()
+                return rec
+
+            # New person
+            rec = PersonMemoryRecord(
+                name=name.strip() if name else "Unknown",
+                recognition_level=0,
+                relationship="unknown",
+                first_seen=time.strftime("%Y-%m-%dT%H:%M:%S"),
+                last_seen=time.strftime("%Y-%m-%dT%H:%M:%S"),
+                seen_count=1,
+                trust_score=min(1.0, confidence),
+            )
+            self._records[rec.person_id] = rec
+            if name_key != "unknown":
+                self._name_index[name_key] = rec.person_id
+            self._save_unlocked()
+            return rec
+
+    def remember_person(
+        self, name: str, relationship: str = "", recognition_level: int = -1,
+    ) -> PersonMemoryRecord:
+        """Store or update a person's relationship and level."""
+        with self._lock:
+            name_key = name.strip().lower()
+            pid = self._name_index.get(name_key)
+            if pid and pid in self._records:
+                rec = self._records[pid]
+            else:
+                rec = PersonMemoryRecord(
+                    name=name.strip(),
+                    first_seen=time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    last_seen=time.strftime("%Y-%m-%dT%H:%M:%S"),
+                )
+                self._records[rec.person_id] = rec
+                self._name_index[name_key] = rec.person_id
+
+            if relationship and relationship in RELATIONSHIP_TYPES:
+                rec.relationship = relationship
+            if recognition_level >= 0:
+                rec.recognition_level = max(0, min(5, recognition_level))
+            if rec.recognition_level >= 5:
+                rec.owner_priority = True
+                rec.relationship = "owner"
+
+            self._save_unlocked()
+            return rec
+
+    def update_relationship(
+        self, person_id: str, relationship: str = "", recognition_level: int = -1,
+    ) -> Optional[PersonMemoryRecord]:
+        with self._lock:
+            rec = self._records.get(person_id)
+            if not rec:
+                return None
+            if relationship and relationship in RELATIONSHIP_TYPES:
+                rec.relationship = relationship
+            if recognition_level >= 0:
+                rec.recognition_level = max(0, min(5, recognition_level))
+            if rec.recognition_level >= 5:
+                rec.owner_priority = True
+                rec.relationship = "owner"
+            self._save_unlocked()
+            return rec
+
+    def append_conversation_note(self, person_id: str, text: str) -> bool:
+        with self._lock:
+            rec = self._records.get(person_id)
+            if not rec:
+                return False
+            line = str(text or "").strip()
+            if not line:
+                return False
+            rec.conversation_notes.append(line)
+            if len(rec.conversation_notes) > 100:
+                rec.conversation_notes = rec.conversation_notes[-100:]
+            self._save_unlocked()
+            return True
+
+    def set_owner(self, name: str) -> PersonMemoryRecord:
+        """Manually assign owner status to a person."""
+        return self.remember_person(name, relationship="owner", recognition_level=5)
+
+    def get_person(self, name: str) -> Optional[PersonMemoryRecord]:
+        with self._lock:
+            pid = self._name_index.get(name.strip().lower())
+            if pid:
+                return self._records.get(pid)
+            return None
+
+    def get_by_id(self, person_id: str) -> Optional[PersonMemoryRecord]:
+        with self._lock:
+            return self._records.get(person_id)
+
+    def list_people(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [r.to_dict() for r in self._records.values()]
+
+    def get_owner(self) -> Optional[PersonMemoryRecord]:
+        with self._lock:
+            for rec in self._records.values():
+                if rec.owner_priority or rec.recognition_level >= 5:
+                    return rec
+            return None
+
+    def is_owner(self, name: str) -> bool:
+        rec = self.get_person(name)
+        return rec is not None and rec.recognition_level >= 5
+
+    def add_note(self, name: str, note: str, category: str = "appearance") -> None:
+        with self._lock:
+            pid = self._name_index.get(name.strip().lower())
+            rec = self._records.get(pid) if pid else None
+            if not rec:
+                return
+            target = getattr(rec, f"{category}_notes", None)
+            if isinstance(target, list):
+                target.append(note)
+                if len(target) > 20:
+                    target[:] = target[-20:]
+            self._save_unlocked()
+
+    # ── Internal ──────────────────────────────────────────────────────
+
+    def _auto_upgrade_level(self, rec: PersonMemoryRecord) -> None:
+        """Auto-promote recognition level based on seen_count."""
+        if rec.recognition_level >= 5:
+            return
+        if rec.seen_count >= 50 and rec.recognition_level < 2:
+            rec.recognition_level = 2
+        elif rec.seen_count >= 10 and rec.recognition_level < 1:
+            rec.recognition_level = 1
+
+    def _load(self) -> None:
+        try:
+            if os.path.exists(self._store_path):
+                with open(self._store_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    for pid, d in data.items():
+                        if isinstance(d, dict):
+                            rec = PersonMemoryRecord.from_dict(d)
+                            rec.person_id = pid
+                            self._records[pid] = rec
+                            name_key = rec.name.strip().lower()
+                            if name_key and name_key != "unknown":
+                                self._name_index[name_key] = pid
+                logger.info("Loaded %d person records from %s", len(self._records), self._store_path)
+        except Exception as exc:
+            logger.warning("Failed to load person identity store: %s", exc)
+
+    def _save_unlocked(self) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._store_path), exist_ok=True)
+            data = {pid: r.to_dict() for pid, r in self._records.items()}
+            with open(self._store_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+        except Exception as exc:
+            logger.warning("Failed to save person identity store: %s", exc)
+
+    def save(self) -> None:
+        with self._lock:
+            self._save_unlocked()
+
+__all__ = ["PersonIdentityManager", "PersonMemoryRecord", "RECOGNITION_LABELS"]

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -4,6 +4,8 @@ import logging
 import os
 import threading
 import time
+import base64
+from datetime import datetime
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
 
 import cv2
@@ -41,6 +43,50 @@ try:
     from .llm_client import generate_text
 except Exception:
     from modules.vlm_bridge.services.llm_client import generate_text  # type: ignore
+
+try:
+    from .person_identity import PersonIdentityManager
+except Exception:
+    try:
+        from modules.vlm_bridge.services.person_identity import PersonIdentityManager
+    except Exception:
+        PersonIdentityManager = None  # type: ignore
+
+try:
+    from .visual_context import VisionFrameContext, VisualContextCache
+except Exception:
+    try:
+        from modules.vlm_bridge.services.visual_context import VisionFrameContext, VisualContextCache
+    except Exception:
+        VisionFrameContext = None  # type: ignore
+        VisualContextCache = None  # type: ignore
+
+try:
+    from .ollama_vlm_client import OllamaVLMClient
+except Exception:
+    try:
+        from modules.vlm_bridge.services.ollama_vlm_client import OllamaVLMClient
+    except Exception:
+        OllamaVLMClient = None  # type: ignore
+
+try:
+    from .vision_sampler import VisionSampler
+except Exception:
+    VisionSampler = None  # type: ignore
+
+try:
+    from .vision_event_bus import VisionEventBus, EVENT_HAZARD_DETECTED, EVENT_NEW_PERSON, EVENT_OWNER_SEEN
+except Exception:
+    VisionEventBus = None  # type: ignore
+    EVENT_HAZARD_DETECTED = "hazard_detected"
+    EVENT_NEW_PERSON = "new_person"
+    EVENT_OWNER_SEEN = "owner_seen"
+
+try:
+    from .head_control_arbiter import HeadControlArbiter, HeadCommand
+except Exception:
+    HeadControlArbiter = None  # type: ignore
+    HeadCommand = None  # type: ignore
 
 
 logger = logging.getLogger("vlm_bridge")
@@ -189,16 +235,75 @@ class VisionProcessor:
         self.semantic = SemanticDescriber(config)
         self.memory = PeopleMemory()
 
+        # Living Vision Agent components
+        if PersonIdentityManager is not None:
+            person_data_path = vision_cfg.get("person_identity_store", "")
+            self.person_identity = PersonIdentityManager(
+                store_path=person_data_path,
+                face_manager=self.face_manager,
+                people_memory=self.memory,
+            )
+        else:
+            self.person_identity = None
+            logger.warning("PersonIdentityManager not available")
+
+        if VisualContextCache is not None:
+            self.visual_context_cache = VisualContextCache()
+        else:
+            self.visual_context_cache = None
+            logger.warning("VisualContextCache not available")
+
+        # Remote VLM client (Ollama)
+        vlm_cfg = config.get("vision_llm", {}) if isinstance(config.get("vision_llm", {}), dict) else {}
+        if vlm_cfg.get("enabled", True) and OllamaVLMClient is not None:
+            try:
+                self.vlm_client = OllamaVLMClient(vlm_cfg)
+                logger.info("[vlm_bridge] Remote VLM client initialized: %s", vlm_cfg.get("model", "unknown"))
+            except Exception as exc:
+                logger.warning("VLM client init failed: %s", exc)
+                self.vlm_client = None
+        else:
+            self.vlm_client = None
+            logger.info("[vlm_bridge] Remote VLM client disabled or unavailable")
+
+        mm_cfg = config.get("remote_multimodal", {}) if isinstance(config.get("remote_multimodal", {}), dict) else {}
+        self.remote_mm_enabled = bool(mm_cfg.get("enabled", False))
+        self.remote_mm_endpoint = str(mm_cfg.get("endpoint", "http://127.0.0.1:8091/vision/analyze")).strip()
+        self.remote_mm_timeout_s = float(mm_cfg.get("timeout_s", 6.0))
+        self.remote_mm_auth_token = str(mm_cfg.get("auth_token", "")).strip()
+
         actions_cfg = config.get("actions", {}) if isinstance(config, dict) else {}
         endpoint = str(actions_cfg.get("endpoint", "http://localhost:8080/autonomy/apply_actions"))
         timeout = float(actions_cfg.get("timeout", 1.5))
         enabled = bool(actions_cfg.get("default_apply", False))
         self.action_dispatcher = VisionActionDispatcher(endpoint=endpoint, timeout=timeout, enabled=enabled)
+        self.vision_sampler = VisionSampler(vlm_cfg) if VisionSampler is not None else None
+        self.event_bus = VisionEventBus() if VisionEventBus is not None else None
+        self.head_arbiter = HeadControlArbiter(self._follow_cfg) if HeadControlArbiter is not None else None
+        if self.head_arbiter is not None:
+            self.head_arbiter.set_move_callback(lambda pan, tilt: self._send_track(int(pan), int(tilt), 0))
 
         if self.processing_mode == "local":
             logger.info("[vlm_bridge] Local mode: OpenCV face recognition + CSRT tracking active")
         else:
             logger.info("[vlm_bridge] Remote mode: waiting for /vlm/results payloads")
+
+        # Runtime realtime profiles for VLM bridge latency tuning.
+        self._realtime_profiles: Dict[str, Dict[str, Any]] = {
+            "fast": {
+                "vlm_timeout_s": 14.0,
+                "vlm_min_interval_s": 4.0,
+                "vlm_num_predict": 220,
+                "follow_track_interval_s": 0.10,
+            },
+            "normal": {
+                "vlm_timeout_s": 20.0,
+                "vlm_min_interval_s": 5.0,
+                "vlm_num_predict": 320,
+                "follow_track_interval_s": 0.12,
+            },
+        }
+        self._active_realtime_profile = "fast"
 
     def get_modes(self) -> Dict[str, bool]:
         return dict(self.mode_flags)
@@ -237,6 +342,45 @@ class VisionProcessor:
         self.processing_mode = "local"
         self.start_stream_processing()
         return {"ok": True, "processing_mode": self.processing_mode}
+
+    def get_realtime_profile_status(self) -> Dict[str, Any]:
+        active = self._active_realtime_profile
+        return {
+            "ok": True,
+            "active": active,
+            "profiles": sorted(self._realtime_profiles.keys()),
+            "settings": dict(self._realtime_profiles.get(active, {})),
+        }
+
+    def apply_realtime_profile(self, mode: str) -> Dict[str, Any]:
+        key = str(mode or "").strip().lower()
+        profile = self._realtime_profiles.get(key)
+        if not profile:
+            return {
+                "ok": False,
+                "error": "unknown_profile",
+                "profiles": sorted(self._realtime_profiles.keys()),
+            }
+
+        self._active_realtime_profile = key
+        applied: Dict[str, Any] = {}
+
+        if self.vlm_client is not None:
+            if "vlm_timeout_s" in profile:
+                self.vlm_client.timeout = float(profile["vlm_timeout_s"])
+                applied["vlm_timeout_s"] = self.vlm_client.timeout
+            if "vlm_min_interval_s" in profile:
+                self.vlm_client.min_interval_s = float(profile["vlm_min_interval_s"])
+                applied["vlm_min_interval_s"] = self.vlm_client.min_interval_s
+            if "vlm_num_predict" in profile and hasattr(self.vlm_client, "num_predict"):
+                self.vlm_client.num_predict = int(profile["vlm_num_predict"])
+                applied["vlm_num_predict"] = self.vlm_client.num_predict
+
+        if "follow_track_interval_s" in profile:
+            self._follow_cfg["track_interval_s"] = float(profile["follow_track_interval_s"])
+            applied["follow_track_interval_s"] = self._follow_cfg["track_interval_s"]
+
+        return {"ok": True, "active": key, "applied": applied}
 
     # -----------------------------------------------------------------
     # Public control API
@@ -645,7 +789,14 @@ class VisionProcessor:
         pan = _clamp(pan, int(self._follow_cfg.get("min_pan", 35)), int(self._follow_cfg.get("max_pan", 145)))
         tilt = _clamp(tilt, int(self._follow_cfg.get("min_tilt", 65)), int(self._follow_cfg.get("max_tilt", 125)))
 
-        self._send_track(pan=pan, tilt=tilt, drive=0)
+        if self.head_arbiter is not None and HeadCommand is not None:
+            source = "owner_follow" if str(self._follow_target or "").lower() in {"owner", "emir"} else "active_speaker"
+            priority = 85 if source == "owner_follow" else 75
+            self.head_arbiter.request_move(
+                HeadCommand(pan=float(pan), tilt=float(tilt), source=source, priority=priority, ttl_s=1.0)
+            )
+        else:
+            self._send_track(pan=pan, tilt=tilt, drive=0)
         self._follow_last_track_ts = now
 
     def _send_track(self, pan: int, tilt: int, drive: int = 0) -> None:
@@ -713,6 +864,16 @@ class VisionProcessor:
         with self._frame_lock:
             if self._latest_raw_frame is not None:
                 frame = self._latest_raw_frame.copy()
+        if frame is None and not self._is_http_camera_source():
+            try:
+                cap = cv2.VideoCapture(self.camera_source)
+                if cap.isOpened():
+                    ok, snap = cap.read()
+                    cap.release()
+                    if ok and snap is not None:
+                        frame = snap
+            except Exception:
+                pass
         if frame is None:
             return False
         return bool(self.face_manager.register_face(name, frame))
@@ -762,6 +923,199 @@ class VisionProcessor:
 
     def record_chat(self, person: str, text: str, role: str = "assistant") -> None:
         self.memory.append_chat(person, role, text)
+
+    # -----------------------------------------------------------------
+    # Living Vision Agent: Context and VLM Integration
+    # -----------------------------------------------------------------
+
+    def _call_remote_multimodal(self, frame: Any) -> Optional[Dict[str, Any]]:
+        if not self.remote_mm_enabled or not self.remote_mm_endpoint:
+            return None
+        try:
+            ok, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 75])
+            if not ok:
+                return None
+            image_b64 = base64.b64encode(buf.tobytes()).decode("ascii")
+            payload = {"image_b64": image_b64}
+            headers = {}
+            if self.remote_mm_auth_token:
+                headers["X-Auth-Token"] = self.remote_mm_auth_token
+            resp = requests.post(
+                self.remote_mm_endpoint,
+                json=payload,
+                headers=headers,
+                timeout=self.remote_mm_timeout_s,
+            )
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+            if isinstance(data, dict):
+                return data
+        except Exception as exc:
+            logger.debug("remote multimodal call failed: %s", exc)
+        return None
+
+    def _context_from_remote_multimodal(self, mm: Dict[str, Any], question: str = "") -> Dict[str, Any]:
+        people = list(mm.get("people", []) or [])
+        objects = list(mm.get("objects", []) or [])
+        hazards = list(mm.get("hazards", []) or [])
+        summary = str(mm.get("summary", "")).strip()
+        interpretation = str(mm.get("persona_interpretation", "")).strip() or summary
+        importance = float(mm.get("importance_score", 0.55 if hazards else 0.4))
+        return {
+            "timestamp": datetime.utcnow().isoformat(),
+            "summary": summary,
+            "objects": objects,
+            "people": people,
+            "hazards": hazards,
+            "interesting_events": list(mm.get("interesting_events", []) or []),
+            "recommended_focus": dict(mm.get("recommended_focus", {}) or {}),
+            "importance_score": min(1.0, max(0.0, importance + (0.1 if question else 0.0))),
+            "raw_vlm_observation": str(mm.get("raw_text", "")),
+            "persona_interpretation": interpretation,
+        }
+
+    def get_latest_visual_context(self) -> Optional[Dict[str, Any]]:
+        """Return the latest cached visual context (if available)."""
+        if self.visual_context_cache is None:
+            return None
+        ctx = self.visual_context_cache.get_latest()
+        if ctx is None:
+            fallback = self._build_context_from_results(self.latest_results)
+            if fallback is None:
+                return None
+            self.update_visual_context(fallback)
+            ctx = self.visual_context_cache.get_latest()
+            if ctx is None:
+                return None
+        return ctx.to_dict()
+
+    def refresh_visual_context(self, question: str = "") -> Optional[Dict[str, Any]]:
+        """Capture/refresh the latest context using VLM when possible."""
+        frame = None
+        with self._frame_lock:
+            if self._latest_raw_frame is not None:
+                frame = self._latest_raw_frame.copy()
+
+        # 1) Preferred path: remote multimodal server (PC-side inference stack)
+        if frame is not None and self.remote_mm_enabled:
+            mm_result = self._call_remote_multimodal(frame)
+            if isinstance(mm_result, dict) and mm_result.get("ok", True):
+                context = self._context_from_remote_multimodal(mm_result, question=question)
+                self.update_visual_context(context)
+                # Keep latest_results in sync so existing flows continue to work.
+                merged_results = []
+                for p in context.get("people", []):
+                    if isinstance(p, dict):
+                        merged_results.append(
+                            {
+                                "label": "person",
+                                "name": p.get("name", "Unknown"),
+                                "confidence": float(p.get("confidence", 0.0) or 0.0),
+                                "bbox": p.get("bbox", []),
+                                "distance_m": p.get("distance_m"),
+                            }
+                        )
+                for o in context.get("objects", []):
+                    if isinstance(o, dict):
+                        merged_results.append(o)
+                if merged_results:
+                    self.latest_results = merged_results
+                latest = self.get_latest_visual_context()
+                if latest is not None:
+                    return latest
+
+        if frame is not None and self.vlm_client is not None:
+            vlm_result = self.vlm_client.analyze_frame(frame, force=bool(question))
+            if isinstance(vlm_result, dict):
+                context = {
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "summary": str(vlm_result.get("summary", "")),
+                    "objects": list(vlm_result.get("objects", []) or []),
+                    "people": list(vlm_result.get("people", []) or []),
+                    "hazards": list(vlm_result.get("hazards", []) or []),
+                    "interesting_events": list(vlm_result.get("interesting", []) or vlm_result.get("interesting_events", []) or []),
+                    "recommended_focus": dict(vlm_result.get("recommended_focus", {}) or {}),
+                    "importance_score": 0.6 if question else 0.4,
+                    "raw_vlm_observation": str(vlm_result.get("raw_text", "")),
+                    "persona_interpretation": str(vlm_result.get("summary", "")),
+                }
+                self.update_visual_context(context)
+                latest = self.get_latest_visual_context()
+                if latest is not None:
+                    return latest
+
+        fallback = self._build_context_from_results(self.latest_results)
+        if fallback is not None:
+            self.update_visual_context(fallback)
+            return self.get_latest_visual_context()
+        return None
+
+    def _build_context_from_results(self, results: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        if not results:
+            return None
+        people = []
+        objects = []
+        for item in results:
+            if str(item.get("label", "")).lower() == "person":
+                people.append(
+                    {
+                        "track_id": "",
+                        "person_id": "",
+                        "name": item.get("name", "Unknown"),
+                        "recognition_level": 0 if item.get("name", "Unknown") == "Unknown" else 2,
+                        "relationship": "unknown",
+                        "confidence": float(item.get("confidence", 0.0) or 0.0),
+                        "bbox": list(item.get("bbox", [0, 0, 0, 0])),
+                        "distance_m": item.get("distance_m"),
+                        "gaze_priority": 0.4,
+                        "last_seen": datetime.utcnow().isoformat(),
+                        "is_follow_target": bool(item.get("tracked", False)),
+                        "appearance_notes": "",
+                    }
+                )
+            else:
+                objects.append(item)
+        summary = f"{len(people)} kişi ve {len(objects)} nesne algılandı."
+        return {
+            "timestamp": datetime.utcnow().isoformat(),
+            "summary": summary,
+            "objects": objects,
+            "people": people,
+            "hazards": [],
+            "interesting_events": [],
+            "recommended_focus": {"type": "person" if people else "none", "target_id": "", "reason": "latest_detection"},
+            "importance_score": 0.5 if people else 0.3,
+            "raw_vlm_observation": summary,
+            "persona_interpretation": summary,
+        }
+
+    def update_visual_context(self, context: Optional[Dict[str, Any]]) -> None:
+        """Update the cached visual context (typically called by VLM after processing)."""
+        if self.visual_context_cache is None or context is None:
+            return
+        try:
+            # Reconstruct from dict if needed
+            if hasattr(self.visual_context_cache, 'set_context'):
+                self.visual_context_cache.set_context(context)
+            else:
+                # Direct assignment if it's a VisualContextCache
+                from .visual_context import VisionFrameContext, PersonContext
+                vfc = VisionFrameContext(
+                    timestamp=context.get("timestamp", ""),
+                    summary=context.get("summary", ""),
+                    objects=context.get("objects", []),
+                    people=[PersonContext(**p) if isinstance(p, dict) else p for p in context.get("people", [])],
+                    hazards=context.get("hazards", []),
+                    interesting_events=context.get("interesting_events", []),
+                    recommended_focus=context.get("recommended_focus", {}),
+                    importance_score=context.get("importance_score", 0.0),
+                    raw_vlm_observation=context.get("raw_vlm_observation", ""),
+                    persona_interpretation=context.get("persona_interpretation", ""),
+                )
+                self.visual_context_cache.update(vfc)
+        except Exception as exc:
+            logger.debug("Failed to update visual context: %s", exc)
 
     # -----------------------------------------------------------------
     # Interaction / alert layer
@@ -835,6 +1189,8 @@ class VisionProcessor:
         parts = [f"{lbl} {dist:.1f}m" for lbl, dist in hazards]
         self._send_tts("Dikkat yakın tehlike: " + ", ".join(parts))
         self._emit_emotion("alert")
+        if self.event_bus is not None:
+            self.event_bus.publish(EVENT_HAZARD_DETECTED, {"hazards": parts})
         self.last_alert_announcement = now
 
     def _emit_emotion(self, emotion: str) -> None:
@@ -858,6 +1214,19 @@ class VisionProcessor:
             name = r.get("name")
             if not name or name == "Unknown":
                 continue
+            if self.person_identity is not None:
+                rec = self.person_identity.recognize(
+                    name=str(name),
+                    confidence=float(r.get("confidence", 0.0) or 0.0),
+                    face_score=float(r.get("confidence", 0.0) or 0.0),
+                )
+                r["person_id"] = rec.person_id
+                r["recognition_level"] = rec.recognition_level
+                r["relationship"] = rec.relationship
+                if rec.recognition_level >= 5 and self.event_bus is not None:
+                    self.event_bus.publish(EVENT_OWNER_SEEN, {"name": rec.name, "person_id": rec.person_id})
+                elif rec.seen_count <= 2 and self.event_bus is not None:
+                    self.event_bus.publish(EVENT_NEW_PERSON, {"name": rec.name, "person_id": rec.person_id})
             last = self._last_person_greet.get(name, 0.0)
             if now - last < greet_cooldown:
                 continue

--- a/modules/vlm_bridge/services/vision_event_bus.py
+++ b/modules/vlm_bridge/services/vision_event_bus.py
@@ -1,0 +1,91 @@
+"""Vision event bus for SentryBOT.
+
+Central pub/sub for visual events so multiple subsystems (Autonomy,
+AgentCore, HeadControlArbiter) can react without tight coupling.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Dict, List
+
+logger = logging.getLogger("vlm_bridge.event_bus")
+
+# Standard event types
+EVENT_PERSON_SEEN = "person_seen"
+EVENT_OWNER_SEEN = "owner_seen"
+EVENT_NEW_PERSON = "new_person"
+EVENT_HAZARD_DETECTED = "hazard_detected"
+EVENT_SCENE_CHANGED = "scene_changed"
+EVENT_VLM_RESULT_READY = "vlm_result_ready"
+EVENT_FOLLOW_START = "follow_start"
+EVENT_FOLLOW_STOP = "follow_stop"
+EVENT_PERSON_LOST = "person_lost"
+
+ALL_EVENTS = frozenset({
+    EVENT_PERSON_SEEN, EVENT_OWNER_SEEN, EVENT_NEW_PERSON,
+    EVENT_HAZARD_DETECTED, EVENT_SCENE_CHANGED, EVENT_VLM_RESULT_READY,
+    EVENT_FOLLOW_START, EVENT_FOLLOW_STOP, EVENT_PERSON_LOST,
+})
+
+EventHandler = Callable[[str, Dict[str, Any]], None]
+
+
+class VisionEventBus:
+    """Thread-safe publish/subscribe bus for vision events."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._subscribers: Dict[str, List[EventHandler]] = {}
+        self._global_subscribers: List[EventHandler] = []
+        self._event_count: int = 0
+
+    def subscribe(self, event_type: str, handler: EventHandler) -> None:
+        with self._lock:
+            self._subscribers.setdefault(event_type, []).append(handler)
+
+    def subscribe_all(self, handler: EventHandler) -> None:
+        with self._lock:
+            self._global_subscribers.append(handler)
+
+    def unsubscribe(self, event_type: str, handler: EventHandler) -> None:
+        with self._lock:
+            handlers = self._subscribers.get(event_type, [])
+            if handler in handlers:
+                handlers.remove(handler)
+
+    def publish(self, event_type: str, data: Dict[str, Any] = None) -> None:
+        data = data or {}
+        data["event_type"] = event_type
+        self._event_count += 1
+
+        with self._lock:
+            handlers = list(self._subscribers.get(event_type, []))
+            global_handlers = list(self._global_subscribers)
+
+        for handler in handlers + global_handlers:
+            try:
+                handler(event_type, data)
+            except Exception as exc:
+                logger.warning("Event handler error for '%s': %s", event_type, exc)
+
+    @property
+    def event_count(self) -> int:
+        return self._event_count
+
+    def get_stats(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "total_events": self._event_count,
+                "subscribers": {k: len(v) for k, v in self._subscribers.items()},
+                "global_subscribers": len(self._global_subscribers),
+            }
+
+
+__all__ = [
+    "VisionEventBus",
+    "EVENT_PERSON_SEEN", "EVENT_OWNER_SEEN", "EVENT_NEW_PERSON",
+    "EVENT_HAZARD_DETECTED", "EVENT_SCENE_CHANGED", "EVENT_VLM_RESULT_READY",
+    "EVENT_FOLLOW_START", "EVENT_FOLLOW_STOP", "EVENT_PERSON_LOST",
+]

--- a/modules/vlm_bridge/services/vision_sampler.py
+++ b/modules/vlm_bridge/services/vision_sampler.py
@@ -1,0 +1,81 @@
+"""VLM sampling strategy for SentryBOT.
+
+Decides *when* to trigger a remote VLM call based on events.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("vlm_bridge.vision_sampler")
+
+
+class VisionSampler:
+    """Decides whether a VLM call should be triggered right now."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        cfg = config or {}
+        self.min_interval_s = float(cfg.get("min_interval_s", 5.0))
+        self.scene_change_threshold = float(cfg.get("scene_change_threshold", 0.35))
+        self.max_idle_interval_s = float(cfg.get("max_idle_interval_s", 60.0))
+        self.suppress_during_follow = bool(cfg.get("suppress_during_follow", True))
+        self._last_call_time: float = 0.0
+        self._call_count: int = 0
+        self._pending_user_question: bool = False
+
+    def should_call_vlm(
+        self, *, new_person: bool = False, owner_seen: bool = False,
+        scene_change_score: float = 0.0, user_question: bool = False,
+        hazard_detected: bool = False, sudden_motion: bool = False,
+        is_bored: bool = False, follow_mode_active: bool = False,
+    ) -> bool:
+        now = time.time()
+        elapsed = now - self._last_call_time
+        mandatory = user_question or hazard_detected or self._pending_user_question
+
+        if not mandatory and elapsed < self.min_interval_s:
+            return False
+        if follow_mode_active and self.suppress_during_follow and not mandatory:
+            return False
+        if user_question or self._pending_user_question:
+            self._pending_user_question = False
+            return True
+        if hazard_detected:
+            return True
+        if owner_seen and elapsed > self.min_interval_s:
+            return True
+        if new_person and elapsed > self.min_interval_s:
+            return True
+        if sudden_motion and elapsed > self.min_interval_s * 1.5:
+            return True
+        if scene_change_score >= self.scene_change_threshold and elapsed > self.min_interval_s:
+            return True
+        if is_bored and elapsed > self.max_idle_interval_s:
+            return True
+        if elapsed > self.max_idle_interval_s * 2:
+            return True
+        return False
+
+    def request_user_question(self) -> None:
+        self._pending_user_question = True
+
+    def record_call(self) -> None:
+        self._last_call_time = time.time()
+        self._call_count += 1
+
+    @property
+    def time_since_last_call(self) -> float:
+        if self._last_call_time <= 0:
+            return float("inf")
+        return time.time() - self._last_call_time
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {
+            "call_count": self._call_count,
+            "time_since_last_s": round(self.time_since_last_call, 1),
+            "pending_user_question": self._pending_user_question,
+        }
+
+__all__ = ["VisionSampler"]

--- a/modules/vlm_bridge/services/visual_context.py
+++ b/modules/vlm_bridge/services/visual_context.py
@@ -1,0 +1,240 @@
+"""Visual context model and cache for SentryBOT VLM Bridge.
+
+Standardises the scene understanding data shared across all modules.
+The ``VisualContextCache`` holds the latest analysed context so that
+Agent Core tools and Autonomy can query it instantly without waiting
+for a new VLM round-trip.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("vlm_bridge.visual_context")
+
+
+# ── Data models ───────────────────────────────────────────────────────
+
+@dataclass
+class PersonContext:
+    """Represents a single person detected in the current frame."""
+
+    track_id: str = ""
+    person_id: str = ""
+    name: str = "Unknown"
+    recognition_level: int = 0  # 0-5
+    relationship: str = "unknown"  # owner|family|friend|known|stranger|unknown
+    confidence: float = 0.0
+    bbox: List[int] = field(default_factory=lambda: [0, 0, 0, 0])  # x1,y1,x2,y2
+    distance_m: Optional[float] = None
+    gaze_priority: float = 0.0
+    last_seen: str = ""
+    is_follow_target: bool = False
+    appearance_notes: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class VisionFrameContext:
+    """Complete visual understanding of a single moment."""
+
+    timestamp: str = ""
+    scene_id: str = field(default_factory=lambda: uuid.uuid4().hex[:8])
+    summary: str = ""
+    objects: List[Dict[str, Any]] = field(default_factory=list)
+    people: List[PersonContext] = field(default_factory=list)
+    hazards: List[Dict[str, Any]] = field(default_factory=list)
+    interesting_events: List[Dict[str, Any]] = field(default_factory=list)
+    recommended_focus: Dict[str, Any] = field(default_factory=dict)
+    importance_score: float = 0.0
+    raw_vlm_observation: str = ""
+    persona_interpretation: str = ""
+
+    # Metadata
+    source: str = "local"  # local | vlm | cached
+    latency_ms: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["people"] = [p.to_dict() if isinstance(p, PersonContext) else p for p in self.people]
+        return d
+
+    @property
+    def has_people(self) -> bool:
+        return bool(self.people)
+
+    @property
+    def has_hazards(self) -> bool:
+        return bool(self.hazards)
+
+    @property
+    def has_owner(self) -> bool:
+        return any(p.recognition_level >= 5 for p in self.people if isinstance(p, PersonContext))
+
+    def get_owner(self) -> Optional[PersonContext]:
+        for p in self.people:
+            if isinstance(p, PersonContext) and p.recognition_level >= 5:
+                return p
+        return None
+
+    def get_highest_priority_person(self) -> Optional[PersonContext]:
+        if not self.people:
+            return None
+        valid = [p for p in self.people if isinstance(p, PersonContext)]
+        if not valid:
+            return None
+        return max(valid, key=lambda p: (p.recognition_level, p.gaze_priority))
+
+
+# ── Importance scoring ────────────────────────────────────────────────
+
+_IMPORTANCE_WEIGHTS = {
+    "owner_present": 0.4,
+    "new_person": 0.3,
+    "hazard_detected": 0.8,
+    "user_question": 0.6,
+    "scene_change": 0.3,
+    "known_person": 0.2,
+    "idle_curiosity": 0.1,
+}
+
+_IMPORTANCE_PENALTIES = {
+    "repeated_scene": -0.4,
+    "low_confidence": -0.2,
+    "follow_mode_active": -0.15,
+}
+
+
+def compute_importance(
+    ctx: VisionFrameContext,
+    *,
+    is_user_question: bool = False,
+    is_scene_change: bool = False,
+    is_follow_active: bool = False,
+    previous_scene_id: str = "",
+) -> float:
+    """Compute importance score (0.0 – 1.0) for a context snapshot."""
+    score = 0.0
+
+    if ctx.has_owner:
+        score += _IMPORTANCE_WEIGHTS["owner_present"]
+    if ctx.has_hazards:
+        score += _IMPORTANCE_WEIGHTS["hazard_detected"]
+    if is_user_question:
+        score += _IMPORTANCE_WEIGHTS["user_question"]
+    if is_scene_change:
+        score += _IMPORTANCE_WEIGHTS["scene_change"]
+
+    for p in ctx.people:
+        if isinstance(p, PersonContext):
+            if p.recognition_level == 0 and p.name == "Unknown":
+                score += _IMPORTANCE_WEIGHTS["new_person"]
+            elif p.recognition_level >= 2:
+                score += _IMPORTANCE_WEIGHTS["known_person"]
+
+    if not ctx.has_people and not ctx.has_hazards and not is_user_question:
+        score += _IMPORTANCE_WEIGHTS["idle_curiosity"]
+
+    # Penalties
+    if previous_scene_id and ctx.scene_id == previous_scene_id:
+        score += _IMPORTANCE_PENALTIES["repeated_scene"]
+    if is_follow_active:
+        score += _IMPORTANCE_PENALTIES["follow_mode_active"]
+
+    avg_conf = 0.0
+    valid_people = [p for p in ctx.people if isinstance(p, PersonContext)]
+    if valid_people:
+        avg_conf = sum(p.confidence for p in valid_people) / len(valid_people)
+        if avg_conf < 0.3:
+            score += _IMPORTANCE_PENALTIES["low_confidence"]
+
+    return max(0.0, min(1.0, score))
+
+
+# ── Thread-safe cache ─────────────────────────────────────────────────
+
+class VisualContextCache:
+    """Thread-safe cache for the latest visual context.
+
+    Usage::
+
+        cache = VisualContextCache()
+        cache.update(new_context)
+        latest = cache.get_latest()  # instant return
+    """
+
+    def __init__(self, max_history: int = 5) -> None:
+        self._lock = threading.Lock()
+        self._latest: Optional[VisionFrameContext] = None
+        self._history: List[VisionFrameContext] = []
+        self._max_history = max(1, int(max_history))
+        self._update_count = 0
+        self._last_update: float = 0.0
+
+    def update(self, ctx: VisionFrameContext) -> None:
+        """Store a new context snapshot."""
+        with self._lock:
+            if self._latest is not None:
+                self._history.append(self._latest)
+                if len(self._history) > self._max_history:
+                    self._history = self._history[-self._max_history:]
+            self._latest = ctx
+            self._update_count += 1
+            self._last_update = time.time()
+
+    def get_latest(self) -> Optional[VisionFrameContext]:
+        """Return the most recent context (or None)."""
+        with self._lock:
+            return self._latest
+
+    def get_latest_dict(self) -> Dict[str, Any]:
+        """Return the most recent context as a JSON-safe dict."""
+        with self._lock:
+            if self._latest is None:
+                return {"available": False, "context": None}
+            return {
+                "available": True,
+                "context": self._latest.to_dict(),
+                "age_s": round(time.time() - self._last_update, 2),
+                "update_count": self._update_count,
+            }
+
+    def get_history(self, limit: int = 3) -> List[Dict[str, Any]]:
+        with self._lock:
+            items = list(self._history[-limit:])
+        return [c.to_dict() for c in items]
+
+    @property
+    def age_s(self) -> float:
+        with self._lock:
+            if self._last_update <= 0:
+                return float("inf")
+            return time.time() - self._last_update
+
+    @property
+    def previous_scene_id(self) -> str:
+        with self._lock:
+            if self._history:
+                return self._history[-1].scene_id
+            return ""
+
+    def clear(self) -> None:
+        with self._lock:
+            self._latest = None
+            self._history.clear()
+            self._update_count = 0
+
+
+__all__ = [
+    "PersonContext",
+    "VisionFrameContext",
+    "VisualContextCache",
+    "compute_importance",
+]

--- a/modules/vlm_bridge/tests/test_living_vision_context_fallback.py
+++ b/modules/vlm_bridge/tests/test_living_vision_context_fallback.py
@@ -1,0 +1,48 @@
+import threading
+
+from modules.vlm_bridge.services.processor import VisionProcessor
+from modules.vlm_bridge.services.visual_context import VisualContextCache
+
+
+def test_timeout_returns_cached_visual_context_fallback():
+    proc = VisionProcessor.__new__(VisionProcessor)
+    proc.visual_context_cache = VisualContextCache()
+    proc.latest_results = [{"label": "person", "name": "Unknown", "confidence": 0.4, "bbox": [1, 1, 10, 10], "tracked": False}]
+    proc._frame_lock = threading.Lock()
+    proc._latest_raw_frame = None
+    proc.vlm_client = None
+
+    # bind methods from class
+    ctx = VisionProcessor.refresh_visual_context(proc, question="ne görüyorsun?")
+    assert ctx is not None
+    assert "summary" in ctx
+    assert "importance_score" in ctx
+
+
+def test_agent_core_get_visual_context_returns_latest_context():
+    proc = VisionProcessor.__new__(VisionProcessor)
+    proc.visual_context_cache = VisualContextCache()
+    proc.latest_results = []
+    proc._frame_lock = threading.Lock()
+    proc._latest_raw_frame = None
+    proc.vlm_client = None
+
+    VisionProcessor.update_visual_context(
+        proc,
+        {
+            "timestamp": "now",
+            "summary": "oda",
+            "objects": [],
+            "people": [],
+            "hazards": [],
+            "interesting_events": [],
+            "recommended_focus": {"type": "none"},
+            "importance_score": 0.3,
+            "raw_vlm_observation": "oda",
+            "persona_interpretation": "oda sakin",
+        },
+    )
+    latest = VisionProcessor.get_latest_visual_context(proc)
+    assert latest is not None
+    assert latest.get("summary") == "oda"
+

--- a/modules/vlm_bridge/tests/test_living_vision_identity_and_control.py
+++ b/modules/vlm_bridge/tests/test_living_vision_identity_and_control.py
@@ -1,0 +1,66 @@
+import tempfile
+import time
+
+
+def test_low_confidence_person_not_owner():
+    from modules.vlm_bridge.services.person_identity import PersonIdentityManager
+
+    with tempfile.TemporaryDirectory() as td:
+        store = f"{td}/people.json"
+        mgr = PersonIdentityManager(store_path=store)
+        rec = mgr.remember_person("TestUser", relationship="known", recognition_level=1)
+        assert rec.recognition_level == 1
+        assert mgr.is_owner("TestUser") is False
+
+
+def test_person_memory_persists_across_restart():
+    from modules.vlm_bridge.services.person_identity import PersonIdentityManager
+
+    with tempfile.TemporaryDirectory() as td:
+        store = f"{td}/people.json"
+        mgr1 = PersonIdentityManager(store_path=store)
+        mgr1.remember_person("Emir", relationship="owner", recognition_level=5)
+        mgr1.save()
+
+        mgr2 = PersonIdentityManager(store_path=store)
+        rec = mgr2.get_person("Emir")
+        assert rec is not None
+        assert rec.recognition_level == 5
+        assert rec.relationship == "owner"
+
+
+def test_remember_person_updates_recognition_level():
+    from modules.vlm_bridge.services.person_identity import PersonIdentityManager
+
+    with tempfile.TemporaryDirectory() as td:
+        store = f"{td}/people.json"
+        mgr = PersonIdentityManager(store_path=store)
+        mgr.remember_person("Alice", relationship="known", recognition_level=2)
+        rec = mgr.remember_person("Alice", relationship="friend", recognition_level=3)
+        assert rec.recognition_level == 3
+        assert rec.relationship == "friend"
+
+
+def test_duplicate_pan_tilt_commands_suppressed():
+    from modules.vlm_bridge.services.head_control_arbiter import HeadControlArbiter
+
+    arb = HeadControlArbiter({"deadband_deg": 3, "max_rate_hz": 1000})
+    first = arb.move(100, 95, source="manual", priority=100)
+    time.sleep(0.01)
+    second = arb.move(96, 93, source="manual", priority=100)
+    assert first["ok"] is True
+    assert second["ok"] is False
+    assert second["reason"] == "deadband"
+
+
+def test_follow_mode_does_not_spam_vlm_calls():
+    from modules.vlm_bridge.services.vision_sampler import VisionSampler
+
+    sampler = VisionSampler({"min_interval_s": 5, "suppress_during_follow": True})
+    should = sampler.should_call_vlm(
+        new_person=True,
+        follow_mode_active=True,
+        user_question=False,
+        hazard_detected=False,
+    )
+    assert should is False

--- a/modules/vlm_bridge/tests/test_living_vision_vlm_client.py
+++ b/modules/vlm_bridge/tests/test_living_vision_vlm_client.py
@@ -1,0 +1,56 @@
+import threading
+import time
+
+
+def test_vlm_json_parse_fallback_works():
+    from modules.vlm_bridge.services.ollama_vlm_client import _parse_vlm_json
+
+    text = "Sonuc:\n```json\n{\"summary\":\"oda\",\"objects\":[]}\n```"
+    parsed = _parse_vlm_json(text)
+
+    assert parsed.get("summary") == "oda"
+    assert "raw_text" in parsed
+
+
+def test_concurrent_vlm_calls_are_deduplicated():
+    from modules.vlm_bridge.services.ollama_vlm_client import OllamaVLMClient
+
+    client = OllamaVLMClient(
+        {
+            "base_url": "http://127.0.0.1:11434",
+            "model": "qwen3-vl:8b",
+            "min_interval_s": 0,
+        }
+    )
+
+    def fake_call(_prompt, _image_b64):
+        time.sleep(0.08)
+        return {"summary": "ok", "raw_text": "ok"}
+
+    def fake_encode(_frame, max_width=640, jpeg_quality=70):
+        return "ZmFrZQ=="
+
+    # monkeypatch without pytest fixture dependency
+    import modules.vlm_bridge.services.ollama_vlm_client as mod
+
+    old_call = client._call_ollama
+    old_encode = mod._resize_and_encode
+    client._call_ollama = fake_call
+    mod._resize_and_encode = fake_encode
+    try:
+        results = []
+
+        def worker():
+            results.append(client.analyze_frame(frame=object(), force=True))
+
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+    finally:
+        client._call_ollama = old_call
+        mod._resize_and_encode = old_encode
+
+    assert sum(1 for r in results if r is not None) == 1


### PR DESCRIPTION
## Summary
- add living-vision core primitives for visual context, identity tracking, event publishing, and sampling cadence in vlm_bridge
- introduce a dedicated Ollama VLM client path with head-control arbitration and supporting config/client wiring
- integrate the new flow into processor and API routes, then add focused tests for fallback behavior, identity/control flow, and VLM client handling

## Test plan
- [ ] Run pytest modules/vlm_bridge/tests/test_living_vision_context_fallback.py
- [ ] Run pytest modules/vlm_bridge/tests/test_living_vision_identity_and_control.py
- [ ] Run pytest modules/vlm_bridge/tests/test_living_vision_vlm_client.py
- [ ] Exercise modules/vlm_bridge/api/router.py endpoints in local runtime and verify living vision outputs

Made with [Cursor](https://cursor.com)