### PR TITLE
feat: add companion behavior pipeline to autonomy

### DIFF
--- a/modules/autonomy/config/config.yml
+++ b/modules/autonomy/config/config.yml
@@ -1,5 +1,5 @@
 defaults:
-  loop_interval_ms: 1000
+  loop_interval_ms: 500
   boredom_threshold_s: 20
   mood:
     decay_rate: 0.5
@@ -43,6 +43,7 @@ endpoints:
   camera: "http://localhost:8080/camera"
   notifier: "http://localhost:8080/notify"
   autonomy: "http://localhost:8080/autonomy"
+  agent_core: "http://localhost:8080/agent"
 
 behaviors:
   idle:
@@ -71,6 +72,8 @@ behaviors:
 llm:
   enabled: true
   model: "qwen3.5:9b"
+  auto_select_persona: false
+  warmup_on_start: true
   prompt_template: |
     Sen duyguları olan bir robotsun.
     
@@ -129,9 +132,51 @@ offline_mode:
     generic:
       - "Baglanti gecici olarak yok, ama etkileşim devam ediyor."
 
+request_timeouts:
+  default_post_s: 1.0
+  default_get_s: 0.8
+  ollama_chat_s: 18.0
+  ollama_warmup_s: 2.5
+  speech_min_interval_s: 0.8
+
+visual_state:
+  emotion_min_interval_s: 2.2
+  default_lock_s: 2.4
+  strong_lock_s: 4.8
+  state_hold_s: 3.2
+  strong_emotions: ["fear", "angry", "furious"]
+  transition_graph:
+    neutral: ["curiosity", "joy", "tired", "sad", "fear", "angry", "furious"]
+    curiosity: ["joy", "neutral", "sad", "fear", "angry"]
+    joy: ["neutral", "curiosity", "tired", "sad"]
+    sad: ["neutral", "curiosity", "fear"]
+    tired: ["neutral", "sad"]
+    angry: ["neutral", "fear", "furious"]
+    furious: ["angry", "fear", "neutral"]
+    fear: ["neutral", "curiosity", "angry"]
+
+companion:
+  enabled: true
+  relationship_memory_path: "modules/autonomy/data/relationship_memory.json"
+  rituals:
+    enabled: true
+    morning_window_h: [6, 11]
+    owner_return_min_absence_s: 180
+    owner_return_cooldown_s: 300
+  proactive:
+    enabled: true
+    cooldown_s: 75
+    min_idle_s: 50
+    max_per_hour: 4
+    owner_only: false
+    enable_callback_lines: true
+    policy:
+      owner_style: "warm"
+      guest_style: "respectful"
+
 vision_hooks:
   enabled: true
-  poll_interval_s: 3
+  poll_interval_s: 2
   max_results: 5
   person_cooldown_s: 25
   ignore_labels:
@@ -139,6 +184,7 @@ vision_hooks:
     - "tv"
   prefer_llm_greetings: true
   speak_on_unknown: false
+  importance_speak_threshold: 0.6
   focus:
     jitter_min: -3
     jitter_max: 3
@@ -305,7 +351,6 @@ owner:
     handle: "WhoIsMrSentry"
   presence_timeout_s: 45
   require_presence: false
-  permission_grace_s: 900
   max_requests_without_owner: 3
   cooldown_s: 20
   speaker_window_s: 10
@@ -313,22 +358,10 @@ owner:
   angry_message: "Baba yokken beni zorlamanı istemiyorum."
   cooldown_message: "Baba gelene kadar konuşmak istemiyorum."
   greeting: "Baba! Geldiğine çok sevindim."
-  permission_message: "Tamam Baba, yanında olmasan da cevap vereceğim."
   restricted_keywords:
     - "format"
     - "kendini kapat"
     - "delete"
-  temporary:
-    enabled: true
-    # support single or list of keywords; include the new Khar language trigger
-    command_keyword:
-      - "geçici sahip"
-    duration_s: 600
-    restricted_features:
-      - "high_torque"
-      - "network_admin"
-    animation: "temp_owner"
-    revoke_message: "Geçici yetkiler sona erdi."
   # Note: Kharuun-specific irreversible triggers removed.
   rfid:
     endpoint: "http://localhost:8080/arduino/rfid/authorize"

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -4,12 +4,16 @@ import logging
 import random
 import datetime
 import json
+import uuid
 from typing import List
 
 from .client import ServiceClient
 from .idle_behaviors import IdleBehaviorPlanner
 from .mood import MoodManager
 from .memory import ShortTermMemory
+from .companion_rituals import CompanionRituals
+from .proactive_planner import ProactivePlanner
+from .relationship_memory import RelationshipMemory
 from .brain_parts.animations import AnimationSupportMixin
 from .brain_parts.owner_guard import OwnerGuardMixin
 from .brain_parts.responses import ResponseTagMixin
