### PR TITLE
feat(config): runtime profiles for Google AI Studio and remote Ollama

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -214,6 +214,10 @@ jobs:
       - name: Update PR latest test status section
         if: ${{ github.event_name == 'pull_request' && always() }}
         uses: actions/github-script@v7
+        env:
+          PYTEST_STATUS: ${{ steps.summary.outputs.status }}
+          PYTEST_STAGE: ${{ steps.summary.outputs.stage }}
+          PYTEST_SUMMARY_LINE: ${{ steps.summary.outputs.summary_line }}
         with:
           script: |
             const fs = require('fs');
@@ -222,11 +226,11 @@ jobs:
             const repo = context.repo.repo;
             const issue_number = context.payload.pull_request.number;
 
-            const status = '${{ steps.summary.outputs.status }}';
-            const stage = '${{ steps.summary.outputs.stage }}';
+            const status = process.env.PYTEST_STATUS || '';
+            const stage = process.env.PYTEST_STAGE || '';
             const icon = status === 'PASSED' ? '✅' : '❌';
 
-            let summary = '${{ steps.summary.outputs.summary_line }}';
+            let summary = process.env.PYTEST_SUMMARY_LINE || '';
             if (!summary || summary.trim() === '') {
               if (fs.existsSync('pytest_collect_output.txt')) {
                 const lines = fs.readFileSync('pytest_collect_output.txt', 'utf8').split(/\r?\n/).filter(Boolean);

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -27,6 +27,69 @@ ollama:
   model: "qwen3.5:9b"
   request_timeout: 60
 
+google_ai_studio:
+  api_key: ""   # bos birakilirsa GOOGLE_API_KEY env kullanilir
+  model: "gemini-2.0-flash"
+  base_url: "https://generativelanguage.googleapis.com"
+  request_timeout: 45
+
+# Tek anahtar ile LLM + VLM + ESP URL degistir: active satirini degistir.
+runtime_profile:
+  active: google_ai_studio   # google_ai_studio | remote_ollama
+
+  profiles:
+    google_ai_studio:
+      llm:
+        provider: google_ai_studio
+      agent:
+        model: "gemini-2.0-flash"
+        request_timeout: 45
+      google_ai_studio:
+        model: "gemini-2.0-flash"
+        request_timeout: 45
+      vlm_bridge:
+        llm:
+          provider: google_ai_studio
+        vision_llm:
+          enabled: true
+          provider: google_ai_studio
+        ollama:
+          endpoint: "http://127.0.0.1:8080/ollama/chat"
+          timeout: 12.0
+      arduino_serial:
+        esp_base_url: "http://sentrybot-2.local:8080"
+      esp_link:
+        base_url: "http://sentrybot-2.local:8080"
+
+    remote_ollama:
+      llm:
+        provider: ollama
+      agent:
+        model: "qwen3.5:9b"
+        ollama_base_url: "http://127.0.0.1:11434"
+        request_timeout: 60
+      ollama:
+        base_url: "http://127.0.0.1:11434"
+        model: "qwen3.5:9b"
+        request_timeout: 60
+      vlm_bridge:
+        llm:
+          provider: ollama
+        vision_llm:
+          enabled: true
+          provider: ollama
+          base_url: "http://127.0.0.1:11434"
+          model: "qwen3-vl:8b"
+          timeout_s: 18
+        ollama:
+          endpoint: "http://127.0.0.1:8080/ollama/chat"
+          model: "qwen3.5:9b"
+          timeout: 12.0
+      arduino_serial:
+        esp_base_url: "http://sentrybot-2.local:8080"
+      esp_link:
+        base_url: "http://sentrybot-2.local:8080"
+
 ollama_service:
   server:
     host: 0.0.0.0

--- a/modules/agent_core/config_loader.py
+++ b/modules/agent_core/config_loader.py
@@ -5,7 +5,8 @@ from typing import Any, Dict
 
 from modules.config_center.agent_yaml_loader import load_agent_config, require_dict_section
 
-_REQUIRED_MODEL = "qwen3.5:9b"
+_REQUIRED_OLLAMA_MODEL = "qwen3.5:9b"
+_GOOGLE_PROVIDERS = frozenset({"google", "google_ai_studio", "gemini"})
 
 
 def _to_float(raw: Any, fallback: float) -> float:
@@ -33,18 +34,53 @@ def _normalize_base_url(raw: Any) -> str:
     return str(raw or "").strip().rstrip("/")
 
 
-def _enforce_policy(cfg: Dict[str, Any]) -> Dict[str, Any]:
+def _enforce_google_policy(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    agent_cfg = require_dict_section(cfg, "agent")
+    llm_cfg = require_dict_section(cfg, "llm")
+    google_cfg = cfg.get("google_ai_studio", {}) if isinstance(cfg.get("google_ai_studio", {}), dict) else {}
+
+    model = (
+        str(google_cfg.get("model", "")).strip()
+        or _pick_model(agent_cfg, llm_cfg, {})
+        or "gemini-2.0-flash"
+    )
+    request_timeout = _to_float(
+        google_cfg.get("request_timeout", agent_cfg.get("request_timeout", 45.0)),
+        45.0,
+    )
+
+    agent_cfg["model"] = model
+    agent_cfg["request_timeout"] = request_timeout
+
+    llm_cfg["provider"] = "google_ai_studio"
+    llm_cfg["model"] = model
+    llm_cfg["primary_model"] = model
+    llm_cfg["single_model_mode"] = True
+    llm_cfg["clm_fallback_enabled"] = False
+    llm_cfg["clm_fallback_model"] = ""
+    llm_cfg["fallback_on_missing_model"] = False
+    llm_cfg["fallback_on_error"] = False
+
+    cfg["google_ai_studio"] = {
+        **google_cfg,
+        "model": model,
+        "request_timeout": request_timeout,
+    }
+    cfg["agent"] = agent_cfg
+    cfg["llm"] = llm_cfg
+    return cfg
+
+
+def _enforce_ollama_policy(cfg: Dict[str, Any]) -> Dict[str, Any]:
     agent_cfg = require_dict_section(cfg, "agent")
     llm_cfg = require_dict_section(cfg, "llm")
     ollama_cfg = cfg.get("ollama", {}) if isinstance(cfg.get("ollama", {}), dict) else {}
 
-    provider = str(llm_cfg.get("provider", "ollama")).strip().lower() or "ollama"
-    if provider != "ollama":
-        raise ValueError("Only ollama provider is allowed in strict single-source mode")
-
-    model = _pick_model(agent_cfg, llm_cfg, ollama_cfg)
-    if model != _REQUIRED_MODEL:
-        raise ValueError(f"Single-model policy requires model '{_REQUIRED_MODEL}', got '{model or '<empty>'}'")
+    model = _pick_model(agent_cfg, llm_cfg, ollama_cfg) or _REQUIRED_OLLAMA_MODEL
+    if model != _REQUIRED_OLLAMA_MODEL:
+        raise ValueError(
+            f"Ollama profile requires model '{_REQUIRED_OLLAMA_MODEL}', got '{model}'"
+        )
 
     base_url = _normalize_base_url(
         agent_cfg.get("ollama_base_url")
@@ -54,21 +90,21 @@ def _enforce_policy(cfg: Dict[str, Any]) -> Dict[str, Any]:
         or "http://127.0.0.1:11434"
     )
     if not base_url:
-        raise ValueError("agent.ollama_base_url is required")
+        raise ValueError("agent.ollama_base_url is required for ollama profile")
 
     request_timeout = _to_float(
         agent_cfg.get("request_timeout", ollama_cfg.get("request_timeout", 60.0)),
         60.0,
     )
 
-    agent_cfg["model"] = _REQUIRED_MODEL
+    agent_cfg["model"] = model
     agent_cfg["ollama_base_url"] = base_url
     agent_cfg["request_timeout"] = request_timeout
 
     llm_cfg["provider"] = "ollama"
     llm_cfg["single_model_mode"] = True
-    llm_cfg["model"] = _REQUIRED_MODEL
-    llm_cfg["primary_model"] = _REQUIRED_MODEL
+    llm_cfg["model"] = model
+    llm_cfg["primary_model"] = model
     llm_cfg["base_url"] = base_url
     llm_cfg["clm_fallback_enabled"] = False
     llm_cfg["clm_fallback_model"] = ""
@@ -78,12 +114,20 @@ def _enforce_policy(cfg: Dict[str, Any]) -> Dict[str, Any]:
     cfg["ollama"] = {
         **ollama_cfg,
         "base_url": base_url,
-        "model": _REQUIRED_MODEL,
+        "model": model,
         "request_timeout": request_timeout,
     }
     cfg["agent"] = agent_cfg
     cfg["llm"] = llm_cfg
     return cfg
+
+
+def _enforce_policy(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    llm_cfg = require_dict_section(cfg, "llm")
+    provider = str(llm_cfg.get("provider", "ollama")).strip().lower() or "ollama"
+    if provider in _GOOGLE_PROVIDERS:
+        return _enforce_google_policy(cfg)
+    return _enforce_ollama_policy(cfg)
 
 
 def load_config(path: str | os.PathLike | None = None) -> Dict[str, Any]:

--- a/modules/agent_core/tests/test_config_loader_env.py
+++ b/modules/agent_core/tests/test_config_loader_env.py
@@ -35,20 +35,23 @@ llm:
     assert cfg["ollama"]["model"] == "qwen3.5:9b"
 
 
-def test_agent_core_load_config_rejects_non_ollama_provider(tmp_path: Path):
+def test_agent_core_load_config_accepts_google_provider(tmp_path: Path):
     cfg_file = tmp_path / "agent.yaml"
     cfg_file.write_text(
         """
 agent:
-  model: qwen3.5:9b
+  model: gemini-2.0-flash
 llm:
   provider: google_ai_studio
+google_ai_studio:
+  model: gemini-2.0-flash
 """.strip(),
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError):
-        load_config(str(cfg_file))
+    cfg = load_config(str(cfg_file))
+    assert cfg["llm"]["provider"] == "google_ai_studio"
+    assert cfg["agent"]["model"] == "gemini-2.0-flash"
 
 
 def test_agent_core_load_config_rejects_non_qwen3_5_9b_model(tmp_path: Path):

--- a/modules/arduino_serial/config/config.yml
+++ b/modules/arduino_serial/config/config.yml
@@ -2,13 +2,15 @@
 # transport: esp_http (production) or serial (legacy/fallback)
 transport: esp_http
 
-# ESP bridge endpoint (ESP32 HTTP server)
-esp_base_url: "http://sentrybot.local"
+# ESP bridge endpoint (ESP32 HTTP server). Prefer static IP + :8080 on Pi; avoid
+# sharing mDNS name "sentrybot" with the Pi hostname (use sentrybot-pi for the Pi).
+# Example: esp_base_url: "http://10.88.255.55:8080"
+esp_base_url: "http://sentrybot-2.local:8080"
 esp_request_path: "/request"
 esp_send_path: "/send"
 esp_health_path: "/healthz"
-esp_timeout_sec: 1.2
-esp_connect_timeout_sec: 0.4
+esp_timeout_sec: 2.5
+esp_connect_timeout_sec: 1.5
 
 # Legacy serial fallback config (used only when transport=serial)
 port: /dev/serial0
@@ -17,12 +19,12 @@ timeout: 0.05
 write_timeout: 0.1
 reconnect_sec: 2.0
 
-# Link liveness
-heartbeat_ms: 100
+# Link liveness (ESP linkTask also sends UART hb every 200ms)
+heartbeat_ms: 250
 auto_heartbeat: true
 # Request/retry tuning (milliseconds for timeouts where noted)
-request_max_retries: 0    # number of additional retries after first attempt
-request_timeout_ms: 1000 # default timeout for requests (ms) if not provided
+request_max_retries: 1    # number of additional retries after first attempt
+request_timeout_ms: 2000 # default timeout for requests (ms) if not provided
 telemetry:
   enabled: false
   interval_ms: 100

--- a/modules/arduino_serial/config_loader.py
+++ b/modules/arduino_serial/config_loader.py
@@ -51,6 +51,22 @@ def load_config(base_dir: Optional[str] = None, overrides: Optional[Dict[str, An
     if overrides:
         cfg.update({k: v for k, v in overrides.items() if v is not None})
 
+    try:
+        from modules.config_center.agent_yaml_loader import load_agent_config
+
+        root = load_agent_config()
+        serial_cfg = root.get("arduino_serial")
+        if isinstance(serial_cfg, dict):
+            cfg.update({k: v for k, v in serial_cfg.items() if v is not None})
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+
+    env_esp = os.getenv("SENTRYBOT_ESP_BASE_URL", "").strip()
+    if env_esp:
+        cfg["esp_base_url"] = env_esp
+
     # env overrides
     env_port = os.getenv("ARDUINO_PORT")
     if env_port:

--- a/modules/config_center/agent_yaml_loader.py
+++ b/modules/config_center/agent_yaml_loader.py
@@ -46,13 +46,15 @@ def resolve_agent_cfg_path(explicit_path: Optional[str | os.PathLike[str]] = Non
 
 
 def load_agent_config(explicit_path: Optional[str | os.PathLike[str]] = None) -> Dict[str, Any]:
+    from modules.config_center.runtime_profile import apply_runtime_profile
+
     cfg_path = resolve_agent_cfg_path(explicit_path)
     with open(cfg_path, "r", encoding="utf-8") as f:
         raw = yaml.safe_load(f) or {}
 
     if not isinstance(raw, dict):
         raise ValueError(f"agent.yaml must be a mapping at top-level: {cfg_path}")
-    return raw
+    return apply_runtime_profile(raw)
 
 
 def require_dict_section(cfg: Dict[str, Any], section: str) -> Dict[str, Any]:

--- a/modules/config_center/runtime_profile.py
+++ b/modules/config_center/runtime_profile.py
@@ -1,0 +1,79 @@
+"""Apply ``runtime_profile`` from agent.yaml to top-level module sections.
+
+Switch backends by editing only::
+
+    runtime_profile:
+      active: google_ai_studio   # or remote_ollama
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+from modules.config_center.agent_yaml_loader import deep_merge
+
+
+_PROFILE_SECTION_KEYS: tuple[str, ...] = (
+    "agent",
+    "llm",
+    "ollama",
+    "google_ai_studio",
+    "ollama_service",
+    "vlm_bridge",
+    "arduino_serial",
+    "esp_link",
+    "speak",
+    "speech",
+    "tri_layer",
+    "realtime_profile",
+    "safety",
+)
+
+
+def apply_runtime_profile(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge the active runtime profile into *cfg* (in place) and return it."""
+    profile_root = cfg.get("runtime_profile")
+    if not isinstance(profile_root, dict):
+        return cfg
+
+    active = str(profile_root.get("active", "")).strip()
+    profiles = profile_root.get("profiles")
+    if not active or not isinstance(profiles, dict):
+        return cfg
+
+    patch = profiles.get(active)
+    if not isinstance(patch, dict):
+        return cfg
+
+    for key in _PROFILE_SECTION_KEYS:
+        section_patch = patch.get(key)
+        if not isinstance(section_patch, dict):
+            continue
+        existing = cfg.get(key)
+        if isinstance(existing, dict):
+            cfg[key] = deep_merge(dict(existing), section_patch)
+        else:
+            cfg[key] = dict(section_patch)
+
+    cfg["_runtime_profile_active"] = active
+    return cfg
+
+
+def list_runtime_profiles(cfg: Dict[str, Any]) -> List[str]:
+    profile_root = cfg.get("runtime_profile")
+    if not isinstance(profile_root, dict):
+        return []
+    profiles = profile_root.get("profiles")
+    if not isinstance(profiles, dict):
+        return []
+    return sorted(str(name) for name in profiles.keys())
+
+
+def active_runtime_profile(cfg: Dict[str, Any]) -> str:
+    explicit = str(cfg.get("_runtime_profile_active", "")).strip()
+    if explicit:
+        return explicit
+    profile_root = cfg.get("runtime_profile")
+    if isinstance(profile_root, dict):
+        return str(profile_root.get("active", "")).strip()
+    return ""

--- a/modules/config_center/tests/test_runtime_profile.py
+++ b/modules/config_center/tests/test_runtime_profile.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.config_center.agent_yaml_loader import load_agent_config
+from modules.config_center.runtime_profile import active_runtime_profile, apply_runtime_profile
+
+
+def test_runtime_profile_merges_active_profile(tmp_path: Path):
+    agent_cfg = tmp_path / "agent.yaml"
+    agent_cfg.write_text(
+        """
+runtime_profile:
+  active: google_ai_studio
+  profiles:
+    google_ai_studio:
+      llm:
+        provider: google_ai_studio
+      agent:
+        model: gemini-2.0-flash
+agent:
+  model: qwen3.5:9b
+llm:
+  provider: ollama
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_agent_config(agent_cfg)
+    assert active_runtime_profile(cfg) == "google_ai_studio"
+    assert cfg["llm"]["provider"] == "google_ai_studio"
+    assert cfg["agent"]["model"] == "gemini-2.0-flash"
+
+
+def test_apply_runtime_profile_noop_without_active():
+    raw = {"agent": {"model": "x"}, "runtime_profile": {"profiles": {}}}
+    out = apply_runtime_profile(dict(raw))
+    assert out["agent"]["model"] == "x"

--- a/modules/esp_link/config/config.yml
+++ b/modules/esp_link/config/config.yml
@@ -6,7 +6,7 @@ network:
   ssid: "SentryBOT"
   password: "SentryBOT"
 
-base_url: "http://sentrybot.local"
+base_url: "http://sentrybot-2.local:8080"
 paths:
   health: "/healthz"
   send: "/send"

--- a/modules/esp_link/config_loader.py
+++ b/modules/esp_link/config_loader.py
@@ -27,11 +27,23 @@ def load_config(path: str | os.PathLike | None = None, overrides: Dict[str, Any]
         data = yaml.safe_load(f) or {}
 
     env: Dict[str, Any] = {}
-    base = os.getenv("ESP_LINK_BASE_URL")
+    base = os.getenv("ESP_LINK_BASE_URL") or os.getenv("SENTRYBOT_ESP_BASE_URL")
     if base:
         env["base_url"] = str(base).strip()
 
     out = _deep_update(data, env)
+
+    try:
+        from modules.config_center.agent_yaml_loader import load_agent_config
+
+        root = load_agent_config()
+        link_cfg = root.get("esp_link")
+        if isinstance(link_cfg, dict):
+            out = _deep_update(out, link_cfg)
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
     if overrides:
         out = _deep_update(out, dict(overrides))
     return out

--- a/modules/ollama/config_loader.py
+++ b/modules/ollama/config_loader.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 from modules.config_center.agent_yaml_loader import deep_merge, load_agent_config, require_dict_section
 
 _REQUIRED_MODEL = "qwen3.5:9b"
+_GOOGLE_PROVIDERS = frozenset({"google", "google_ai_studio", "gemini"})
 
 _DEFAULT_CFG: Dict[str, Any] = {
     "server": {"host": "0.0.0.0", "port": 8099},
@@ -13,9 +14,9 @@ _DEFAULT_CFG: Dict[str, Any] = {
     "ollama": {"base_url": "http://127.0.0.1:11434", "model": _REQUIRED_MODEL, "request_timeout": 60.0},
     "google_ai_studio": {
         "api_key": "",
-        "model": "gemini-1.5-flash",
+        "model": "gemini-2.0-flash",
         "base_url": "https://generativelanguage.googleapis.com",
-        "request_timeout": 60.0,
+        "request_timeout": 45.0,
     },
     "persona": {"default": "sentry", "dir": "modules/ollama/config/personalities"},
     "actions": {
@@ -63,45 +64,79 @@ def load_config(config_path: str | None = None) -> Dict[str, Any]:
     llm_cfg = require_dict_section(root_cfg, "llm")
     ollama_global = require_dict_section(root_cfg, "ollama")
     service_cfg = require_dict_section(root_cfg, "ollama_service")
+    google_global = root_cfg.get("google_ai_studio", {})
+    if not isinstance(google_global, dict):
+        google_global = {}
 
-    provider = str(llm_cfg.get("provider", "")).strip().lower()
-    if provider != "ollama":
-        raise ValueError("Only ollama provider is allowed for ollama module")
-
-    model = _pick_model(agent_cfg, llm_cfg, ollama_global)
-    if model != _REQUIRED_MODEL:
-        raise ValueError(f"Single-model policy requires model '{_REQUIRED_MODEL}', got '{model or '<empty>'}'")
-
-    base_url = _normalize_base_url(
-        agent_cfg.get("ollama_base_url")
-        or llm_cfg.get("base_url")
-        or ollama_global.get("base_url")
-        or os.getenv("AGENT_OLLAMA_BASE_URL")
-        or "http://127.0.0.1:11434"
-    )
-    if not base_url:
-        raise ValueError("agent.ollama_base_url is required")
-
+    provider = str(llm_cfg.get("provider", "")).strip().lower() or "ollama"
     request_timeout = _to_float(
         ollama_global.get("request_timeout", agent_cfg.get("request_timeout", 60.0)),
         60.0,
     )
 
-    strict_core_cfg: Dict[str, Any] = {
-        "llm": {
-            "provider": "ollama",
-            "single_model_mode": True,
-            "model": _REQUIRED_MODEL,
-            "primary_model": _REQUIRED_MODEL,
-            "base_url": base_url,
-        },
-        "ollama": {
-            "base_url": base_url,
-            "model": _REQUIRED_MODEL,
-            "request_timeout": request_timeout,
-        },
-    }
+    if provider in _GOOGLE_PROVIDERS:
+        model = (
+            str(google_global.get("model", "")).strip()
+            or _pick_model(agent_cfg, llm_cfg, ollama_global)
+            or "gemini-2.0-flash"
+        )
+        google_timeout = _to_float(google_global.get("request_timeout", request_timeout), request_timeout)
+        core_cfg: Dict[str, Any] = {
+            "llm": {
+                "provider": "google_ai_studio",
+                "single_model_mode": True,
+                "model": model,
+                "primary_model": model,
+            },
+            "google_ai_studio": {
+                **google_global,
+                "model": model,
+                "request_timeout": google_timeout,
+            },
+            "ollama": {
+                "base_url": _normalize_base_url(
+                    agent_cfg.get("ollama_base_url")
+                    or ollama_global.get("base_url")
+                    or os.getenv("AGENT_OLLAMA_BASE_URL")
+                    or "http://127.0.0.1:11434"
+                ),
+                "model": _REQUIRED_MODEL,
+                "request_timeout": request_timeout,
+            },
+        }
+    else:
+        model = _pick_model(agent_cfg, llm_cfg, ollama_global)
+        if model != _REQUIRED_MODEL:
+            raise ValueError(
+                f"Ollama profile requires model '{_REQUIRED_MODEL}', got '{model or '<empty>'}'"
+            )
+
+        base_url = _normalize_base_url(
+            agent_cfg.get("ollama_base_url")
+            or llm_cfg.get("base_url")
+            or ollama_global.get("base_url")
+            or os.getenv("AGENT_OLLAMA_BASE_URL")
+            or "http://127.0.0.1:11434"
+        )
+        if not base_url:
+            raise ValueError("agent.ollama_base_url is required")
+
+        core_cfg = {
+            "llm": {
+                "provider": "ollama",
+                "single_model_mode": True,
+                "model": _REQUIRED_MODEL,
+                "primary_model": _REQUIRED_MODEL,
+                "base_url": base_url,
+            },
+            "ollama": {
+                "base_url": base_url,
+                "model": _REQUIRED_MODEL,
+                "request_timeout": request_timeout,
+            },
+            "google_ai_studio": google_global,
+        }
 
     merged = deep_merge(_DEFAULT_CFG, service_cfg)
-    merged = deep_merge(merged, strict_core_cfg)
+    merged = deep_merge(merged, core_cfg)
     return merged

--- a/modules/ollama/services/clients.py
+++ b/modules/ollama/services/clients.py
@@ -274,6 +274,55 @@ class GoogleAIStudioClient:
 
         return {"message": {"content": text}, "raw": data}
 
+    def generate_with_image(
+        self,
+        prompt: str,
+        image_b64: str,
+        *,
+        mime_type: str = "image/jpeg",
+        model: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Multimodal generateContent (text + inline image)."""
+        selected_model = str(model or self.model).strip() or self.model
+        if model and not selected_model.lower().startswith("gemini"):
+            selected_model = self.model
+
+        generation_config: Dict[str, Any] = {"temperature": 0.3}
+        if isinstance(options, dict) and "temperature" in options:
+            generation_config["temperature"] = options["temperature"]
+
+        payload: Dict[str, Any] = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"text": str(prompt or "")},
+                        {"inline_data": {"mime_type": mime_type, "data": image_b64}},
+                    ],
+                }
+            ],
+            "generationConfig": generation_config,
+        }
+
+        url = f"{self.base_url}/v1beta/models/{selected_model}:generateContent"
+        resp = requests.post(
+            url,
+            params={"key": self.api_key},
+            json=payload,
+            timeout=float(self.timeout),
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        try:
+            parts = data.get("candidates", [])[0].get("content", {}).get("parts", [])
+            return "\n".join(
+                str(p.get("text", "")) for p in parts if isinstance(p, dict)
+            ).strip()
+        except Exception:
+            return ""
+
 
 def create_llm_client(cfg: Dict[str, Any]) -> Tuple[LLMClientProtocol, str]:
     llm_cfg = cfg.get("llm", {}) or {}

--- a/modules/ollama/tests/test_config_loader_env.py
+++ b/modules/ollama/tests/test_config_loader_env.py
@@ -48,14 +48,16 @@ ollama_service:
     assert int(cfg["server"]["port"]) == 9001
 
 
-def test_load_config_rejects_non_ollama_provider(tmp_path: Path):
+def test_load_config_accepts_google_provider(tmp_path: Path):
     agent_cfg = tmp_path / "agent.yaml"
     agent_cfg.write_text(
         """
 agent:
-  model: qwen3.5:9b
+  model: gemini-2.0-flash
 llm:
   provider: google_ai_studio
+google_ai_studio:
+  model: gemini-2.0-flash
 ollama:
   base_url: "http://127.0.0.1:11434"
   model: qwen3.5:9b
@@ -66,8 +68,9 @@ ollama_service:
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError):
-        load_config(str(agent_cfg))
+    cfg = load_config(str(agent_cfg))
+    assert cfg["llm"]["provider"] == "google_ai_studio"
+    assert cfg["google_ai_studio"]["model"] == "gemini-2.0-flash"
 
 
 def test_load_config_rejects_non_qwen3_5_9b_model(tmp_path: Path):

--- a/modules/vlm_bridge/config_loader.py
+++ b/modules/vlm_bridge/config_loader.py
@@ -9,7 +9,7 @@ from modules.config_center.agent_yaml_loader import deep_merge, load_agent_confi
 DEFAULT_CONFIG: Dict[str, Any] = {
     "server": {"host": "0.0.0.0", "port": 8101},
     "vision": {
-        "processing_mode": "remote",  # local | remote (remote-first default)
+        "processing_mode": "remote",
         "camera_source": "http://127.0.0.1:8080/camera/video",
         "blind_mode": {"enabled": False, "interval_seconds": 5.0},
         "confidence_threshold": 0.5,
@@ -33,11 +33,11 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         },
     },
     "remote": {
-        "auth_token": "changeme",  # Override in deployment
+        "auth_token": "changeme",
         "accept_results": True,
     },
     "llm": {
-        "provider": "ollama",  # ollama | google_ai_studio
+        "provider": "ollama",
         "single_model_mode": True,
         "primary_model": "qwen3.5:9b",
         "clm_fallback_enabled": False,
@@ -51,6 +51,16 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "timeout": 12.0,
         "num_predict": 160,
     },
+    "vision_llm": {
+        "enabled": True,
+        "provider": "ollama",
+    },
+    "google_ai_studio": {
+        "api_key": "",
+        "model": "gemini-2.0-flash",
+        "base_url": "https://generativelanguage.googleapis.com",
+        "request_timeout": 45.0,
+    },
     "speak": {
         "endpoint": "http://localhost:8083/speak/say",
     },
@@ -61,7 +71,8 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     },
 }
 
-_REQUIRED_MODEL = "qwen3.5:9b"
+_REQUIRED_OLLAMA_MODEL = "qwen3.5:9b"
+_GOOGLE_PROVIDERS = frozenset({"google", "google_ai_studio", "gemini"})
 
 
 def _to_float(raw: Any, fallback: float) -> float:
@@ -107,29 +118,86 @@ def _resolve_agent_cfg_path(base_dir: Optional[str]) -> Optional[str]:
     return str(base / "config" / "agent.yaml")
 
 
-def _enforce_single_model_policy(cfg: Dict[str, Any], root_cfg: Dict[str, Any]) -> Dict[str, Any]:
+def _pick_model(agent_cfg: Dict[str, Any], llm_cfg: Dict[str, Any], ollama_cfg: Dict[str, Any]) -> str:
+    for candidate in (
+        agent_cfg.get("model"),
+        llm_cfg.get("model"),
+        llm_cfg.get("primary_model"),
+        ollama_cfg.get("model"),
+    ):
+        text = str(candidate or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _enforce_google_policy(cfg: Dict[str, Any], root_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    root_agent = require_dict_section(root_cfg, "agent")
+    root_llm = require_dict_section(root_cfg, "llm")
+    root_google = root_cfg.get("google_ai_studio", {})
+    if not isinstance(root_google, dict):
+        root_google = {}
+
+    model = (
+        str(root_google.get("model", "")).strip()
+        or _pick_model(root_agent, root_llm, {})
+        or "gemini-2.0-flash"
+    )
+    google_timeout = _to_float(
+        root_google.get("request_timeout", root_agent.get("request_timeout", 45.0)),
+        45.0,
+    )
+
+    llm_cfg = cfg.setdefault("llm", {})
+    ollama_cfg = cfg.setdefault("ollama", {})
+    vision_cfg = cfg.setdefault("vision_llm", {})
+    google_cfg = cfg.setdefault("google_ai_studio", {})
+
+    llm_cfg["provider"] = "google_ai_studio"
+    llm_cfg["single_model_mode"] = True
+    llm_cfg["primary_model"] = model
+    llm_cfg["model"] = model
+    llm_cfg["clm_fallback_enabled"] = False
+    llm_cfg["clm_fallback_model"] = ""
+    llm_cfg["fallback_on_missing_model"] = False
+    llm_cfg["fallback_on_error"] = False
+
+    vlm_root = require_dict_section(root_cfg, "vlm_bridge")
+    vlm_ollama = vlm_root.get("ollama", {}) if isinstance(vlm_root.get("ollama"), dict) else {}
+    explicit_endpoint = str(vlm_ollama.get("endpoint", "")).strip()
+    ollama_cfg["endpoint"] = _to_vlm_chat_endpoint(
+        explicit_endpoint or "http://127.0.0.1:8080/ollama/chat"
+    )
+    ollama_cfg["model"] = model
+    ollama_cfg["timeout"] = _to_float(ollama_cfg.get("timeout", 12.0), 12.0)
+
+    vision_cfg["enabled"] = bool(vision_cfg.get("enabled", True))
+    vision_cfg["provider"] = "google_ai_studio"
+
+    google_cfg.update(
+        {
+            **root_google,
+            "model": model,
+            "request_timeout": google_timeout,
+        }
+    )
+    cfg["google_ai_studio"] = google_cfg
+    cfg["llm"] = llm_cfg
+    cfg["ollama"] = ollama_cfg
+    cfg["vision_llm"] = vision_cfg
+    return cfg
+
+
+def _enforce_ollama_policy(cfg: Dict[str, Any], root_cfg: Dict[str, Any]) -> Dict[str, Any]:
     root_agent = require_dict_section(root_cfg, "agent")
     root_llm = require_dict_section(root_cfg, "llm")
     root_ollama = require_dict_section(root_cfg, "ollama")
 
-    provider = str(root_llm.get("provider", "")).strip().lower()
-    if provider != "ollama":
-        raise ValueError("vlm_bridge supports only ollama provider in strict mode")
-
-    model_candidates = (
-        root_agent.get("model"),
-        root_llm.get("model"),
-        root_llm.get("primary_model"),
-        root_ollama.get("model"),
-    )
-    model = ""
-    for candidate in model_candidates:
-        text = str(candidate or "").strip()
-        if text:
-            model = text
-            break
-    if model != _REQUIRED_MODEL:
-        raise ValueError(f"Single-model policy requires model '{_REQUIRED_MODEL}', got '{model or '<empty>'}'")
+    model = _pick_model(root_agent, root_llm, root_ollama) or _REQUIRED_OLLAMA_MODEL
+    if model != _REQUIRED_OLLAMA_MODEL:
+        raise ValueError(
+            f"Ollama profile requires model '{_REQUIRED_OLLAMA_MODEL}', got '{model}'"
+        )
 
     base_url = _normalize_ollama_base_url(
         root_agent.get("ollama_base_url")
@@ -143,22 +211,43 @@ def _enforce_single_model_policy(cfg: Dict[str, Any], root_cfg: Dict[str, Any]) 
 
     llm_cfg = cfg.setdefault("llm", {})
     ollama_cfg = cfg.setdefault("ollama", {})
+    vision_cfg = cfg.setdefault("vision_llm", {})
 
     llm_cfg["provider"] = "ollama"
     llm_cfg["single_model_mode"] = True
-    llm_cfg["primary_model"] = _REQUIRED_MODEL
-    llm_cfg["model"] = _REQUIRED_MODEL
+    llm_cfg["primary_model"] = _REQUIRED_OLLAMA_MODEL
+    llm_cfg["model"] = _REQUIRED_OLLAMA_MODEL
     llm_cfg["clm_fallback_enabled"] = False
     llm_cfg["clm_fallback_model"] = ""
     llm_cfg["fallback_on_missing_model"] = False
     llm_cfg["fallback_on_error"] = False
 
-    ollama_cfg["endpoint"] = _to_vlm_chat_endpoint(base_url)
-    ollama_cfg["model"] = _REQUIRED_MODEL
-    ollama_cfg["timeout"] = _to_float(ollama_cfg.get("timeout", root_ollama.get("request_timeout", 12.0)), 12.0)
+    vlm_root = require_dict_section(root_cfg, "vlm_bridge")
+    vlm_ollama = vlm_root.get("ollama", {}) if isinstance(vlm_root.get("ollama"), dict) else {}
+    explicit_endpoint = str(vlm_ollama.get("endpoint", "")).strip()
+    ollama_cfg["endpoint"] = _to_vlm_chat_endpoint(explicit_endpoint or base_url)
+    ollama_cfg["model"] = _REQUIRED_OLLAMA_MODEL
+    ollama_cfg["timeout"] = _to_float(
+        ollama_cfg.get("timeout", root_ollama.get("request_timeout", 12.0)),
+        12.0,
+    )
+
+    vision_cfg["provider"] = str(vision_cfg.get("provider", "ollama")).strip().lower() or "ollama"
+    if vision_cfg.get("base_url") in (None, ""):
+        vision_cfg["base_url"] = base_url
+
     cfg["ollama"] = ollama_cfg
     cfg["llm"] = llm_cfg
+    cfg["vision_llm"] = vision_cfg
     return cfg
+
+
+def _enforce_policy(cfg: Dict[str, Any], root_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    root_llm = require_dict_section(root_cfg, "llm")
+    provider = str(root_llm.get("provider", "ollama")).strip().lower() or "ollama"
+    if provider in _GOOGLE_PROVIDERS:
+        return _enforce_google_policy(cfg, root_cfg)
+    return _enforce_ollama_policy(cfg, root_cfg)
 
 
 def load_config(base_dir: Optional[str] = None, overrides: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -170,4 +259,11 @@ def load_config(base_dir: Optional[str] = None, overrides: Optional[Dict[str, An
     if overrides:
         cfg = deep_merge(cfg, {k: v for k, v in overrides.items() if v is not None})
 
-    return _enforce_single_model_policy(cfg, root_cfg)
+    root_google = root_cfg.get("google_ai_studio", {})
+    if isinstance(root_google, dict) and root_google:
+        cfg["google_ai_studio"] = deep_merge(
+            cfg.get("google_ai_studio", {}) if isinstance(cfg.get("google_ai_studio"), dict) else {},
+            root_google,
+        )
+
+    return _enforce_policy(cfg, root_cfg)

--- a/modules/vlm_bridge/services/google_vlm_client.py
+++ b/modules/vlm_bridge/services/google_vlm_client.py
@@ -1,0 +1,160 @@
+"""Google AI Studio (Gemini) vision client for scene analysis."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("vlm_bridge.google_vlm")
+
+try:
+    from .ollama_vlm_client import (
+        _QUESTION_PROMPT_TR,
+        _SCENE_PROMPT_TR,
+        _parse_vlm_json,
+        _resize_and_encode,
+    )
+except Exception:
+    from modules.vlm_bridge.services.ollama_vlm_client import (  # type: ignore
+        _QUESTION_PROMPT_TR,
+        _SCENE_PROMPT_TR,
+        _parse_vlm_json,
+        _resize_and_encode,
+    )
+
+
+class GoogleVLMClient:
+    """Gemini multimodal client with the same surface as :class:`OllamaVLMClient`."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        from modules.ollama.services.clients import GoogleAIStudioClient, _sanitize_google_api_key
+
+        cfg = config or {}
+        google_cfg = cfg.get("google_ai_studio", {}) if isinstance(cfg.get("google_ai_studio"), dict) else cfg
+
+        api_key = _sanitize_google_api_key(google_cfg.get("api_key", ""))
+        if not api_key:
+            import os
+
+            api_key = _sanitize_google_api_key(os.environ.get("GOOGLE_API_KEY", ""))
+        if not api_key:
+            raise RuntimeError("Google AI Studio vision selected but api_key is missing")
+
+        model = str(google_cfg.get("model", cfg.get("model", "gemini-2.0-flash"))).strip() or "gemini-2.0-flash"
+        base_url = str(
+            google_cfg.get("base_url", "https://generativelanguage.googleapis.com")
+        ).strip()
+        timeout = float(google_cfg.get("request_timeout", cfg.get("timeout_s", 45.0)))
+
+        self._client = GoogleAIStudioClient(
+            api_key=api_key,
+            model=model,
+            base_url=base_url,
+            request_timeout=timeout,
+        )
+        self.model = model
+        self.timeout = timeout
+        self.max_image_width = int(cfg.get("max_image_width", 640))
+        self.jpeg_quality = int(cfg.get("jpeg_quality", 70))
+        self.min_interval_s = float(cfg.get("min_interval_s", 5.0))
+        self.num_predict = int(cfg.get("num_predict", 256))
+
+        self._lock = threading.Lock()
+        self._in_flight = False
+        self._last_call: float = 0.0
+        self._call_count = 0
+        self._error_count = 0
+
+    def analyze_frame(
+        self,
+        frame,
+        *,
+        custom_prompt: str = "",
+        force: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        now = time.time()
+        with self._lock:
+            if self._in_flight:
+                return None
+            if not force and (now - self._last_call) < self.min_interval_s:
+                return None
+            self._in_flight = True
+            self._last_call = now
+
+        try:
+            image_b64 = _resize_and_encode(
+                frame,
+                max_width=self.max_image_width,
+                jpeg_quality=self.jpeg_quality,
+            )
+        except Exception as exc:
+            logger.warning("Frame encoding failed: %s", exc)
+            with self._lock:
+                self._in_flight = False
+            return None
+
+        prompt = custom_prompt or _SCENE_PROMPT_TR
+        start = time.time()
+        try:
+            text = self._client.generate_with_image(
+                prompt,
+                image_b64,
+                options={"temperature": 0.3},
+            )
+            if not text:
+                return None
+            result = _parse_vlm_json(text)
+            result["_latency_ms"] = round((time.time() - start) * 1000, 1)
+            self._call_count += 1
+            return result
+        except Exception as exc:
+            self._error_count += 1
+            logger.warning("Gemini VLM analysis failed: %s", exc)
+            return None
+        finally:
+            with self._lock:
+                self._in_flight = False
+
+    def ask_about_scene(self, frame, question: str, force: bool = True) -> Optional[str]:
+        prompt = _QUESTION_PROMPT_TR.format(question=question)
+        result = self.analyze_frame(frame, custom_prompt=prompt, force=force)
+        if result is None:
+            return None
+        return result.get("raw_text") or result.get("summary") or str(result)
+
+    def is_available(self) -> bool:
+        return bool(getattr(self._client, "api_key", ""))
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {
+            "provider": "google_ai_studio",
+            "model": self.model,
+            "call_count": self._call_count,
+            "error_count": self._error_count,
+            "in_flight": self._in_flight,
+            "last_call_age_s": round(time.time() - self._last_call, 1) if self._last_call else None,
+        }
+
+
+def create_vision_llm_client(config: Dict[str, Any]):
+    """Factory: returns OllamaVLMClient or GoogleVLMClient based on provider."""
+    vlm_cfg = config.get("vision_llm", {}) if isinstance(config.get("vision_llm"), dict) else {}
+    provider = str(vlm_cfg.get("provider", "ollama")).strip().lower() or "ollama"
+
+    if provider in {"google", "google_ai_studio", "gemini"}:
+        merged = dict(vlm_cfg)
+        if isinstance(config.get("google_ai_studio"), dict):
+            merged["google_ai_studio"] = config["google_ai_studio"]
+        return GoogleVLMClient(merged)
+
+    try:
+        from .ollama_vlm_client import OllamaVLMClient
+    except Exception:
+        from modules.vlm_bridge.services.ollama_vlm_client import OllamaVLMClient  # type: ignore
+
+    return OllamaVLMClient(vlm_cfg)
+
+
+__all__ = ["GoogleVLMClient", "create_vision_llm_client"]

--- a/modules/vlm_bridge/services/llm_client.py
+++ b/modules/vlm_bridge/services/llm_client.py
@@ -130,6 +130,29 @@ def _mark_cooldown(endpoint: str, seconds: float) -> None:
     _CHAT_COOLDOWN_UNTIL[endpoint] = time.time() + max(1.0, float(seconds))
 
 
+def _generate_google_text(prompt: str, *, timeout: float) -> Optional[str]:
+    try:
+        from modules.ollama.config_loader import load_config as load_ollama_config  # type: ignore
+        from modules.ollama.services.clients import create_llm_client  # type: ignore
+    except Exception:
+        return None
+
+    try:
+        cfg = load_ollama_config(None)
+        client, _ = create_llm_client(cfg)
+        client.timeout = float(timeout)
+        result = client.chat(
+            messages=[{"role": "user", "content": prompt}],
+            options={"temperature": 0.4},
+        )
+        msg = result.get("message", {}) if isinstance(result, dict) else {}
+        out = str(msg.get("content", "")).strip()
+        return out or None
+    except Exception as exc:
+        logger.debug("Gemini text request failed: %s", exc)
+        return None
+
+
 def generate_text(
     prompt: str,
     ollama_cfg: Dict[str, Any],
@@ -137,32 +160,25 @@ def generate_text(
     timeout: float = 5.0,
     response_lang: str = "tr",
 ) -> Optional[str]:
-    if httpx is None:
-        return None
-
     text = str(prompt or "").strip()
     if not text:
         return None
 
-    endpoint = _normalize_endpoint(ollama_cfg)
-    cooldown_s = float((ollama_cfg or {}).get("cooldown_on_failure_s", 30.0))
-
     hint = _provider_hint()
     provider = str(hint.get("provider", "") or "").strip().lower()
 
-    # When Google provider is selected, direct Ollama REST endpoints are incompatible.
-    # In that mode only gateway chat endpoint (/ollama/chat) should be used.
     if provider in {"google", "google_ai_studio", "gemini"}:
-        if _is_direct_ollama_chat_endpoint(endpoint) or _is_legacy_generate_endpoint(endpoint):
+        if bool(hint.get("google_key_ready")):
+            return _generate_google_text(text, timeout=timeout)
+        endpoint = _normalize_endpoint(ollama_cfg)
+        if not endpoint.rstrip("/").endswith("/ollama/chat"):
             return None
 
-    # Google provider selected but key is missing/placeholder: skip remote call and fall back.
-    if (
-        provider in {"google", "google_ai_studio", "gemini"}
-        and not bool(hint.get("google_key_ready"))
-        and not _is_legacy_generate_endpoint(endpoint)
-    ):
+    if httpx is None:
         return None
+
+    endpoint = _normalize_endpoint(ollama_cfg)
+    cooldown_s = float((ollama_cfg or {}).get("cooldown_on_failure_s", 30.0))
 
     try:
         with httpx.Client(timeout=float(timeout)) as client:

--- a/modules/vlm_bridge/services/llm_client.py
+++ b/modules/vlm_bridge/services/llm_client.py
@@ -170,9 +170,7 @@ def generate_text(
     if provider in {"google", "google_ai_studio", "gemini"}:
         if bool(hint.get("google_key_ready")):
             return _generate_google_text(text, timeout=timeout)
-        endpoint = _normalize_endpoint(ollama_cfg)
-        if not endpoint.rstrip("/").endswith("/ollama/chat"):
-            return None
+        return None
 
     if httpx is None:
         return None

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -303,12 +303,22 @@ class VisionProcessor:
             self.visual_context_cache = None
             logger.warning("VisualContextCache not available")
 
-        # Remote VLM client (Ollama)
+        # Remote VLM client (Ollama or Google AI Studio)
         vlm_cfg = config.get("vision_llm", {}) if isinstance(config.get("vision_llm", {}), dict) else {}
-        if vlm_cfg.get("enabled", True) and OllamaVLMClient is not None:
+        if vlm_cfg.get("enabled", True):
             try:
-                self.vlm_client = OllamaVLMClient(vlm_cfg)
-                logger.info("[vlm_bridge] Remote VLM client initialized: %s", vlm_cfg.get("model", "unknown"))
+                try:
+                    from .google_vlm_client import create_vision_llm_client
+                except Exception:
+                    from modules.vlm_bridge.services.google_vlm_client import create_vision_llm_client  # type: ignore
+
+                self.vlm_client = create_vision_llm_client(config)
+                provider = str(vlm_cfg.get("provider", "ollama"))
+                logger.info(
+                    "[vlm_bridge] Vision LLM client initialized (%s): %s",
+                    provider,
+                    getattr(self.vlm_client, "model", "unknown"),
+                )
             except Exception as exc:
                 logger.warning("VLM client init failed: %s", exc)
                 self.vlm_client = None

--- a/modules/vlm_bridge/tests/test_config_loader.py
+++ b/modules/vlm_bridge/tests/test_config_loader.py
@@ -37,27 +37,33 @@ vlm_bridge:
     assert cfg["llm"]["single_model_mode"] is True
 
 
-def test_vlm_config_loader_rejects_non_ollama_provider(tmp_path: Path):
+def test_vlm_config_loader_accepts_google_provider(tmp_path: Path):
     agent_cfg = tmp_path / "agent.yaml"
     agent_cfg.write_text(
         """
 agent:
-  model: qwen3.5:9b
-  ollama_base_url: "http://127.0.0.1:11434"
+  model: gemini-2.0-flash
 llm:
   provider: google_ai_studio
+google_ai_studio:
+  model: gemini-2.0-flash
+  request_timeout: 30
 ollama:
   base_url: "http://127.0.0.1:11434"
   model: qwen3.5:9b
 vlm_bridge:
   llm:
     provider: google_ai_studio
+  vision_llm:
+    provider: google_ai_studio
 """.strip(),
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError):
-        load_config(base_dir=str(agent_cfg))
+    cfg = load_config(base_dir=str(agent_cfg))
+    assert cfg["llm"]["provider"] == "google_ai_studio"
+    assert cfg["vision_llm"]["provider"] == "google_ai_studio"
+    assert cfg["ollama"]["model"] == "gemini-2.0-flash"
 
 
 def test_vlm_config_loader_rejects_non_qwen3_5_9b_model(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Add `runtime_profile` in `config/agent.yaml` with `google_ai_studio` and `remote_ollama` profiles; switch backends by changing `active` only.
- Wire Google AI Studio for agent chat (ollama module client) and Gemini multimodal vision via new `GoogleVLMClient`.
- Relax strict ollama-only config loaders to honor the active profile provider.
- Default ESP URLs to `http://sentrybot-2.local:8080`; arduino_serial and esp_link read overrides from agent.yaml profiles.

## Test plan
- [ ] Set `GOOGLE_API_KEY` on Pi, keep `runtime_profile.active: google_ai_studio`, restart robot and verify chat + VLM scene description.
- [ ] Switch to `remote_ollama`, update profile `ollama_base_url` / `vision_llm.base_url` to remote GPU host, restart and verify Ollama path.
- [ ] Confirm ESP reachability at `sentrybot-2.local:8080/healthz` (or static IP in profile).
- [x] `pytest modules/config_center/tests/test_runtime_profile.py modules/vlm_bridge/tests/test_config_loader.py modules/agent_core/tests/test_config_loader_env.py modules/ollama/tests/test_config_loader_env.py`

Made with [Cursor](https://cursor.com)