@@ -47,6 +51,15 @@ class AutonomyBrain(
         self.client = ServiceClient(config.get("endpoints", {}), config=config)
         self.idle_planner = IdleBehaviorPlanner(config)
         self.memory = ShortTermMemory(max_items=20)
+        companion_cfg = config.get("companion", {}) if isinstance(config.get("companion", {}), dict) else {}
+        self.relationship_memory = RelationshipMemory(
+            enabled=bool(companion_cfg.get("enabled", True)),
+            path=str(companion_cfg.get("relationship_memory_path", "modules/autonomy/data/relationship_memory.json")),
+        )
+        self.companion_rituals = CompanionRituals(
+            companion_cfg.get("rituals", {}) if isinstance(companion_cfg.get("rituals", {}), dict) else {}
+        )
+        self.proactive_planner = ProactivePlanner(companion_cfg.get("proactive", {}) if isinstance(companion_cfg.get("proactive", {}), dict) else {})
         self._vision_cfg = config.get("vision_hooks", {})
         self.owner_cfg = config.get("owner", {})
 
@@ -84,9 +97,6 @@ class AutonomyBrain(
             "owner_last_seen": 0.0,
             "owner_lockout_until": 0.0,
             "owner_last_greet": 0.0,
-            "owner_permission_until": 0.0,
-            "temp_owner": None,
-            "temp_owner_expires": 0.0,
             "rfid_authorized_until": 0.0,
             "last_speaker": None,
             "persona_mode": None,
@@ -99,16 +109,53 @@ class AutonomyBrain(
         self._last_owner_scan = 0.0
         self._last_idle_action = 0.0
         self._reset_daily_timeline()
+        self._speech_req_lock = threading.Lock()
+        self._active_speech_req_id: str = ""
+        self._speech_busy: bool = False
+        self._speech_min_interval_s = float(self.config.get("request_timeouts", {}).get("speech_min_interval_s", 0.8))
+        visuals_cfg = self.config.get("visual_state", {}) if isinstance(self.config.get("visual_state", {}), dict) else {}
+        self._visual_emotion_min_interval_s = float(visuals_cfg.get("emotion_min_interval_s", 2.0))
+        self._visual_lock_default_s = float(visuals_cfg.get("default_lock_s", 2.2))
+        self._visual_lock_strong_s = float(visuals_cfg.get("strong_lock_s", 4.5))
+        self._visual_state_hold_s = float(visuals_cfg.get("state_hold_s", 3.0))
+        self._visual_strong_emotions = {
+            str(x).strip().lower()
+            for x in (visuals_cfg.get("strong_emotions", ["fear", "angry", "furious"]) or [])
+            if str(x).strip()
+        }
+        graph_cfg = visuals_cfg.get("transition_graph", {}) if isinstance(visuals_cfg.get("transition_graph", {}), dict) else {}
+        self._visual_transition_graph = {
+            str(src).strip().lower(): [
+                str(dst).strip().lower()
+                for dst in (targets if isinstance(targets, list) else [])
+                if str(dst).strip()
+            ]
+            for src, targets in graph_cfg.items()
+            if str(src).strip()
+        }
+        self._last_emotion_sync_ts: float = 0.0
+        self._visual_lock_until: float = 0.0
+        self._visual_lock_reason: str = ""
+        self._visual_state_emotion: str = "neutral"
+        self._visual_state_since: float = time.time()
 
     def start(self):
         if self.running:
             return
         self.running = True
 
-        try:
-            self.client.select_persona("sentry")
-        except Exception:
-            logger.warning("Failed to select persona 'sentry'")
+        auto_select_persona = bool(self.config.get("llm", {}).get("auto_select_persona", False))
+        if auto_select_persona:
+            try:
+                self.client.select_persona("sentry")
+            except Exception:
+                logger.warning("Failed to select persona 'sentry'")
+
+        if bool(self.config.get("llm", {}).get("warmup_on_start", True)):
+            try:
+                self.client.warmup_ollama()
+            except Exception:
+                pass
 
         # Start Agent Core subsystems (sensors, idle behaviors, memory)
         if self.agent:
@@ -172,26 +219,39 @@ class AutonomyBrain(
                 text = speech["text"]
                 lang = str(speech.get("language") or self.state.get("last_speech_language") or "tr")
                 elapsed = time.time() - self.state["last_speech_time"]
-                if text != self.state["last_speech_text"] and elapsed > 2:
+                if text != self.state["last_speech_text"] and elapsed > self._speech_min_interval_s:
                     self.state["last_speech_text"] = text
                     self.state["last_speech_time"] = time.time()
                     self.state["last_speech_language"] = lang
-                    self._react_to_speech(text, source_lang=lang)
+                    threading.Thread(
+                        target=self._react_to_speech,
+                        args=(text,),
+                        kwargs={"source_lang": lang},
+                        daemon=True,
+                    ).start()
         except Exception:
             pass
 
     def _sync_emotion(self):
         dominant = self.mood.get_dominant_emotion()
-        if not dominant or dominant == self._last_emotion_sent:
+        now = time.time()
+        if not dominant:
             return
-        self._last_emotion_sent = dominant
-        self.state["last_emotion"] = dominant
-        self.client.update_emotions([dominant])
-        self.client.push_interaction_event(f"emotion.{dominant}")
+        target_emotion = self._select_visual_emotion(dominant)
+        if target_emotion == self._last_emotion_sent:
+            return
+        if (now - self._last_emotion_sync_ts) < self._visual_emotion_min_interval_s:
+            return
+        self._last_emotion_sent = target_emotion
+        self._last_emotion_sync_ts = now
+        self.state["last_emotion"] = target_emotion
+        self.client.update_emotions([target_emotion])
+        self.client.push_interaction_event(f"emotion.{target_emotion}")
+        self._apply_emotion_visual_state(target_emotion)
         # Try to run a matching scene for the dominant emotion (e.g. emotion_joy)
         try:
-            scene_name = f"emotion_{dominant}"
-            ran = self._run_scene(scene_name, context={"emotion": dominant})
+            scene_name = f"emotion_{target_emotion}"
+            ran = self._run_scene(scene_name, context={"emotion": target_emotion})
             if ran:
                 # emit a scene-level interaction event for other subsystems
                 try:
@@ -219,6 +279,7 @@ class AutonomyBrain(
             self._perform_micro_movement()
 
         self._maybe_scan_for_owner()
+        self._forward_visual_events_to_agent()
 
         boredom_threshold = self.config.get("defaults", {}).get("boredom_threshold_s", 20)
         time_since_interaction = now - self.state["last_interaction"]
@@ -238,6 +299,104 @@ class AutonomyBrain(
         else:
             self.state["is_bored"] = False
 
+        self._run_companion_rituals(now)
+        self._run_companion_proactive(now)
+
+    def _run_companion_rituals(self, now: float) -> None:
+        if self._speech_busy:
+            return
+        owner_present = bool(self._owner_seen_recently()) if hasattr(self, "_owner_seen_recently") else False
+        plan = self.companion_rituals.propose(
+            now_ts=now,
+            owner_present=owner_present,
+            is_sleeping=bool(self.state.get("is_sleeping", False)),
+        )
+        if not plan:
+            return
+        text = str(plan.get("text", "")).strip()
+        if not text:
+            return
+        emotion = str(plan.get("emotion", "joy")).strip()
+        event = str(plan.get("event", "companion.ritual")).strip()
+        self.client.push_interaction_event(event, {"text": text, "emotion": emotion})
+        self._speak_with_mood(text, emotion=emotion)
+        self.memory.add_event(f"Companion ritual: {text}")
+        logger.info(
+            "Companion ritual fired | event=%s emotion=%s text=%s",
+            event,
+            emotion,
+            text,
+        )
+
+    def _run_companion_proactive(self, now: float) -> None:
+        if self.state.get("is_sleeping"):
+            return
+        if self._speech_busy:
+            return
+        idle_s = max(0.0, now - float(self.state.get("last_interaction", now)))
+        dominant = str(self.mood.get_dominant_emotion() or "neutral")
+        speaker = str(self.state.get("last_speaker") or "")
+        owner_present = bool(self._owner_seen_recently()) if hasattr(self, "_owner_seen_recently") else False
+        social_profile = self.relationship_memory.social_profile(speaker) if speaker else {}
+        plan = self.proactive_planner.propose(
+            now_ts=now,
+            idle_s=idle_s,
+            dominant_emotion=dominant,
+            last_speaker=speaker,
+            owner_present=owner_present,
+            social_profile=social_profile,
+        )
+        if not plan:
+            return
+        text = str(plan.get("text", "")).strip()
+        if not text:
+            return
+        emotion = str(plan.get("emotion", "curiosity")).strip()
+        event = str(plan.get("event", "companion.proactive")).strip()
+        self.client.push_interaction_event(event, {"text": text, "emotion": emotion})
+        self._speak_with_mood(text, emotion=emotion)
+        self.memory.add_event(f"Proactive companion line: {text}")
+        logger.info(
+            "Companion proactive fired | event=%s emotion=%s text=%s",
+            event,
+            emotion,
+            text,
+        )
+
+    def _forward_visual_events_to_agent(self) -> None:
+        """Forward key autonomy/vision signals to Agent Core event endpoint."""
+        if not hasattr(self.client, "emit_agent_event"):
+            return
+        try:
+            ctx_resp = self.client.get_visual_context()
+            if not (isinstance(ctx_resp, dict) and ctx_resp.get("available")):
+                return
+            ctx = ctx_resp.get("context", {}) if isinstance(ctx_resp.get("context", {}), dict) else {}
+            hazards = ctx.get("hazards", []) if isinstance(ctx.get("hazards", []), list) else []
+            people = ctx.get("people", []) if isinstance(ctx.get("people", []), list) else []
+            if hazards:
+                self.client.emit_agent_event("hazard_detected", {"count": len(hazards)})
+                return
+            owner_seen = False
+            new_people = 0
+            for p in people:
+                if not isinstance(p, dict):
+                    continue
+                lvl = int(p.get("recognition_level", 0) or 0)
+                rel = str(p.get("relationship", "")).lower()
+                if lvl >= 5 or rel == "owner":
+                    owner_seen = True
+                if lvl <= 1:
+                    new_people += 1
+            if owner_seen:
+                self.client.emit_agent_event("owner_follow_intent", {})
+            elif new_people > 0:
+                self.client.emit_agent_event("new_person_seen", {"count": new_people})
+            elif self.state.get("is_bored"):
+                self.client.emit_agent_event("idle_comment_request", {"prompt": "look around and comment naturally"})
+        except Exception:
+            pass
+
     def _run_idle_behavior(self, now: float) -> bool:
         choice = self.idle_planner.pick(now=now)
         if choice is None:
@@ -254,11 +413,15 @@ class AutonomyBrain(
             return
 
         events = "\n".join(self.memory.get_recent_events())
+        social_context = self.relationship_memory.build_social_context(
+            current_speaker=str(self.state.get("last_speaker") or "")
+        )
         prompt = (
             f"You are currently BORED and IDLE.\n"
             f"Internal State:\n"
             f"- Happiness: {int(self.mood['happiness'])}/100, Energy: {int(self.mood['energy'])}/100, Curiosity: {int(self.mood['curiosity'])}/100\n"
             f"Recent Events:\n{events}\n\n"
+            f"{social_context}\n\n"
             f"Use your internal physical tools right now (such as looking around, playing an animation on OLED, "
             f"or changing body lights) to entertain yourself or find something interesting to do. Do not ask for permission."
         )
@@ -276,11 +439,16 @@ class AutonomyBrain(
 
     def _execute_action(self, action):
         if action == "LOOK_AROUND":
+            if self._visual_lock_active():
+                logger.debug("Skipping LOOK_AROUND due to visual lock: %s", self._visual_lock_reason)
+                return
             self.client.push_interaction_event("autonomy.look_around")
             self._emit_idle_visuals("look_around")
             if not self._trigger_animation("look_around"):
                 self._head_scan_fallback()
         elif action == "BLINK":
+            if self._visual_lock_active():
+                return
             # Always emit a visual event so LED/OLED can react even if
             # servo animation endpoint reports success while degrading.
             self.client.push_interaction_event("autonomy.blink")
@@ -292,6 +460,8 @@ class AutonomyBrain(
             self.client.push_interaction_event("autonomy.bored")
             self._emit_idle_visuals("bored")
         elif action == "STRETCH":
+            if self._visual_lock_active():
+                return
             self.client.push_interaction_event("autonomy.stretch")
             self._emit_idle_visuals("stretch")
             if not self._trigger_animation("stretch"):
@@ -308,6 +478,8 @@ class AutonomyBrain(
         feedback alive when interactions adapter/config is degraded.
         """
         key = str(action or "").strip().lower()
+        if self._visual_lock_active():
+            return
         neo_map = {
             "blink": "RANDOM_BLINK",
             "look_around": "COMET",
@@ -343,6 +515,67 @@ class AutonomyBrain(
         except Exception:
             pass
 
+    @staticmethod
+    def _normalize_emotion_name(emotion: str) -> str:
+        e = str(emotion or "neutral").strip().lower()
+        aliases = {
+            "sadness": "sad",
+            "anger": "angry",
+            "tire": "tired",
+            "anxious": "fear",
+        }
+        return aliases.get(e, e or "neutral")
+
+    def _select_visual_emotion(self, dominant_emotion: str) -> str:
+        now = time.time()
+        candidate = self._normalize_emotion_name(dominant_emotion)
+        current = self._normalize_emotion_name(self._visual_state_emotion)
+        strong = self._visual_strong_emotions
+        if not current:
+            self._visual_state_emotion = candidate
+            self._visual_state_since = now
+            return candidate
+        if candidate == current:
+            return current
+        if candidate in strong:
+            self._visual_state_emotion = candidate
+            self._visual_state_since = now
+            return candidate
+        if (now - self._visual_state_since) < max(0.1, self._visual_state_hold_s):
+            return current
+        allowed = self._visual_transition_graph.get(current, [])
+        if allowed and candidate not in allowed:
+            return current
+        self._visual_state_emotion = candidate
+        self._visual_state_since = now
+        return candidate
+
+    def _visual_lock_active(self) -> bool:
+        return time.time() < float(self._visual_lock_until)
+
+    def _apply_emotion_visual_state(self, emotion: str) -> None:
+        e = str(emotion or "neutral").strip().lower()
+        mapping = {
+            "joy": {"effect": "RAINBOW_CYCLE", "oled": "happy", "color": [255, 190, 80], "strong": False},
+            "curiosity": {"effect": "COMET", "oled": "focused", "color": [60, 190, 255], "strong": False},
+            "sadness": {"effect": "PULSE", "oled": "sad", "color": [60, 90, 180], "strong": False},
+            "tired": {"effect": "BREATHE", "oled": "sleepy", "color": [80, 70, 120], "strong": False},
+            "fear": {"effect": "PULSE", "oled": "scared", "color": [255, 40, 40], "strong": True},
+            "neutral": {"effect": "BREATHE", "oled": "normal", "color": [120, 120, 140], "strong": False},
+        }
+        spec = mapping.get(e, mapping["neutral"])
+        lock_s = self._visual_lock_strong_s if spec.get("strong") else self._visual_lock_default_s
+        self._visual_lock_until = max(self._visual_lock_until, time.time() + max(0.2, float(lock_s)))
+        self._visual_lock_reason = f"emotion:{e}"
+        try:
+            self.client.set_neopixel(str(spec.get("effect", "BREATHE")), emotions=[e], color=spec.get("color"))
+        except Exception:
+            pass
+        try:
+            self.client.oled_show(str(spec.get("oled", "normal")))
+        except Exception:
+            pass
+
     def _react_to_sound(self, angle):
         """Turn head towards sound source."""
         logger.info("Sound detected at %s", angle)
@@ -354,7 +587,7 @@ class AutonomyBrain(
             context={"angle": int(angle), "target_pan": int(target_pan)},
         )
         if not ran:
-            self.client.move_head(target_pan, self.state["current_tilt"])
+            self.client.queue_action("head_move", priority=60, payload={"pan": target_pan, "tilt": self.state["current_tilt"]})
         self.client.push_interaction_event("autonomy.excited")
         self.state["last_interaction"] = time.time()
         self.mood.modify("curiosity", 5)
@@ -363,6 +596,11 @@ class AutonomyBrain(
 
     def _react_to_speech(self, text, source_lang: str | None = None):
         """React to heard text."""
+        request_id = uuid.uuid4().hex[:10]
+        with self._speech_req_lock:
+            self._active_speech_req_id = request_id
+            self._speech_busy = True
+
         logger.info("Heard: %s", text)
         self.state["last_interaction"] = time.time()
         self.mood.modify("happiness", 5)
@@ -375,6 +613,7 @@ class AutonomyBrain(
         speaker = self._guess_active_person()
         if speaker:
             self.state["last_speaker"] = speaker
+            self._note_person_seen(speaker, emotion=str(self.state.get("last_emotion") or ""))
             self._remember_person_chat(speaker, text, role="user")
 
         self.client.push_interaction_event("autonomy.excited")
@@ -413,62 +652,42 @@ class AutonomyBrain(
         raw_response = None
         try:
             # ── PRIMARY PATH: Agent Core (ReAct + Tool Calling + Safety) ──
+            # Uses built-in ProgressManager + SpeechArbiter for staged
+            # ack → progress → final lifecycle.  No manual _waiter thread
+            # needed — agent.step() emits its own progress events.
             if self.agent:
                 try:
-                    # Speak a short ack immediately, then periodic waiting messages while agent runs.
-                    waiting_messages = [
-                        "Beklemedeyim...",
-                        "Islem suruyor...",
-                        "Hala isliyorum...",
-                    ]
-                    try:
-                        agent_cfg = self.agent.config.get("agent", {}) if isinstance(self.agent.config, dict) else {}
-                        cfg_waiting = agent_cfg.get("waiting_messages")
-                        if isinstance(cfg_waiting, list) and cfg_waiting:
-                            waiting_messages = [str(m) for m in cfg_waiting if str(m).strip()]
-                    except Exception:
-                        pass
+                    # Wire SpeechArbiter speak_fn to autonomy's speak client
+                    if not self.agent.speech_arbiter._speak_fn:
+                        self.agent.speech_arbiter.set_speak_fn(
+                            lambda text, tone=None, language=None: self.client.speak(
+                                text, tone=tone, language=language or lang,
+                            )
+                        )
 
-                    interval = float(getattr(self.agent, "status_interval_s", 3.0))
-                    wait_done = threading.Event()
-
-                    def _waiter():
-                        idx = 0
-                        while not wait_done.wait(timeout=interval):
-                            if not waiting_messages:
-                                continue
-                            msg = waiting_messages[idx % len(waiting_messages)]
-                            idx += 1
-                            self._speak_with_mood(msg, emotion="neutral", language=lang)
-
-                    self._speak_with_mood("Tamam, bakiyorum.", emotion="neutral", language=lang)
-                    wait_thread = threading.Thread(target=_waiter, daemon=True)
-                    wait_thread.start()
-                    try:
-                        agent_result = self.agent.step(text)
-                    finally:
-                        wait_done.set()
-                        try:
-                            wait_thread.join(timeout=0.1)
-                        except Exception:
-                            pass
+                    enriched_text = self._enrich_user_text_with_companion_context(text=text, speaker=speaker)
+                    agent_result = self.agent.step(enriched_text)
                     if agent_result and agent_result.get("text"):
+                        if not self._is_active_request(request_id):
+                            return
                         response_text = agent_result["text"]
                         # Actions are already executed by the agent pipeline
                         # (validated -> safety filtered -> routed -> HAL)
-                        # So we only need to speak the text response here.
                         logger.info("Agent Core handled speech with full pipeline.")
-                        # Log to short-term memory too
                         self.memory.add_event(f"Agent replied: {response_text}")
                         self._remember_person_chat(speaker, response_text, role="assistant")
-                        self._speak_with_mood(response_text, language=lang)
+                        # Final response is spoken via SpeechArbiter
+                        self.agent.speech_arbiter.enqueue_final(
+                            response_text, language=lang,
+                        )
                         return
                 except Exception as exc:
                     logger.warning("Agent Core step failed, falling back to direct LLM: %s", exc)
 
             # ── FALLBACK PATH: Direct Ollama (no tool-calling) ──
             logger.info("Routing to Ollama...")
-            resp = self.client.chat(text, source_lang="auto", response_lang=None)
+            enriched_text = self._enrich_user_text_with_companion_context(text=text, speaker=speaker)
+            resp = self.client.chat(enriched_text, source_lang="auto", response_lang=None)
             if resp and "answer" in resp:
                 response_text = resp["answer"]
                 response_actions = resp.get("actions")
@@ -478,8 +697,12 @@ class AutonomyBrain(
                     lang = str(trans.get("response_lang"))
 
             if response_text:
+                if not self._is_active_request(request_id):
+                    return
                 clean_text = self.apply_llm_response(response_text, response_actions, raw_response, speak=False)
                 if clean_text:
+                    if not self._is_active_request(request_id):
+                        return
                     self._remember_person_chat(speaker, clean_text, role="assistant")
                     self._speak_with_mood(clean_text, language=lang)
                     logger.info("Reply: %s", clean_text)
@@ -488,13 +711,75 @@ class AutonomyBrain(
                     logger.info("LLM response only triggered physical actions.")
         except Exception as exc:
             logger.error("Failed to generate reply: %s", exc)
+            self.mood.modify("fear", 15)
+            self.client.push_interaction_event("error", {"source": "ollama", "reason": "chat_failed"})
+            self._apply_emotion_visual_state("fear")
+        finally:
+            with self._speech_req_lock:
+                if self._active_speech_req_id == request_id:
+                    self._speech_busy = False
+
+    def _is_active_request(self, request_id: str) -> bool:
+        with self._speech_req_lock:
+            return self._active_speech_req_id == request_id
 
     def _remember_person_chat(self, speaker: str | None, text: str, role: str) -> None:
         person = str(speaker or "").strip()
         if not person or person.lower() == "unknown" or not text:
             return
         try:
+            self.relationship_memory.add_chat(name=person, role=role, text=text)
+        except Exception:
+            pass
+        try:
             self.client.append_person_chat(person=person, text=text, role=role)
+        except Exception:
+            pass
+
+    def _enrich_user_text_with_companion_context(self, text: str, speaker: str | None) -> str:
+        raw = str(text or "").strip()
+        spk = str(speaker or "").strip()
+        if not raw:
+            return raw
+        if not spk:
+            return raw
+        profile = self.relationship_memory.social_profile(spk)
+        if not profile:
+            return raw
+        likes = profile.get("likes", []) if isinstance(profile.get("likes", []), list) else []
+        topics = profile.get("topics", []) if isinstance(profile.get("topics", []), list) else []
+        top_memory = str(profile.get("top_memory", "")).strip()
+        hints = []
+        if likes:
+            hints.append(f"likes={','.join([str(x) for x in likes[:3]])}")
+        if topics:
+            hints.append(f"topics={','.join([str(x) for x in topics[:3]])}")
+        if top_memory:
+            hints.append(f"memory={top_memory[:90]}")
+        if not hints:
+            return raw
+        enriched = f"{raw}\n\n[CompanionContext speaker={spk}] {', '.join(hints)}"
+        logger.info(
+            "Companion context injected | speaker=%s hints=%s",
+            spk,
+            ", ".join(hints),
+        )
+        try:
+            self.client.push_interaction_event("companion.context_injected", {"speaker": spk})
+        except Exception:
+            pass
+        return enriched
+
+    def _note_person_seen(self, name: str, emotion: str = "") -> None:
+        person = str(name or "").strip()
+        if not person or person.lower() == "unknown":
+            return
+        try:
+            self.relationship_memory.observe_person(
+                name=person,
+                is_owner=bool(self._is_owner_name(person)) if hasattr(self, "_is_owner_name") else False,
+                emotion=emotion,
+            )
         except Exception:
             pass
 
@@ -622,7 +907,7 @@ class AutonomyBrain(
             self.client.push_interaction_event("autonomy.sleep")
             ran = self._run_scene("sleepy_entry", context={"hour": hour})
             if not ran:
-                self.client.move_head(90, 120)
+                self.client.queue_action("head_move", priority=70, payload={"pan": 90, "tilt": 120})
                 self._speak_with_mood("İyi geceler.", emotion="tired")
             self.client.set_speech_tracking(False)
 

--- a/modules/autonomy/services/brain_parts/owner_guard.py
+++ b/modules/autonomy/services/brain_parts/owner_guard.py
@@ -65,78 +65,9 @@ class OwnerGuardMixin:
         return False
 
     def _handle_owner_commands(self, text: str, speaker: str | None) -> bool:
-        if not self._is_owner_context(speaker):
-            return False
-        lowered = text.lower()
-        handled = False
-        temp_cfg = self.owner_cfg.get("temporary", {})
-        # support single keyword or list of keywords for temporary owner commands
-        cmd_kw = temp_cfg.get("command_keyword") or "geçici sahip"
-        if isinstance(cmd_kw, str):
-            keywords = [cmd_kw.lower()]
-        else:
-            keywords = [k.lower() for k in cmd_kw if k]
-        if temp_cfg.get("enabled"):
-            for keyword in keywords:
-                if keyword in lowered:
-                    target = self._extract_temp_owner_name(text, keyword)
-                    if target:
-                        self._assign_temp_owner(target)
-                        handled = True
-                        break
-        if any(phrase in lowered for phrase in ["geçici yetki iptal", "geçici sahip değil"]):
-            self._clear_temp_owner(announce=True)
-            handled = True
-        if any(phrase in lowered for phrase in ["izin ver", "serbest", "cevap verebilirsin"]):
-            self._grant_owner_permission()
-            handled = True
-        # Legacy: Kharuun-specific trigger handling removed.
-        return handled
-
-    def _is_owner_context(self, speaker: str | None) -> bool:
-        if speaker and self._is_owner_name(speaker):
-            return True
-        return self._owner_seen_recently()
-
-    def _extract_temp_owner_name(self, text: str, keyword: str) -> str | None:
-        lower_text = text.lower()
-        idx = lower_text.find(keyword)
-        if idx <= 0:
-            return None
-        candidate = text[:idx].replace("adlı kişi", "").strip()
-        return candidate or None
-
-    def _assign_temp_owner(self, name: str) -> None:
-        cfg = self.owner_cfg.get("temporary", {})
-        duration = cfg.get("duration_s", 600)
-        self.state["temp_owner"] = name
-        self.state["temp_owner_expires"] = time.time() + duration
-        self.client.push_interaction_event("owner.temp_granted", {"name": name})
-        if cfg.get("animation"):
-            self._trigger_animation(cfg["animation"])
-        msg = f"{name}, Baba yokken seni dinleyebilirim ama dikkatli ol."
-        self._speak_with_mood(msg, emotion="neutral")
-        self.memory.add_event(f"Temp owner: {name}")
-
-    def _clear_temp_owner(self, announce: bool = False) -> None:
-        if not self.state.get("temp_owner"):
-            return
-        name = self.state.get("temp_owner")
-        self.state["temp_owner"] = None
-        self.state["temp_owner_expires"] = 0.0
-        self.client.push_interaction_event("owner.temp_revoked", {"name": name})
-        if announce:
-            msg = self.owner_cfg.get("temporary", {}).get("revoke_message", "Geçici yetkiler sona erdi.")
-            self._speak_with_mood(msg, emotion="neutral")
-        self.memory.add_event(f"Temp owner cleared: {name}")
-
-    def _grant_owner_permission(self) -> None:
-        grace = self.owner_cfg.get("permission_grace_s", 600)
-        self.state["owner_permission_until"] = time.time() + grace
-        message = self.owner_cfg.get("permission_message", "Tamam, yanında olmasan da cevap vereceğim.")
-        message = message.replace("{nickname}", self._address_owner("affectionate"))
-        self._speak_with_mood(message, emotion="joy")
-        self.client.push_interaction_event("owner.permission_granted")
+        # Delegation is intentionally disabled: owner cannot transfer authority
+        # to a third person via voice commands.
+        return False
 
     def _owner_guard_enabled(self) -> bool:
         return bool(self.owner_cfg.get("enabled") and self.owner_cfg.get("require_presence", True))
@@ -151,37 +82,21 @@ class OwnerGuardMixin:
     def _owner_cooldown_active(self) -> bool:
         return time.time() < self.state.get("owner_lockout_until", 0.0)
 
-    def _owner_permission_active(self) -> bool:
-        return time.time() < self.state.get("owner_permission_until", 0.0)
-
     def _rfid_active(self) -> bool:
         return time.time() < self.state.get("rfid_authorized_until", 0.0)
-
-    def _temp_owner_active(self) -> bool:
-        now = time.time()
-        expires = self.state.get("temp_owner_expires", 0.0)
-        if self.state.get("temp_owner") and now < expires:
-            return True
-        if self.state.get("temp_owner") and now >= expires:
-            self._clear_temp_owner(announce=True)
-        return False
 
     def _has_full_owner_authority(self) -> bool:
         if not self.owner_cfg.get("enabled"):
             return True
         return any([
             self._owner_seen_recently(),
-            self._owner_permission_active(),
             self._rfid_active(),
         ])
-
-    def _has_any_authority(self) -> bool:
-        return self._has_full_owner_authority() or self._temp_owner_active()
 
     def _maybe_block_request(self, text: str) -> tuple[str, str] | None:
         if not self._owner_guard_enabled():
             return None
-        if self._has_any_authority():
+        if self._has_full_owner_authority():
             return None
         entry = self._record_external_request(text)
         affectionate = self._address_owner("affectionate")
@@ -258,8 +173,6 @@ class OwnerGuardMixin:
         self.state["owner_last_seen"] = timestamp
         self.state["owner_lockout_until"] = 0.0
         self.state["rfid_authorized_until"] = 0.0
-        self.state["owner_permission_until"] = 0.0
-        self._clear_temp_owner()
         affectionate = self._address_owner("affectionate")
         greet_cooldown = max(10, self.owner_cfg.get("presence_timeout_s", 30) / 2)
         if timestamp - self.state.get("owner_last_greet", 0.0) > greet_cooldown:

--- a/modules/autonomy/services/brain_parts/vision.py
+++ b/modules/autonomy/services/brain_parts/vision.py
@@ -18,6 +18,26 @@ class VisionMixin:
         if now - last_poll < interval:
             return
         self.state["last_vision_poll"] = now
+
+        # Use visual context importance score to influence persona polish
+        try:
+            ctx_resp = self.client.get_visual_context()
+            if ctx_resp and ctx_resp.get("available"):
+                ctx_data = ctx_resp.get("context", {})
+                importance = float(ctx_data.get("importance_score", 0.0))
+                self.state["last_visual_importance"] = importance
+                if importance > 0.6:
+                    self.mood.modify("curiosity", int(importance * 20))
+                    self.mood.modify("energy", 10)
+                    if self.state.get("is_bored"):
+                        self.state["is_bored"] = False
+                        self.memory.add_event("Saw something important, no longer bored.")
+                elif importance < 0.2 and self.state.get("is_bored"):
+                    self.mood.modify("happiness", -2)
+        except Exception as exc:
+            import logging
+            logging.getLogger("autonomy.vision").debug("Failed to get visual context: %s", exc)
+
         max_results = self._vision_cfg.get("max_results", 5)
         results = self.client.get_latest_vision_results(limit=max_results)
         if not results:
@@ -52,12 +72,19 @@ class VisionMixin:
         self.memory.add_event(f"Vision {name} tespit etti.")
         if name != "Unknown":
             self._track_person_stat(name)
+            if hasattr(self, "_note_person_seen"):
+                try:
+                    self._note_person_seen(name, emotion=str(result.get("emotion", "") or ""))
+                except Exception:
+                    pass
         happiness_boost = 10 if name != "Unknown" else 4
         self.mood.modify("happiness", happiness_boost)
         self.mood.modify("curiosity", 5)
         self.client.push_interaction_event("vision.person", {"name": name})
         self._focus_on_target(result)
         should_speak = name != "Unknown" or self._vision_cfg.get("speak_on_unknown", False)
+        if not self._should_announce_vision():
+            should_speak = False
         if should_speak:
             utterance = self._compose_greeting_for_person(name, result)
             if utterance:
@@ -101,6 +128,9 @@ class VisionMixin:
             except Exception:
                 pass
         pieces = [f"Merhaba {name}"]
+        conf = result.get("confidence")
+        if isinstance(conf, (int, float)) and float(conf) < 0.5 and name != "Unknown":
+            pieces = [f"Merhaba, bu kişi {name} olabilir"]
         if distance:
             try:
                 pieces.append(f"yaklaşık {float(distance):.1f} metre uzaklıktasın.")
@@ -109,6 +139,11 @@ class VisionMixin:
         if summary:
             pieces.append(summary[:120])
         return " ".join(pieces)
+
+    def _should_announce_vision(self) -> bool:
+        threshold = float(self._vision_cfg.get("importance_speak_threshold", 0.6))
+        current = float(self.state.get("last_visual_importance", 0.0) or 0.0)
+        return current >= threshold
 
     def _focus_on_target(self, result: Dict[str, Any]) -> None:
         if self._trigger_animation("vision_focus"):
@@ -128,7 +163,7 @@ class VisionMixin:
 
         target = int(round((current * smooth) + (proposed * (1.0 - smooth))))
         self.state["current_pan"] = target
-        self.client.move_head(target, self.state["current_tilt"])
+        self.client.queue_action("head_move", priority=60, payload={"pan": target, "tilt": self.state["current_tilt"]})
         self._blink_fallback()
 
     def _compute_person_cooldown(self, result: Dict[str, Any]) -> float:

--- a/modules/autonomy/services/brain_parts/vocal.py
+++ b/modules/autonomy/services/brain_parts/vocal.py
@@ -46,9 +46,13 @@ class VocalMixin:
             return
         tone = self._tone_profile(emotion)
         try:
-            self.client.speak(text, tone=tone, language=language)
+            self.client.queue_action("speak", priority=50, ttl_ms=10000, payload={
+                "text": text,
+                "tone": tone,
+                "language": language
+            })
         except Exception as exc:  # pragma: no cover - best effort speech
-            logger.debug("Failed to speak with tone %s: %s", tone, exc)
+            logger.debug("Failed to queue speech action: %s", exc)
 
     def _tone_profile(self, emotion: str | None = None) -> dict:
         emotion = emotion or self.state.get("last_emotion") or self.mood.get_dominant_emotion() or "neutral"

--- a/modules/autonomy/services/client.py
+++ b/modules/autonomy/services/client.py
@@ -26,27 +26,30 @@ class ServiceClient:
         cfg = config or {}
         self.speech_quiet_cfg = dict(cfg.get("speech_quiet_hours", {}))
         self.offline_cfg = dict(cfg.get("offline_mode", {}))
+        self.request_timeouts = dict(cfg.get("request_timeouts", {}))
         self._availability_cache = {}
 
-    def _post(self, service, endpoint, json=None, params=None):
+    def _post(self, service, endpoint, json=None, params=None, timeout_s=None):
         url = self.urls.get(service)
         if not url:
             return None
         try:
             full_url = f"{url}{endpoint}"
-            resp = requests.post(full_url, json=json, params=params, timeout=1.0)
+            timeout = float(timeout_s) if timeout_s is not None else float(self.request_timeouts.get("default_post_s", 1.0))
+            resp = requests.post(full_url, json=json, params=params, timeout=timeout)
             return resp.json() if resp.status_code == 200 else None
         except Exception as e:
             logger.debug(f"Failed to post to {service}: {e}")
             return None
 
-    def _get(self, service, endpoint, params=None):
+    def _get(self, service, endpoint, params=None, timeout_s=None):
         url = self.urls.get(service)
         if not url:
             return None
         try:
             full_url = f"{url}{endpoint}"
-            resp = requests.get(full_url, params=params, timeout=1.0)
+            timeout = float(timeout_s) if timeout_s is not None else float(self.request_timeouts.get("default_get_s", 1.0))
+            resp = requests.get(full_url, params=params, timeout=timeout)
             return resp.json() if resp.status_code == 200 else None
         except Exception as e:
             logger.debug(f"Failed to get from {service}: {e}")
@@ -246,7 +249,12 @@ class ServiceClient:
             params["source_lang"] = str(source_lang)
         if response_lang:
             params["response_lang"] = str(response_lang)
-        return self._post("ollama", "/chat", None, params=params)
+        timeout = float(self.request_timeouts.get("ollama_chat_s", 20.0))
+        return self._post("ollama", "/chat", None, params=params, timeout_s=timeout)
+
+    def warmup_ollama(self):
+        timeout = float(self.request_timeouts.get("ollama_warmup_s", 2.5))
+        return self._post("ollama", "/warmup", timeout_s=timeout)
 
     def get_speech_direction(self):
         return self._get("speech", "/direction")
@@ -375,6 +383,22 @@ class ServiceClient:
     def get_face_follow_status(self):
         return self._get_vlm("/follow/status")
 
+    # ── Living Vision Agent Methods ──
+
+    def get_visual_context(self):
+        return self._get_vlm("/context/latest")
+
+    def refresh_visual_context(self):
+        return self._post("vlm", "/context/refresh")
+
+    def focus_person(self, person: str):
+        if not person:
+            return None
+        return self._post("vlm", "/focus/person", params={"person": str(person)})
+
+    def start_owner_follow(self):
+        return self._post("vlm", "/follow/owner/start")
+
     def check_rfid(self, endpoint):
         if not endpoint:
             return False
@@ -389,3 +413,35 @@ class ServiceClient:
         except Exception as exc:
             logger.debug("RFID check failed: %s", exc)
             return False
+
+    def queue_action(self, action_type: str, priority: int = 50, ttl_ms: int = 5000, payload: dict = None):
+        if payload is None:
+            payload = {}
+        # Try routing through agent core endpoint (assuming gateway exposes it at /agent)
+        url = self.urls.get("agent_core") or "http://127.0.0.1:8080/agent"
+        try:
+            resp = requests.post(f"{url}/actions/queue", json={
+                "type": action_type,
+                "priority": priority,
+                "ttl_ms": ttl_ms,
+                "payload": payload,
+            }, timeout=1.0)
+            return resp.json() if resp.status_code == 200 else None
+        except Exception as e:
+            logger.debug(f"Failed to queue action {action_type}: {e}")
+            return None
+
+    def emit_agent_event(self, event_type: str, payload: dict | None = None):
+        if payload is None:
+            payload = {}
+        url = self.urls.get("agent_core") or "http://127.0.0.1:8080/agent"
+        try:
+            resp = requests.post(
+                f"{url}/events",
+                json={"type": str(event_type), "payload": payload},
+                timeout=1.0,
+            )
+            return resp.json() if resp.status_code == 200 else None
+        except Exception as e:
+            logger.debug(f"Failed to emit agent event {event_type}: {e}")
+            return None

--- a/modules/autonomy/services/companion_rituals.py
+++ b/modules/autonomy/services/companion_rituals.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import datetime
+import time
+from typing import Any, Dict, Optional
+
+
+class CompanionRituals:
+    """Low-frequency social rituals to improve companion continuity."""
+
+    def __init__(self, cfg: Dict[str, Any]) -> None:
+        self.cfg = cfg if isinstance(cfg, dict) else {}
+        self.enabled = bool(self.cfg.get("enabled", True))
+        self.min_absence_s = float(self.cfg.get("owner_return_min_absence_s", 180.0))
+        self.owner_return_cooldown_s = float(self.cfg.get("owner_return_cooldown_s", 300.0))
+        self.morning_window = tuple(self.cfg.get("morning_window_h", [6, 11]))  # inclusive start/end
+        self._last_owner_return_ts: float = 0.0
+        self._owner_absent_since: float = time.time()
+        self._owner_prev_present: bool = False
+        self._morning_done_day: str = ""
+
+    def propose(self, now_ts: float, owner_present: bool, is_sleeping: bool) -> Optional[Dict[str, Any]]:
+        if not self.enabled or is_sleeping:
+            self._update_owner_presence(now_ts, owner_present)
+            return None
+
+        proposal = self._propose_morning(owner_present)
+        if proposal:
+            self._update_owner_presence(now_ts, owner_present)
+            return proposal
+
+        proposal = self._propose_owner_return(now_ts, owner_present)
+        self._update_owner_presence(now_ts, owner_present)
+        return proposal
+
+    def _propose_morning(self, owner_present: bool) -> Optional[Dict[str, Any]]:
+        if not owner_present:
+            return None
+        now = datetime.datetime.now()
+        day_key = now.strftime("%Y-%m-%d")
+        if self._morning_done_day == day_key:
+            return None
+        start_h, end_h = self._safe_window()
+        if not (start_h <= now.hour <= end_h):
+            return None
+        self._morning_done_day = day_key
+        return {
+            "text": "Gunaydin, bugun nasil hissettigini merak ediyorum.",
+            "emotion": "joy",
+            "event": "companion.ritual.morning",
+        }
+
+    def _propose_owner_return(self, now_ts: float, owner_present: bool) -> Optional[Dict[str, Any]]:
+        if not owner_present:
+            return None
+        if self._owner_prev_present:
+            return None
+        absence_s = max(0.0, now_ts - self._owner_absent_since)
+        if absence_s < self.min_absence_s:
+            return None
+        if (now_ts - self._last_owner_return_ts) < self.owner_return_cooldown_s:
+            return None
+        self._last_owner_return_ts = now_ts
+        return {
+            "text": "Tekrar hos geldin, seni gormek iyi hissettirdi.",
+            "emotion": "joy",
+            "event": "companion.ritual.owner_return",
+        }
+
+    def _update_owner_presence(self, now_ts: float, owner_present: bool) -> None:
+        if not owner_present:
+            if self._owner_prev_present:
+                self._owner_absent_since = now_ts
+            self._owner_prev_present = False
+            return
+        self._owner_prev_present = True
+
+    def _safe_window(self) -> tuple[int, int]:
+        try:
+            start_h = int(self.morning_window[0])
+            end_h = int(self.morning_window[1])
+        except Exception:
+            return (6, 11)
+        start_h = max(0, min(23, start_h))
+        end_h = max(0, min(23, end_h))
+        if start_h > end_h:
+            return (6, 11)
+        return (start_h, end_h)

--- a/modules/autonomy/services/proactive_planner.py
+++ b/modules/autonomy/services/proactive_planner.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Dict, Optional
+
+
+class ProactivePlanner:
+    """Small rule-based planner for low-frequency companion proactivity."""
+
+    def __init__(self, cfg: Dict[str, Any]) -> None:
+        self.cfg = cfg if isinstance(cfg, dict) else {}
+        self.enabled = bool(self.cfg.get("enabled", True))
+        self.cooldown_s = float(self.cfg.get("cooldown_s", 70.0))
+        self.min_idle_s = float(self.cfg.get("min_idle_s", 45.0))
+        self.max_per_hour = int(self.cfg.get("max_per_hour", 4))
+        self.owner_only = bool(self.cfg.get("owner_only", False))
+        self.enable_callback_lines = bool(self.cfg.get("enable_callback_lines", True))
+        policy_cfg = self.cfg.get("policy", {}) if isinstance(self.cfg.get("policy", {}), dict) else {}
+        self.owner_style = str(policy_cfg.get("owner_style", "warm")).strip().lower() or "warm"
+        self.guest_style = str(policy_cfg.get("guest_style", "respectful")).strip().lower() or "respectful"
+        self._last_ts = 0.0
+        self._events: list[float] = []
+        self._rng = random.Random()
+
+    def propose(
+        self,
+        now_ts: float,
+        idle_s: float,
+        dominant_emotion: str,
+        last_speaker: str,
+        owner_present: bool,
+        social_profile: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        if not self.enabled:
+            return None
+        if idle_s < self.min_idle_s:
+            return None
+        if (now_ts - self._last_ts) < self.cooldown_s:
+            return None
+        if self.owner_only and not owner_present:
+            return None
+        self._trim_events(now_ts)
+        if len(self._events) >= self.max_per_hour:
+            return None
+
+        mood = str(dominant_emotion or "neutral").strip().lower()
+        speaker = str(last_speaker or "").strip()
+        line = self._pick_line(
+            mood=mood,
+            speaker=speaker,
+            owner_present=owner_present,
+            social_profile=social_profile or {},
+        )
+        if not line:
+            return None
+        self._last_ts = now_ts
+        self._events.append(now_ts)
+        return {
+            "text": line,
+            "emotion": "curiosity" if mood in {"neutral", "tired"} else mood,
+            "event": "companion.proactive",
+        }
+
+    def _pick_line(self, mood: str, speaker: str, owner_present: bool, social_profile: Dict[str, Any]) -> str:
+        if self.enable_callback_lines:
+            callback = self._callback_line(social_profile=social_profile, speaker=speaker, owner_present=owner_present)
+            if callback:
+                return callback
+
+        if mood == "tired":
+            pool = [
+                "Bugun biraz yavasim ama seninleyim.",
+                "Biraz dinleniyorum, istersen kisa sohbet edelim.",
+            ]
+            return self._rng.choice(pool)
+        if mood in {"sad", "sadness"}:
+            pool = [
+                "Sessizlik oldu, yine de yanindayim.",
+                "Biraz sessiz kaldik, nasil gidiyor?",
+            ]
+            return self._rng.choice(pool)
+        if owner_present:
+            pool = [
+                "Buradayim, istersen etrafa birlikte bakalim.",
+                "Seni gorunce daha iyi hissediyorum.",
+            ]
+            if self.owner_style == "warm":
+                pool.extend(
+                    [
+                        "Yanindayken daha guvende hissediyorum.",
+                        "Sana eslik etmek hosuma gidiyor.",
+                    ]
+                )
+            return self._rng.choice(pool)
+        if speaker:
+            if self.guest_style == "respectful":
+                return f"{speaker}, istersen kisa bir sey deneyebiliriz."
+            return f"{speaker}, hadi birlikte bir sey deneyelim."
+        pool = [
+            "Merak ettigim bir sey var, ortamda yeni bir degisiklik var mi?",
+            "Hazirim, istersen yeni bir sey deneyebiliriz.",
+        ]
+        return self._rng.choice(pool)
+
+    def _callback_line(self, social_profile: Dict[str, Any], speaker: str, owner_present: bool) -> str:
+        if not social_profile:
+            return ""
+        last_user_utt = str(social_profile.get("last_user_utterance", "")).strip()
+        likes = social_profile.get("likes", []) if isinstance(social_profile.get("likes", []), list) else []
+        topics = social_profile.get("topics", []) if isinstance(social_profile.get("topics", []), list) else []
+        name = str(social_profile.get("name", "")).strip() or speaker
+        if likes:
+            pick = str(likes[-1]).strip()
+            if pick:
+                if owner_present:
+                    return f"{name}, {pick} sevdigini soylemistin; istersen onunla ilgili konusalim."
+                return f"{name}, {pick} konusunu acmak ister misin?"
+        if topics:
+            t = str(topics[-1]).strip()
+            if t:
+                return f"Az once {t} hakkinda konusuyorduk, devam edelim mi?"
+        if last_user_utt and len(last_user_utt) >= 8:
+            short = last_user_utt[:72].rstrip()
+            return f"Az once '{short}' demistin, buna geri donmek ister misin?"
+        return ""
+
+    def _trim_events(self, now_ts: float) -> None:
+        window = 3600.0
+        self._events = [t for t in self._events if (now_ts - t) <= window]

--- a/modules/autonomy/services/relationship_memory.py
+++ b/modules/autonomy/services/relationship_memory.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class RelationshipMemory:
+    """Lightweight per-person social memory for companion behavior."""
+
+    def __init__(self, enabled: bool = True, path: str = "") -> None:
+        self.enabled = bool(enabled)
+        self.path = Path(path).resolve() if path else None
+        self._people: Dict[str, Dict[str, Any]] = {}
+        if self.enabled:
+            self._load()
+
+    def observe_person(self, name: str, is_owner: bool = False, emotion: str = "") -> None:
+        if not self.enabled:
+            return
+        key = self._normalize(name)
+        if not key:
+            return
+        now = time.time()
+        rec = self._people.setdefault(
+            key,
+            {
+                "name": name,
+                "first_seen": now,
+                "last_seen": 0.0,
+                "seen_count": 0,
+                "is_owner": False,
+                "last_emotion": "",
+                "chat_history": [],
+                "preferences": {},
+                "moments": [],
+            },
+        )
+        rec["name"] = name
+        rec["last_seen"] = now
+        rec["seen_count"] = int(rec.get("seen_count", 0)) + 1
+        rec["is_owner"] = bool(rec.get("is_owner", False) or is_owner)
+        if emotion:
+            rec["last_emotion"] = str(emotion)
+        self._persist()
+
+    def add_chat(self, name: str, role: str, text: str) -> None:
+        if not self.enabled:
+            return
+        key = self._normalize(name)
+        text_val = str(text or "").strip()
+        if not key or not text_val:
+            return
+        self.observe_person(name=name)
+        rec = self._people.get(key)
+        if rec is None:
+            return
+        hist = rec.setdefault("chat_history", [])
+        hist.append({"ts": time.time(), "role": str(role or "user"), "text": text_val[:240]})
+        if len(hist) > 16:
+            del hist[:-16]
+        if str(role or "").strip().lower() == "user":
+            self._extract_preferences(rec, text_val)
+            self._add_moment(rec, text=f"user:{text_val}", salience=0.35)
+        self._persist()
+
+    def top_people(self, limit: int = 3) -> List[Dict[str, Any]]:
+        rows = list(self._people.values())
+        rows.sort(key=lambda r: (int(r.get("seen_count", 0)), float(r.get("last_seen", 0.0))), reverse=True)
+        return rows[: max(1, int(limit))]
+
+    def get(self, name: str) -> Optional[Dict[str, Any]]:
+        return self._people.get(self._normalize(name))
+
+    def last_user_utterance(self, name: str) -> str:
+        rec = self.get(name)
+        if not rec:
+            return ""
+        hist = rec.get("chat_history", [])
+        if not isinstance(hist, list):
+            return ""
+        for item in reversed(hist):
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("role", "")).strip().lower() == "user":
+                return str(item.get("text", "")).strip()
+        return ""
+
+    def social_profile(self, name: str) -> Dict[str, Any]:
+        rec = self.get(name) or {}
+        prefs = rec.get("preferences", {}) if isinstance(rec.get("preferences", {}), dict) else {}
+        likes = prefs.get("likes", []) if isinstance(prefs.get("likes", []), list) else []
+        dislikes = prefs.get("dislikes", []) if isinstance(prefs.get("dislikes", []), list) else []
+        topics = prefs.get("topics", []) if isinstance(prefs.get("topics", []), list) else []
+        self._decay_moments(rec)
+        moments = rec.get("moments", []) if isinstance(rec.get("moments", []), list) else []
+        top_memory = ""
+        if moments:
+            moments.sort(key=lambda m: float(m.get("score", 0.0)), reverse=True)
+            top_memory = str((moments[0] or {}).get("text", "")).strip()
+        return {
+            "name": rec.get("name", name),
+            "is_owner": bool(rec.get("is_owner", False)),
+            "seen_count": int(rec.get("seen_count", 0) or 0),
+            "likes": likes[:5],
+            "dislikes": dislikes[:5],
+            "topics": topics[:6],
+            "last_user_utterance": self.last_user_utterance(name),
+            "top_memory": top_memory[:180],
+        }
+
+    def build_social_context(self, current_speaker: str = "") -> str:
+        if not self.enabled:
+            return ""
+        lines: List[str] = []
+        top = self.top_people(limit=3)
+        if top:
+            lines.append("Recent social context:")
+        for p in top:
+            pname = str(p.get("name", "Unknown"))
+            seen = int(p.get("seen_count", 0))
+            is_owner = bool(p.get("is_owner", False))
+            last_em = str(p.get("last_emotion", "")).strip()
+            tag = "owner" if is_owner else "known"
+            line = f"- {pname} ({tag}), seen={seen}"
+            if last_em:
+                line += f", last_emotion={last_em}"
+            lines.append(line)
+        if current_speaker:
+            lines.append(f"Current speaker guess: {current_speaker}")
+        return "\n".join(lines).strip()
+
+    @staticmethod
+    def _normalize(name: str) -> str:
+        return str(name or "").strip().lower()
+
+    def _load(self) -> None:
+        if self.path is None or not self.path.exists():
+            return
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                self._people = raw
+        except Exception:
+            self._people = {}
+
+    def _persist(self) -> None:
+        if self.path is None:
+            return
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.write_text(json.dumps(self._people, ensure_ascii=True, indent=2), encoding="utf-8")
+        except Exception:
+            pass
+
+    def _extract_preferences(self, rec: Dict[str, Any], text: str) -> None:
+        prefs = rec.setdefault("preferences", {})
+        likes = prefs.setdefault("likes", [])
+        dislikes = prefs.setdefault("dislikes", [])
+        topics = prefs.setdefault("topics", [])
+        low = str(text or "").strip().lower()
+        if not low:
+            return
+
+        patterns_like = [
+            r"\b(?:seviyorum|hoslaniyorum|bayiliyorum)\s+([a-z0-9_\-\s]{2,40})",
+            r"\b(?:i like|i love)\s+([a-z0-9_\-\s]{2,40})",
+            r"\b(?:favorim|favorite)\s+([a-z0-9_\-\s]{2,40})",
+        ]
+        patterns_dislike = [
+            r"\b(?:sevmiyorum|nefret ediyorum)\s+([a-z0-9_\-\s]{2,40})",
+            r"\b(?:i hate|i dislike)\s+([a-z0-9_\-\s]{2,40})",
+        ]
+
+        for pat in patterns_like:
+            for m in re.findall(pat, low):
+                val = str(m).strip(" .,!?:;")
+                if 2 <= len(val) <= 40 and val not in likes:
+                    likes.append(val)
+                    self._add_moment(rec, text=f"likes:{val}", salience=0.6)
+
+        for pat in patterns_dislike:
+            for m in re.findall(pat, low):
+                val = str(m).strip(" .,!?:;")
+                if 2 <= len(val) <= 40 and val not in dislikes:
+                    dislikes.append(val)
+                    self._add_moment(rec, text=f"dislikes:{val}", salience=0.65)
+
+        if "?" in low:
+            for token in ["muzik", "film", "oyun", "okul", "is", "hava", "spor", "robot", "yazilim", "ai"]:
+                if token in low and token not in topics:
+                    topics.append(token)
+                    self._add_moment(rec, text=f"topic:{token}", salience=0.45)
+
+        if len(likes) > 12:
+            del likes[:-12]
+        if len(dislikes) > 12:
+            del dislikes[:-12]
+        if len(topics) > 16:
+            del topics[:-16]
+
+    def _add_moment(self, rec: Dict[str, Any], text: str, salience: float) -> None:
+        moments = rec.setdefault("moments", [])
+        if not isinstance(moments, list):
+            rec["moments"] = []
+            moments = rec["moments"]
+        now = time.time()
+        val = str(text or "").strip()[:220]
+        if not val:
+            return
+        for m in moments:
+            if not isinstance(m, dict):
+                continue
+            if str(m.get("text", "")).strip() == val:
+                m["score"] = min(1.0, float(m.get("score", 0.0)) + float(salience))
+                m["updated_at"] = now
+                self._decay_moments(rec)
+                return
+        moments.append(
+            {
+                "text": val,
+                "score": max(0.05, min(1.0, float(salience))),
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+        self._decay_moments(rec)
+
+    def _decay_moments(self, rec: Dict[str, Any]) -> None:
+        moments = rec.get("moments", [])
+        if not isinstance(moments, list):
+            return
+        now = time.time()
+        half_life_s = 2.5 * 24 * 3600.0
+        decay_per_sec = 0.5 / half_life_s
+        kept = []
+        for m in moments:
+            if not isinstance(m, dict):
+                continue
+            updated = float(m.get("updated_at", now) or now)
+            dt = max(0.0, now - updated)
+            score = float(m.get("score", 0.0)) - (dt * decay_per_sec)
+            score = max(0.0, min(1.0, score))
+            if score < 0.08:
+                continue
+            m["score"] = score
+            m["updated_at"] = now
+            kept.append(m)
+        kept.sort(key=lambda x: float(x.get("score", 0.0)), reverse=True)
+        rec["moments"] = kept[:24]

--- a/modules/autonomy/tests/test_living_vision_request_cancel.py
+++ b/modules/autonomy/tests/test_living_vision_request_cancel.py
@@ -1,0 +1,10 @@
+from modules.autonomy.services.brain import AutonomyBrain
+
+
+def test_request_id_switch_marks_old_inactive():
+    brain = AutonomyBrain({"llm": {"enabled": False}, "vision_hooks": {"enabled": False}})
+    brain._active_speech_req_id = "old_req"
+    assert brain._is_active_request("old_req") is True
+    brain._active_speech_req_id = "new_req"
+    assert brain._is_active_request("old_req") is False
+    assert brain._is_active_request("new_req") is True

--- a/modules/autonomy/tests/test_offline_fallback.py
+++ b/modules/autonomy/tests/test_offline_fallback.py
@@ -25,6 +25,11 @@ class _OfflineClient:
         self.spoken.append(text)
         return {"ok": True}
 
+    def queue_action(self, action_type, priority=50, payload=None, source="test", ttl_ms=5000):
+        if action_type == "speak" and payload and payload.get("text"):
+            self.spoken.append(payload["text"])
+        return {"ok": True}
+
     def chat(self, query, apply_actions: bool = False, source_lang=None, response_lang=None):
         self.chat_called += 1
         return {"answer": "should-not-happen"}

--- a/modules/autonomy/tests/test_vision_focus_tuning.py
+++ b/modules/autonomy/tests/test_vision_focus_tuning.py
@@ -14,6 +14,11 @@ class _FocusClient:
     def move_head(self, pan, tilt):
         self.moves.append((int(pan), int(tilt)))
 
+    def queue_action(self, action_type, priority=50, ttl_ms=5000, payload=None):
+        payload = payload or {}
+        if action_type == "head_move":
+            self.moves.append((int(payload.get("pan", 90)), int(payload.get("tilt", 90))))
+
 
 class _FocusBrain(VisionMixin):
     def __init__(self):
@@ -63,3 +68,12 @@ def test_scene_picker_prefers_owner_then_close_variants():
     assert brain._pick_vision_scene("owner", {"distance_m": 2.0}) == "vision_greeting_owner"
     assert brain._pick_vision_scene("Unknown", {"distance_m": 0.9}) == "vision_greeting_unknown_close"
     assert brain._pick_vision_scene("Ali", {"distance_m": 0.9}) == "vision_greeting_known_close"
+
+
+def test_vision_announce_threshold_gate():
+    brain = _FocusBrain()
+    brain._vision_cfg["importance_speak_threshold"] = 0.6
+    brain.state["last_visual_importance"] = 0.59
+    assert brain._should_announce_vision() is False
+    brain.state["last_visual_importance"] = 0.6
+    assert brain._should_announce_vision() is True

--- a/modules/gateway/services/bootstrap.py
+++ b/modules/gateway/services/bootstrap.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 from typing import Dict, Any, Optional
 import os
 
@@ -603,6 +603,24 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
             logger.info("arduino->neopixel event bridge mounted (rate-limited)")
         except Exception as exc:
             logger.warning("arduino->neopixel bridge mount failed: %s", exc)
+
+    # Living Vision wiring: VLM event bus -> Autonomy -> Agent Core events
+    vlm_bridge = started.get("vlm_bridge")
+    autonomy = started.get("autonomy")
+    try:
+        brain = getattr(autonomy, "brain", None)
+        if vlm_bridge is not None and brain is not None and hasattr(vlm_bridge, "event_bus") and getattr(vlm_bridge, "event_bus", None):
+            def _forward_vlm_event(event_type: str, data: Dict[str, Any]) -> None:
+                try:
+                    if hasattr(brain, "client") and hasattr(brain.client, "emit_agent_event"):
+                        brain.client.emit_agent_event(event_type, data)
+                except Exception:
+                    pass
+
+            vlm_bridge.event_bus.subscribe_all(_forward_vlm_event)
+            logger.info("vlm event bus -> agent event bridge mounted")
+    except Exception as exc:
+        logger.warning("vlm/autonomy event bridge mount failed: %s", exc)
 
     return started
 

--- a/modules/interactions/services/engine.py
+++ b/modules/interactions/services/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import logging
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple
@@ -13,6 +14,8 @@ except Exception:  # pragma: no cover
 from .metrics import MetricsCollector
 from .rules import Rule, eval_condition, priority_rank
 from .adapters.neopixel_client import NeoHttpClient, NoOpNeoClient
+
+logger = logging.getLogger("interactions.engine")
 
 
 class InteractionEngine:
@@ -98,6 +101,7 @@ class InteractionEngine:
         self._last_base: Optional[Tuple[str, Optional[str | tuple[int, int, int]]]] = None
         self._active_effect_until: float = 0.0
         self._ctx: Dict[str, Any] = {"arduino_connected": False}
+        self._event_counts: Dict[str, int] = {}
         self._last_net_burst: float = 0.0
         self.monitor_cfg = dict(cfg.get("monitor", {}))
         self._last_arduino_check = 0.0
@@ -119,13 +123,18 @@ class InteractionEngine:
 
     # API
     def push_event(self, type_: str, data: Optional[Dict[str, Any]] = None) -> None:
+        evt = str(type_ or "").strip()
         with self._lock:
-            self._ctx["event"] = type_
+            self._ctx["event"] = evt
             if data:
                 self._ctx.setdefault("event_data", {}).update(data)
+            if evt:
+                self._event_counts[evt] = int(self._event_counts.get(evt, 0)) + 1
+        if evt.startswith("companion."):
+            logger.info("Companion event received: %s data=%s", evt, data or {})
         for handler in list(self._event_handlers):
             try:
-                handler(type_, data or {})
+                handler(evt, data or {})
             except Exception:
                 pass
 
@@ -152,6 +161,7 @@ class InteractionEngine:
                 "metrics": self._ctx.get("metrics"),
                 "active_base": self._last_base,
                 "effect_active": time.time() < self._active_effect_until,
+                "event_counts": dict(self._event_counts),
                 "ctx": {k: v for k, v in self._ctx.items() if k not in ("metrics",)},
             }
 

--- a/modules/oled_faces/config/config.yml
+++ b/modules/oled_faces/config/config.yml
@@ -4,6 +4,20 @@ server:
 
 enabled: true
 poll_interval_s: 0.7
+min_switch_interval_s: 0.55
+animation_hold_s: 1.4
+bitmap_hold_s: 0.35
+event_cooldown_s: 0.8
+priority_map:
+  error: 95
+  warning: 90
+  owner.locked: 92
+  autonomy.look_around: 45
+  autonomy.blink: 35
+  vision.focus: 55
+  emotion:fear: 88
+  emotion:angry: 86
+  emotion:furious: 90
 
 display:
   enabled: true

--- a/modules/oled_faces/xOledFacesService.py
+++ b/modules/oled_faces/xOledFacesService.py
@@ -24,6 +24,10 @@ class xOledFacesService:
         self._last_operational = None
         self._last_emotions = None
         self._last_sent: Optional[tuple[str, str]] = None
+        self._last_apply_ts: float = 0.0
+        self._active_hold_until: float = 0.0
+        self._active_priority: int = 0
+        self._last_event_ts: Dict[str, float] = {}
 
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
@@ -57,12 +61,15 @@ class xOledFacesService:
     def on_interaction_event(self, event_type: str, data: Optional[Dict[str, Any]] = None) -> None:
         if not self.cfg.get("enabled", True):
             return
+        if self._event_rate_limited(event_type):
+            return
         action = self.mapper.from_interaction_event(event_type)
-        self._apply(action)
+        pri = self._priority_for(source="event", event_type=event_type, action=action)
+        self._apply(action, priority=pri)
 
     def apply_manual(self, mode: str, name: str) -> Dict[str, Any]:
         action = OledAction(mode=str(mode), name=str(name))
-        ok = self._apply(action)
+        ok = self._apply(action, priority=100, force=True)
         return {"ok": ok, "mode": action.mode, "name": action.name}
 
     def _loop(self) -> None:
@@ -84,24 +91,72 @@ class xOledFacesService:
 
         if emotions != self._last_emotions and emotions:
             self._last_emotions = list(emotions)
-            self._apply(self.mapper.from_emotions(emotions))
+            action = self.mapper.from_emotions(emotions)
+            pri = self._priority_for(source="emotion", event_type=f"emotion:{emotions[0]}", action=action)
+            self._apply(action, priority=pri)
             return
 
         if operational != self._last_operational:
             self._last_operational = operational
-            self._apply(self.mapper.from_operational(operational))
+            action = self.mapper.from_operational(operational)
+            pri = self._priority_for(source="state", event_type=operational, action=action)
+            self._apply(action, priority=pri)
 
     def _boot_action(self) -> OledAction:
         boot_mode = str(self.cfg.get("boot", {}).get("mode", "logo"))
         boot_name = str(self.cfg.get("boot", {}).get("name", "logo"))
         return OledAction(mode=boot_mode, name=boot_name)
 
-    def _apply(self, action: OledAction) -> bool:
+    def _event_rate_limited(self, event_type: str) -> bool:
+        now = time.time()
+        cooldown_s = float(self.cfg.get("event_cooldown_s", 0.8))
+        key = str(event_type or "").strip().lower()
+        if not key:
+            return False
+        last = float(self._last_event_ts.get(key, 0.0))
+        if now - last < max(0.05, cooldown_s):
+            return True
+        self._last_event_ts[key] = now
+        return False
+
+    def _priority_for(self, source: str, event_type: str, action: OledAction) -> int:
+        key = str(event_type or "").strip().lower()
+        pri_map = self.cfg.get("priority_map", {}) if isinstance(self.cfg.get("priority_map"), dict) else {}
+        if key in pri_map:
+            try:
+                return int(pri_map.get(key))
+            except Exception:
+                pass
+        mode = str(action.mode or "").strip().lower()
+        if source == "event":
+            if "error" in key or "warning" in key or "owner.locked" in key:
+                return 90
+            if mode == "animation":
+                return 70
+            return 65
+        if source == "emotion":
+            if "fear" in key or "angry" in key or "furious" in key:
+                return 85
+            return 60
+        if source == "state":
+            return 40 if mode == "bitmap" else 50
+        return 50
+
+    def _apply(self, action: OledAction, priority: int = 50, force: bool = False) -> bool:
         if not bool(self.cfg.get("enabled", True)):
             return False
+        now = time.time()
         mode = action.mode.strip().lower()
         name = action.name.strip().lower()
         sent_key = (mode, name)
+
+        min_interval = float(self.cfg.get("min_switch_interval_s", 0.45))
+        if not force and sent_key != self._last_sent and (now - self._last_apply_ts) < max(0.03, min_interval):
+            return False
+
+        if not force and now < self._active_hold_until and priority < self._active_priority and sent_key != self._last_sent:
+            return False
+
         if sent_key == self._last_sent and mode != "animation":
             return True
         try:
@@ -119,6 +174,12 @@ class xOledFacesService:
             if not ok:
                 return False
             self._last_sent = sent_key
+            self._last_apply_ts = now
+            self._active_priority = int(priority)
+            if mode == "animation":
+                self._active_hold_until = now + max(0.2, float(self.cfg.get("animation_hold_s", 1.2)))
+            else:
+                self._active_hold_until = now + max(0.05, float(self.cfg.get("bitmap_hold_s", 0.25)))
             return True
         except Exception:
             return False


### PR DESCRIPTION
## Summary
- add companion memory, proactive planner, and ritual services to autonomy for relationship-aware social behavior
- integrate the companion path into autonomy brain/runtime flows, owner-guard policy, and related gateway/interactions/oled surfaces
- extend autonomy tests for living-vision request cancellation and companion-related client compatibility cases

## Test plan
- [ ] Run `pytest modules/autonomy/tests/test_living_vision_request_cancel.py`
- [ ] Run `pytest modules/autonomy/tests/test_offline_fallback.py`
- [ ] Run `pytest modules/autonomy/tests/test_vision_focus_tuning.py`
- [ ] Exercise autonomy runtime and verify companion telemetry appears in normal logs

Made with [Cursor](https://cursor.com)