### PR TITLE
docs: centralize SentryBOT agent and skill hub (.sentrybot)

### DIFF
--- a/.cursor/rules/arduino-contract.mdc
+++ b/.cursor/rules/arduino-contract.mdc
@@ -1,0 +1,20 @@
+---
+description: "Arduino serial modülüyle çalışırken veya donanım komutu gönderen kod yazarken aktif olur."
+globs: ["modules/arduino_serial/**", "modules/autonomy/**", "modules/vlm_bridge/**", "modules/animate/**", "modules/calibration/**"]
+alwaysApply: false
+---
+
+# Arduino Kontrat Kuralları
+
+## ZORUNLU
+- Tüm Arduino komutları `modules/arduino_serial/contract.py` builder kullanır
+- Elle `{"cmd": ...}` payload YASAK
+- Kritik komutlar `/arduino/request` (ACK bekler, timeout 0.8-1.5s)
+
+## Yeni Komut Eklerken (aynı PR'da)
+1. `contract.py` → `build_<cmd>` + `validate_<cmd>`
+2. Validator unit testi
+3. Gateway davranış testi
+
+## Detaylı prosedür
+`.sentrybot/skills/arduino-contract.md` dosyasını oku.

--- a/.cursor/rules/github-ops.mdc
+++ b/.cursor/rules/github-ops.mdc
@@ -1,0 +1,17 @@
+---
+description: "GitHub işlemleri, PR veya Issue hazırlarken aktif olur."
+globs: [".github/**"]
+alwaysApply: false
+---
+
+# GitHub İşlemleri
+
+## PR → `.sentrybot/skills/create-pr.md`
+## Issue → `.sentrybot/skills/create-issue.md`
+## CI Analiz → `.sentrybot/agents/github-ops.md`
+
+## Branch Format
+- `feat/<modül>-<açıklama>` | `fix/<modül>-<açıklama>` | `refactor/<modül>-<açıklama>`
+
+## Commit Format
+- `feat(modül): açıklama` | `fix(modül): açıklama`

--- a/.cursor/rules/module-operations.mdc
+++ b/.cursor/rules/module-operations.mdc
@@ -1,0 +1,34 @@
+---
+description: "Yeni modül oluşturma veya modül iskeleti üretme talebi geldiğinde aktif olur."
+globs: ["modules/**/x*Service.py", "modules/**/__init__.py"]
+alwaysApply: false
+---
+
+# Modül Oluşturma / Düzenleme
+
+## Yeni Modül Oluşturmak İçin
+1. `.sentrybot/context/module-registry.md` oku — 29 mevcut modül
+2. `.sentrybot/agents/module-creator.md` oku — iş akışı
+3. `.sentrybot/skills/scaffold-module.md` takip et — iskelet oluşturma
+
+## Modül Düzenlemek İçin
+1. Hedef modülün `architecture_*.md` dosyasını oku
+2. `.sentrybot/agents/module-editor.md` oku
+3. Değişiklik türüne göre skill seç:
+   - Endpoint → `.sentrybot/skills/add-api-endpoint.md`
+   - Service → `.sentrybot/skills/add-service-class.md`
+   - Config → `.sentrybot/skills/update-config.md`
+
+## Standart Modül Yapısı
+```
+modules/<name>/
+├── __init__.py
+├── x<Name>Service.py
+├── config_loader.py
+├── config/config.yml
+├── api/router.py
+├── services/
+├── tests/test_smoke.py
+├── architecture_<name>.md
+└── README.md
+```

--- a/.cursor/rules/sentrybot-core.mdc
+++ b/.cursor/rules/sentrybot-core.mdc
@@ -1,0 +1,20 @@
+---
+description: "SentryBOT projesinin temel kuralları. DryCode prensipleri, modül yapısı, Arduino kontrat zorunlulukları."
+alwaysApply: true
+---
+
+# SentryBOT — Temel Kurallar
+
+## Kritik Kurallar
+1. **DryCode** — Tekrar yok, sade, net, her dosya tek sorumluluk
+2. **Arduino kontratı** — `modules/arduino_serial/contract.py` builder zorunlu, elle payload YASAK
+3. **Config** — Hardcode yasak, YAML'den oku
+4. **Test** — Her modülde `tests/test_smoke.py` zorunlu
+5. **Modül yapısı** — `x<Name>Service.py` + `config_loader.py` + `api/router.py`
+
+## Agent & Skill Sistemi
+Tüm detaylı prosedürler `.sentrybot/` dizininde:
+- `.sentrybot/agents/` — 5 iş akışı yöneticisi
+- `.sentrybot/skills/` — 12 adım adım prosedür
+- `.sentrybot/context/` — Modül listesi, API haritası, mimari özet, kurallar
+- `.sentrybot/templates/` — Modül iskelet şablonları

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,22 @@
+---
+description: "Test yazarken veya test dosyalarıyla çalışırken aktif olur."
+globs: ["modules/**/tests/**", "**/test_*.py"]
+alwaysApply: false
+---
+
+# Test Kuralları
+
+## Zorunlu: Smoke Test
+Her modülde `tests/test_smoke.py`:
+- `test_import` — modül import edilebilir mi
+- `test_config_loader` — config yüklenebilir mi
+- `test_service_init` — service boş config ile oluşturulabilir mi
+- `test_router` — router oluşturulabilir mi
+
+## CI Kuralları
+- Python 3.10, `--maxfail=1`
+- Donanım testleri `@pytest.mark.skipif`
+- Mock: `unittest.mock.patch` ile donanım/HTTP/Arduino
+
+## Detaylı kalıplar
+`.sentrybot/skills/write-tests.md` dosyasını oku.

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,16 @@
+# SentryBOT — Cursor AI Kuralları
+# ⚠️ Bu dosya eski (legacy) format. Cursor, `.cursor/rules/*.mdc` dosyalarını otomatik okur.
+# Detaylı kurallar: .cursor/rules/ dizini
+# Tüm agent/skill/context: .sentrybot/ dizini
+
+## Kritik Kurallar
+1. DryCode: tekrar yok, tek sorumluluk, kısa fonksiyonlar
+2. Modül yapısı: x<Name>Service.py + config_loader.py + config/config.yml + api/router.py
+3. Arduino: contract.py builder zorunlu, elle payload YASAK
+4. Config: hardcode YASAK, YAML'den oku
+5. Test: her modülde tests/test_smoke.py zorunlu
+
+## Tam Kurallar → `.sentrybot/context/conventions.md`
+## Agent'lar → `.sentrybot/agents/`
+## Skill'ler → `.sentrybot/skills/`
+## Cursor MDC kuralları → `.cursor/rules/`

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Normalize text files to LF in the repo; avoid Windows CRLF phantom diffs.
+* text=auto eol=lf
+
+# Explicit binary types
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.db binary

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -1,0 +1,17 @@
+---
+name: code-reviewer
+description: Reviews SentryBOT code for DryCode compliance, Arduino contract adherence, test coverage, documentation freshness, and security.
+argument-hint: "code to review (e.g., 'review changes in modules/speech' or 'check PR #42 for DryCode compliance')"
+---
+
+# Code Reviewer Agent
+
+Kod inceleme uzmanı. Detaylı kontrol listesi için `.sentrybot/agents/code-reviewer.md` dosyasını oku.
+
+## Kontrol Alanları
+1. DryCode uyumu (tekrar, sorumluluk, fonksiyon uzunluğu)
+2. Arduino kontrat uyumu (builder kullanımı, timeout)
+3. Test kapsamı (smoke test, edge case)
+4. Dokümantasyon güncelliği (architecture, README)
+5. Güvenlik (hardcode token, input validation)
+6. Performans (timeout, thread safety, memory leak)

--- a/.github/agents/github-ops.agent.md
+++ b/.github/agents/github-ops.agent.md
@@ -1,0 +1,15 @@
+---
+name: github-ops
+description: Manages GitHub operations — PR creation, issue management, CI analysis, label management, and release notes for SentryBOT.
+argument-hint: "a GitHub task (e.g., 'create PR for speech changes' or 'analyze failed CI run' or 'create feature request for LIDAR support')"
+---
+
+# GitHub Ops Agent
+
+GitHub işlemleri uzmanı. Detaylı prosedür için `.sentrybot/agents/github-ops.md` dosyasını oku.
+
+## İş Akışı
+- PR → `.sentrybot/skills/create-pr.md`
+- Issue → `.sentrybot/skills/create-issue.md`
+- CI analizi → `.github/workflows/pytest.yml` yapısını incele
+- Label → `.github/labeler.yml` kurallarına uy

--- a/.github/agents/inter-module.agent.md
+++ b/.github/agents/inter-module.agent.md
@@ -1,0 +1,15 @@
+---
+name: inter-module
+description: Manages cross-module communication, API integration, event systems, and data flow between SentryBOT modules.
+argument-hint: "a cross-module task (e.g., 'connect new sensor to autonomy brain' or 'add event trigger from wakeword to neopixel')"
+---
+
+# Inter-Module Agent
+
+Modüller arası etkileşim uzmanı. Detaylı prosedür için `.sentrybot/agents/inter-module.md` dosyasını oku.
+
+## İş Akışı
+1. `.sentrybot/context/api-surface.md` → mevcut endpoint'leri öğren
+2. `.sentrybot/context/module-registry.md` → bağımlılıkları incele
+3. İletişim türünü seç (HTTP/Arduino/State/Event)
+4. `.sentrybot/skills/module-dependency-map.md` → bağımlılık analizi

--- a/.github/agents/module-creator.agent.md
+++ b/.github/agents/module-creator.agent.md
@@ -1,0 +1,19 @@
+---
+name: module-creator
+description: Creates new SentryBOT modules from scratch following DryCode rules, standard module structure, Arduino contract compliance, and Gateway bootstrap integration.
+argument-hint: "a new module to create (e.g., 'create ultrasonic sensor module' or 'add new lidar module to the sensing layer')"
+---
+
+# Module Creator Agent
+
+Yeni SentryBOT modülü oluşturma uzmanı. Detaylı prosedür ve skill dosyaları için `.sentrybot/agents/module-creator.md` dosyasını oku.
+
+## İş Akışı
+1. `.sentrybot/context/module-registry.md` → mevcut modülleri öğren
+2. İlişkili modülleri incele
+3. `.sentrybot/skills/scaffold-module.md` → iskelet oluştur
+4. `.sentrybot/skills/gateway-bootstrap.md` → Gateway'e kayıt
+5. Arduino gerekiyorsa → `.sentrybot/skills/arduino-contract.md`
+6. `.sentrybot/skills/write-tests.md` → test yaz
+7. `.sentrybot/skills/write-architecture-doc.md` → mimari dok yaz
+8. `.sentrybot/skills/create-pr.md` → PR hazırla

--- a/.github/agents/module-editor.agent.md
+++ b/.github/agents/module-editor.agent.md
@@ -1,0 +1,17 @@
+---
+name: module-editor
+description: Edits existing SentryBOT modules — adds endpoints, services, config changes, bug fixes, and refactoring while maintaining backward compatibility.
+argument-hint: "a module modification task (e.g., 'add volume endpoint to speak module' or 'fix VLM tracker crash')"
+---
+
+# Module Editor Agent
+
+Mevcut modül düzenleme uzmanı. Detaylı prosedür için `.sentrybot/agents/module-editor.md` dosyasını oku.
+
+## İş Akışı
+1. Hedef modülün `architecture_*.md` ve `config.yml` dosyalarını oku
+2. Değişiklik türünü belirle (endpoint/service/config/fix/refactor)
+3. Uygun skill'i seç ve uygula
+4. Testleri güncelle → `.sentrybot/skills/write-tests.md`
+5. Architecture doc güncelle → `.sentrybot/skills/write-architecture-doc.md`
+6. PR hazırla → `.sentrybot/skills/create-pr.md`

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -1,0 +1,8 @@
+---
+description: "DryCode, Arduino kontrat, test ve güvenlik kontrolü yapar."
+mode: primary
+---
+
+# Code Reviewer
+Detaylı prosedür: `.sentrybot/agents/code-reviewer.md`
+Context: `.sentrybot/context/conventions.md`

--- a/.opencode/agents/github-ops.md
+++ b/.opencode/agents/github-ops.md
@@ -1,0 +1,8 @@
+---
+description: "GitHub PR/Issue oluşturma, CI analizi uzmanı."
+mode: primary
+---
+
+# GitHub Ops
+Detaylı prosedür: `.sentrybot/agents/github-ops.md`
+Skills: `create-pr.md`, `create-issue.md`

--- a/.opencode/agents/inter-module.md
+++ b/.opencode/agents/inter-module.md
@@ -1,0 +1,8 @@
+---
+description: "Modüller arası HTTP/Arduino/State/Event bağlantılarını yönetir."
+mode: primary
+---
+
+# Inter-Module
+Detaylı prosedür: `.sentrybot/agents/inter-module.md`
+Context: `.sentrybot/context/api-surface.md`

--- a/.opencode/agents/module-creator.md
+++ b/.opencode/agents/module-creator.md
@@ -1,0 +1,9 @@
+---
+description: "Sıfırdan yeni SentryBOT modülü oluşturma uzmanı."
+mode: primary
+---
+
+# Module Creator
+Detaylı prosedür: `.sentrybot/agents/module-creator.md`
+Context: `.sentrybot/context/module-registry.md`, `.sentrybot/context/conventions.md`
+Skill: `.sentrybot/skills/scaffold-module.md`

--- a/.opencode/agents/module-editor.md
+++ b/.opencode/agents/module-editor.md
@@ -1,0 +1,8 @@
+---
+description: "Mevcut SentryBOT modüllerini düzenleme uzmanı."
+mode: primary
+---
+
+# Module Editor
+Detaylı prosedür: `.sentrybot/agents/module-editor.md`
+Skills: `add-api-endpoint.md`, `add-service-class.md`, `update-config.md`

--- a/.opencode/skills/add-api-endpoint/SKILL.md
+++ b/.opencode/skills/add-api-endpoint/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: add-api-endpoint
+description: "Mevcut SentryBOT modülüne yeni API endpoint ekler. Router, service, config ve test güncellemelerini kapsar."
+---
+
+# Add API Endpoint
+
+Mevcut modüle yeni endpoint ekleme prosedürü.
+
+## Adımlar
+1. Mevcut `api/router.py` dosyasını incele (naming pattern)
+2. Yeni route fonksiyonu ekle
+3. Gerekirse `services/` altında service class oluştur
+4. Config'e yeni parametreler ekle (gerekirse)
+5. Test yaz
+6. Architecture doc güncelle
+
+## Tam Prosedür
+`.sentrybot/skills/add-api-endpoint.md` dosyasını oku.

--- a/.opencode/skills/arduino-contract/SKILL.md
+++ b/.opencode/skills/arduino-contract/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: arduino-contract
+description: "Arduino kontrat builder ve validator ekler. contract.py'ye build_* ve validate_* fonksiyonları, zorunlu testler."
+---
+
+# Arduino Contract
+
+Arduino komut kontratı ekleme prosedürü.
+
+## Zorunlu Çıktılar (Aynı PR'da)
+1. `modules/arduino_serial/contract.py`'ye `build_<cmd>` fonksiyonu
+2. `modules/arduino_serial/contract.py`'ye `validate_<cmd>` fonksiyonu
+3. Validator unit testi
+4. Gateway davranış testi
+
+## Kurallar
+- Elle `{"cmd": ...}` payload yazmak YASAK
+- Kritik komutlar `/arduino/request` kullanır (ACK bekler)
+- Timeout: 0.8–1.5s arası
+
+## Tam Prosedür
+`.sentrybot/skills/arduino-contract.md` dosyasını oku.

--- a/.opencode/skills/create-pr/SKILL.md
+++ b/.opencode/skills/create-pr/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: create-pr
+description: "SentryBOT PR standartlarına uygun Pull Request hazırlar. Branch adlandırma, şablon doldurma, label atama."
+---
+
+# Create PR
+
+## Branch Formatı
+- `feat/<modül>-<açıklama>` — Yeni özellik
+- `fix/<modül>-<açıklama>` — Hata düzeltme
+- `refactor/<modül>-<açıklama>` — Refactor
+
+## PR Şablonu
+`.github/pull_request_template.md` kontrol listesini doldur.
+
+## Tam Prosedür
+`.sentrybot/skills/create-pr.md` dosyasını oku.

--- a/.opencode/skills/debug-module/SKILL.md
+++ b/.opencode/skills/debug-module/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: debug-module
+description: "SentryBOT modüllerinde hata ayıklama. Sağlık kontrolü, log analizi, yaygın sorunlar ve izole test."
+---
+
+# Debug Module
+
+## Hızlı Teşhis
+```bash
+# Import kontrolü
+python -c "from modules.<modül> import *; print('OK')"
+
+# Config kontrolü
+python -c "from modules.<modül>.config_loader import load_config; print(load_config())"
+
+# Test
+python -m pytest modules/<modül>/tests/ -v --maxfail=1
+
+# API sağlık
+curl http://localhost:8080/<modül>/status
+```
+
+## Tam Prosedür
+`.sentrybot/skills/debug-module.md` dosyasını oku.

--- a/.opencode/skills/gateway-bootstrap/SKILL.md
+++ b/.opencode/skills/gateway-bootstrap/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: gateway-bootstrap
+description: "Yeni modülü Gateway bootstrap sistemine kaydeder. bootstrap.py, config.yml ve include sıralaması."
+---
+
+# Gateway Bootstrap
+
+## Adımlar
+1. `modules/gateway/services/bootstrap.py`'ye `_include_<module>` fonksiyonu ekle
+2. `modules/gateway/config/config.yml`'ye `include.<module>: true` ekle
+3. Bootstrap sırasına uy (bağımlılıklar önce)
+
+## Tam Prosedür
+`.sentrybot/skills/gateway-bootstrap.md` dosyasını oku.

--- a/.opencode/skills/scaffold-module/SKILL.md
+++ b/.opencode/skills/scaffold-module/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: scaffold-module
+description: "SentryBOT deposuna sıfırdan yeni modül iskeleti oluşturur. 10 dosyalı standart yapı: xService, config, router, tests, docs."
+---
+
+# Scaffold Module
+
+SentryBOT modül yapı kurallarına uygun iskelet oluştur.
+
+## Oluşturulacak Dosyalar
+```
+modules/<module_name>/
+├── __init__.py
+├── x<ModuleName>Service.py
+├── config_loader.py
+├── config/config.yml
+├── api/__init__.py
+├── api/router.py
+├── services/__init__.py
+├── tests/test_smoke.py
+├── architecture_<name>.md
+└── README.md
+```
+
+## Tam Şablonlar
+`.sentrybot/skills/scaffold-module.md` dosyasında her dosyanın tam kod şablonu mevcut.
+
+## Kurallar
+- Config değerleri hardcode edilmez
+- Her modül hem kütüphane hem servis olarak çalışabilmeli
+- Smoke test zorunlu

--- a/.opencode/skills/write-tests/SKILL.md
+++ b/.opencode/skills/write-tests/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: write-tests
+description: "SentryBOT modülleri için smoke, unit, API ve mock testleri yazar. CI uyumlu test kalıpları."
+---
+
+# Write Tests
+
+## Test Türleri
+1. **Smoke Test** (zorunlu) — import, config, service init, router
+2. **Unit Test** — tek fonksiyon/class izole test
+3. **API Test** — FastAPI TestClient ile endpoint testi
+4. **Mock** — donanım/HTTP/Arduino bağımlılıkları mock
+
+## CI Kuralları
+- Python 3.10 hedef
+- `--maxfail=1`
+- Donanım testleri `@pytest.mark.skipif` ile korunur
+
+## Tam Kalıplar
+`.sentrybot/skills/write-tests.md` dosyasını oku.

--- a/.sentrybot/README.md
+++ b/.sentrybot/README.md
@@ -1,0 +1,85 @@
+# SentryBOT AI Agent & Skill Sistemi
+
+Bu dizin, SentryBOT deposunda çalışan **tüm AI kodlama asistanları** için yapılandırılmış agent tanımları, skill dosyaları, context bilgileri ve şablonlar içerir.
+
+## Desteklenen AI Araçları
+
+| Araç | Keşif Dosyası | Durum |
+|------|--------------|-------|
+| **Claude Code** | `CLAUDE.md` (kök dizin) | ✅ |
+| **GitHub Copilot** | `.github/copilot-instructions.md` + `.github/agents/` | ✅ |
+| **Cursor** | `.cursorrules` (kök dizin) | ✅ |
+| **Windsurf** | `.windsurfrules` (kök dizin) | ✅ |
+| **OpenCode** | `AGENTS.md` (kök dizin) | ✅ |
+| **Aider** | `AGENTS.md` (kök dizin) | ✅ |
+| **Antigravity** | `AGENTS.md` (kök dizin) | ✅ |
+
+## Dizin Yapısı
+
+```
+.sentrybot/
+├── README.md                    ← Bu dosya
+├── agents/                      # İş akışı yöneticileri
+│   ├── module-creator.md        # 🏗️ Yeni modül oluşturma
+│   ├── module-editor.md         # ✏️ Mevcut modül düzenleme
+│   ├── github-ops.md            # 🐙 GitHub işlemleri (PR/Issue/CI)
+│   ├── inter-module.md          # 🔗 Modüller arası etkileşim
+│   └── code-reviewer.md         # 🔍 Kod inceleme
+├── skills/                      # Adım adım prosedürler
+│   ├── scaffold-module.md       # Modül iskeleti oluşturma
+│   ├── add-api-endpoint.md      # API endpoint ekleme
+│   ├── add-service-class.md     # Service class ekleme
+│   ├── update-config.md         # Config güncelleme
+│   ├── write-tests.md           # Test yazma
+│   ├── write-architecture-doc.md# Mimari dok yazma
+│   ├── arduino-contract.md      # Arduino kontrat ekleme
+│   ├── gateway-bootstrap.md     # Gateway modül kaydı
+│   ├── create-pr.md             # PR oluşturma
+│   ├── create-issue.md          # Issue oluşturma
+│   ├── module-dependency-map.md # Bağımlılık haritası
+│   └── debug-module.md          # Debugging
+├── context/                     # Bilgi tabanı
+│   ├── module-registry.md       # 29 modülün listesi
+│   ├── api-surface.md           # Tüm HTTP endpoint'ler
+│   ├── architecture-summary.md  # Mimari özet
+│   └── conventions.md           # Kod kuralları
+└── templates/                   # İskelet şablonları
+    └── module/                  # Modül dosya şablonları
+        ├── __init__.py.tmpl
+        ├── xService.py.tmpl
+        ├── config_loader.py.tmpl
+        ├── config.yml.tmpl
+        ├── router.py.tmpl
+        ├── test_smoke.py.tmpl
+        ├── architecture.md.tmpl
+        └── README.md.tmpl
+```
+
+## Kullanım
+
+### AI Asistan ile Çalışırken
+
+1. **İlk adım:** İlgili context dosyasını oku (modül listesi, API yüzeyi, kurallar)
+2. **Görev seç:** Uygun agent dosyasını oku (module-creator, module-editor, vb.)
+3. **Uygula:** Agent'ın referans verdiği skill dosyalarını adım adım takip et
+4. **Doğrula:** Testleri çalıştır, dokümantasyonu güncelle
+
+### Yeni Modül Oluşturma Örneği
+
+```
+AI Asistana: "Yeni bir ultrasonik sensör modülü oluştur"
+
+AI Asistan:
+1. .sentrybot/context/module-registry.md → mevcut modülleri öğrenir
+2. .sentrybot/agents/module-creator.md → iş akışını takip eder
+3. .sentrybot/skills/scaffold-module.md → iskelet oluşturur
+4. .sentrybot/skills/gateway-bootstrap.md → Gateway'e kaydeder
+5. .sentrybot/skills/write-tests.md → test yazar
+```
+
+## Güncelleme
+
+Bu dosyalar depoyla birlikte güncel tutulmalıdır:
+- Yeni modül eklendiğinde → `context/module-registry.md` güncellenir
+- Yeni endpoint eklendiğinde → `context/api-surface.md` güncellenir
+- Kural değiştiğinde → `context/conventions.md` güncellenir

--- a/.sentrybot/agents/code-reviewer.md
+++ b/.sentrybot/agents/code-reviewer.md
@@ -1,0 +1,124 @@
+# Agent: Code Reviewer — Kod İnceleme
+
+> Bu agent, SentryBOT deposundaki kod değişikliklerini DryCode kuralları, Arduino kontrat uyumu, test kapsamı ve mimari tutarlılık açısından inceler.
+
+## Kimlik
+
+- **Ad:** code-reviewer
+- **Rol:** Kod kalite kontrol uzmanı
+- **Hedef:** DryCode uyumu, güvenlik, test kapsamı ve mimari tutarlılık sağlamak
+
+## Ön Koşullar
+
+Bu agent çalışmadan önce şu dosyaları oku:
+1. `.sentrybot/context/conventions.md` — Tüm kurallar
+2. `.sentrybot/context/module-registry.md` — Arduino kullanan modüller
+3. `.github/pull_request_template.md` — PR kontrol listesi
+
+## İnceleme Kontrol Listesi
+
+### 1. DryCode Uyumu
+- [ ] Her dosya tek sorumluluk taşıyor mu?
+- [ ] Fonksiyonlar kısa ve tek işlevli mi? (30 satır kuralı)
+- [ ] Tekrarlanan kod var mı? (util/helper çıkarılmalı mı?)
+- [ ] Gereksiz import var mı?
+- [ ] Gereksiz bağımlılık eklenmiş mi?
+
+### 2. Modül Yapı Kuralları
+- [ ] `x<ModuleName>Service.py` adlandırma kuralına uyuyor mu?
+- [ ] `config_loader.py` config okuma kalıbını kullanıyor mu?
+- [ ] `config/config.yml` dosyası var mı ve doğru formatta mı?
+- [ ] Config değerleri hardcode edilmemiş mi?
+- [ ] `__init__.py` re-export yapıyor mu?
+
+### 3. Arduino Kontrat Uyumu
+- [ ] Arduino'ya komut gönderen kod `contract.py` builder kullanıyor mu?
+- [ ] Elle `{"cmd": ...}` payload yazılmamış mı?
+- [ ] Kritik komutlar `/arduino/request` kullanıyor mu?
+- [ ] Timeout değeri 0.8–1.5s arasında mı?
+- [ ] Yeni komut varsa: builder + validator + test üçlüsü mevcut mu?
+- [ ] Modül listesi güncel mi? (kontrat kullanan modüller)
+
+### 4. Test Kapsamı
+- [ ] `tests/test_smoke.py` var mı ve geçiyor mu?
+- [ ] Yeni eklenen fonksiyon/class için test var mı?
+- [ ] Mock kullanımı uygun mu? (donanım bağımlılıkları mock edilmeli)
+- [ ] Edge case'ler test edilmiş mi?
+- [ ] CI'da çalışacak mı? (donanım gerektiren testler skip edilmeli)
+
+### 5. Dokümantasyon
+- [ ] `architecture_<name>.md` güncel mi?
+- [ ] `README.md` güncel mi?
+- [ ] Yeni config alanları belgelenmiş mi?
+- [ ] API endpoint'leri belgelenmiş mi?
+- [ ] Mermaid diyagramı güncel mi?
+
+### 6. Güvenlik
+- [ ] API key/token hardcode edilmemiş mi?
+- [ ] `.env.example` güncellenmiş mi?
+- [ ] Input validation yapılıyor mu?
+- [ ] SQL injection koruması var mı? (parametrized queries)
+- [ ] Path traversal koruması var mı? (dosya işlemleri)
+
+### 7. Performans ve Dayanıklılık
+- [ ] HTTP çağrılarında timeout var mı?
+- [ ] try/except ile hata yakalama yapılıyor mu?
+- [ ] Sonsuz döngü riski var mı?
+- [ ] Thread safety sağlanmış mı? (shared state varsa)
+- [ ] Memory leak riski var mı? (kapatılmayan connection'lar)
+
+### 8. PR Kalitesi
+- [ ] PR şablonu doğru doldurulmuş mu?
+- [ ] Commit mesajları açıklayıcı mı?
+- [ ] Etkilenen modüller doğru listelenmiş mi?
+- [ ] Breaking change varsa belirtilmiş mi?
+- [ ] İlgili issue bağlanmış mı?
+
+## Otomatik Kontrol Komutları
+
+```bash
+# Lint kontrolü (varsa)
+python -m flake8 modules/<module>/ --max-line-length=120
+
+# Type checking (varsa)
+python -m mypy modules/<module>/ --ignore-missing-imports
+
+# Test çalıştırma
+python -m pytest modules/<module>/tests/ -v --maxfail=1
+
+# Import kontrolü
+python -c "from modules.<module> import *; print('OK')"
+
+# Config yükleme kontrolü
+python -c "from modules.<module>.config_loader import load_config; print(load_config())"
+```
+
+## Sıklık ve Ciddiyet Seviyeleri
+
+| Seviye | Açıklama | Örnek |
+|--------|----------|-------|
+| 🔴 Blocker | Merge edilemez | Güvenlik açığı, test kırılması, kontrat ihlali |
+| 🟠 Major | Düzeltilmeli | DryCode ihlali, eksik test, eksik dokümantasyon |
+| 🟡 Minor | Önerilir | Naming convention sapması, gereksiz import |
+| 🟢 Nitpick | İsteğe bağlı | Yorum ekleme, satır uzunluğu |
+
+## Çıktı Formatı
+
+```
+## Kod İnceleme Raporu
+
+### Özet
+- **Dosya Sayısı:** <sayı>
+- **Blocker:** <sayı>
+- **Major:** <sayı>
+- **Minor:** <sayı>
+- **Onay:** ✅ Onaylandı / ❌ Değişiklik gerekli
+
+### Bulgular
+1. 🔴 `<dosya>:<satır>` — <açıklama>
+2. 🟠 `<dosya>:<satır>` — <açıklama>
+3. 🟡 `<dosya>:<satır>` — <açıklama>
+
+### Öneriler
+- <öneri>
+```

--- a/.sentrybot/agents/github-ops.md
+++ b/.sentrybot/agents/github-ops.md
@@ -1,0 +1,133 @@
+# Agent: GitHub Ops — GitHub İşlemleri
+
+> Bu agent, SentryBOT deposundaki tüm GitHub işlemlerini (PR, Issue, CI, Label, Release) yönetir.
+
+## Kimlik
+
+- **Ad:** github-ops
+- **Rol:** GitHub iş akışı uzmanı
+- **Hedef:** Standartlara uygun PR/Issue oluşturma, CI analizi, release yönetimi
+
+## Ön Koşullar
+
+Bu agent çalışmadan önce şu dosyaları oku:
+1. `.github/pull_request_template.md` — PR şablonu
+2. `.github/ISSUE_TEMPLATE/bug_report.yml` — Bug raporu şablonu
+3. `.github/ISSUE_TEMPLATE/feature_request.yml` — Feature request şablonu
+4. `.github/CONTRIBUTING.md` — Katkı kılavuzu
+5. `.github/labeler.yml` — Otomatik label kuralları
+6. `.github/labels.yml` — Tüm label tanımları
+7. `.sentrybot/context/conventions.md` — PR standartları
+
+## Desteklenen İşlemler
+
+### 1. PR Oluşturma
+**Skill:** `.sentrybot/skills/create-pr.md`
+
+**Prosedür:**
+1. Branch adı oluştur: `feat/<module>-<kısa-açıklama>` veya `fix/<module>-<kısa-açıklama>`
+2. `.github/pull_request_template.md` şablonunu doldur:
+   - Özet (ne değişti, neden)
+   - Değişiklik tipi (hata/özellik/refactor/doküman/test)
+   - Etkilenen modüller
+   - Doğrulama kontrol listesi
+   - Arduino kontrat kontrolü (uygunsa)
+   - Risk ve geri alma planı
+   - İlgili issue numarası
+3. Uygun label'ları ata (aşağıdaki haritaya göre)
+4. Reviewer ata (varsa)
+
+**Label Haritası:**
+| Dosya Yolu | Otomatik Label |
+|------------|---------------|
+| `modules/arduino_serial/**` | `module:arduino` |
+| `modules/autonomy/**` | `module:autonomy` |
+| `modules/camera/**` | `module:camera` |
+| `modules/speak/**` | `module:speak` |
+| `modules/speech/**` | `module:speech` |
+| `modules/vlm_bridge/**` | `module:vlm` |
+| `modules/neopixel/**` | `module:neopixel` |
+| `modules/gateway/**` | `module:gateway` |
+| `modules/ollama/**` | `module:ollama` |
+| `modules/agent_core/**` | `module:agent-core` |
+| `arduino/**` | `hardware:arduino` |
+| `docs/**` | `documentation` |
+| `.github/**` | `ci/cd` |
+
+### 2. Issue Oluşturma
+**Skill:** `.sentrybot/skills/create-issue.md`
+
+**Bug Report:**
+1. `bug_report.yml` şablonunu doldur
+2. Beklenen davranış vs gerçekleşen davranış
+3. Tekrar adımları
+4. Ortam bilgisi (Pi5, Python sürümü, OS)
+5. Log çıktıları
+
+**Feature Request:**
+1. `feature_request.yml` şablonunu doldur
+2. Motivasyon ve kullanım senaryosu
+3. Önerilen çözüm
+4. Alternatifler
+5. Etkilenecek modüller
+
+### 3. CI Analizi
+
+**Pytest Başarısızlık Analizi:**
+1. `.github/workflows/pytest.yml` yapısını anla
+2. Başarısız adımı tespit et (collection vs tests)
+3. Hata türünü sınıflandır:
+   - Import hatası → eksik bağımlılık
+   - Exit code 134 → SIGABRT (native crash)
+   - Timeout → sonsuz döngü veya ağır test
+   - Assertion error → mantık hatası
+4. Çözüm öner
+
+**CI Sorun Giderme:**
+```bash
+# Lokal test çalıştırma
+python -m pytest modules/<module>/tests/ -v
+
+# Collection kontrolü
+python -m pytest --collect-only modules/ -vv
+
+# Tek modül testi
+python -m pytest modules/<module>/tests/test_smoke.py -v --maxfail=1
+```
+
+### 4. Release Notları
+
+1. Son release'den bu yana yapılan commit'leri tara
+2. Değişiklikleri kategorize et:
+   - 🚀 Yeni özellikler
+   - 🐛 Hata düzeltmeleri
+   - ♻️ Refactor
+   - 📝 Dokümantasyon
+   - 🧪 Test güncellemeleri
+3. Breaking change'leri vurgula
+4. Etkilenen modülleri listele
+
+### 5. Label Yönetimi
+
+`labeler.yml` kurallarına göre otomatik label atama:
+- Dosya yoluna göre modül label'ı
+- Değişiklik türüne göre tip label'ı
+- Öncelik label'ı (kritik güvenlik, acil fix vb.)
+
+## Güvenlik Kuralları
+
+- Güvenlik açıkları → public issue **açılmaz** → `SECURITY.md` politikasına göre private bildirim
+- API key, token gibi hassas bilgiler → commit'e **asla** dahil edilmez
+- `.env.example` dosyası güncellenir, `.env` dosyası `.gitignore`'da kalır
+
+## Çıktı Formatı
+
+```
+## GitHub İşlem Raporu
+
+- **İşlem:** PR / Issue / CI Analiz / Release
+- **Başlık:** <başlık>
+- **Labels:** <label listesi>
+- **Etkilenen Modüller:** <liste>
+- **Durum:** Oluşturuldu / Analiz tamamlandı
+```

--- a/.sentrybot/agents/inter-module.md
+++ b/.sentrybot/agents/inter-module.md
@@ -1,0 +1,182 @@
+# Agent: Inter-Module — Modüller Arası Etkileşim
+
+> Bu agent, SentryBOT modülleri arasındaki bağlantıları, API çağrılarını, event sistemini ve veri akışlarını yönetir.
+
+## Kimlik
+
+- **Ad:** inter-module
+- **Rol:** Modüller arası entegrasyon uzmanı
+- **Hedef:** Modüller arasında temiz, belgelenmiş, test edilebilir iletişim kanalları kurmak
+
+## Ön Koşullar
+
+Bu agent çalışmadan önce şu dosyaları oku:
+1. `.sentrybot/context/module-registry.md` — Modül listesi ve bağımlılıklar
+2. `.sentrybot/context/api-surface.md` — Tüm endpoint'ler
+3. `.sentrybot/context/architecture-summary.md` — Veri akışı
+4. `modules/autonomy/services/client.py` — ServiceClient referans implementasyonu
+5. `modules/gateway/services/bootstrap.py` — Bootstrap sırası
+
+## İletişim Kalıpları
+
+SentryBOT'ta modüller arası iletişim 4 yolla olur:
+
+### 1. HTTP API (ServiceClient)
+En yaygın yöntem. Autonomy modülü bunu referans olarak uygular.
+
+```python
+# modules/autonomy/services/client.py kalıbı
+import httpx
+
+class ServiceClient:
+    def __init__(self, base_url: str = "http://localhost:8080"):
+        self.base = base_url
+        self.timeout = 1.0  # 1 saniyelik timeout
+
+    async def speak(self, text: str, tone: str = "neutral"):
+        """TTS modülüne konuşma isteği gönder."""
+        await self._post("/speak/say", {"text": text, "tone": tone})
+
+    async def set_lights(self, name: str, **kwargs):
+        """NeoPixel modülüne animasyon isteği gönder."""
+        await self._post("/neopixel/animate", {"name": name, **kwargs})
+
+    async def _post(self, path: str, data: dict):
+        async with httpx.AsyncClient(timeout=self.timeout) as c:
+            try:
+                return await c.post(f"{self.base}{path}", json=data)
+            except Exception:
+                pass  # modül çökmüş olabilir, robot hayatta kalmalı
+```
+
+### 2. Arduino Serial Kontratı
+Donanım komutları için. Mutlaka `contract.py` builder kullanılır.
+
+```python
+from modules.arduino_serial.contract import build_set_servo
+
+payload = build_set_servo(servo_id=1, angle=90)
+response = await client.post("/arduino/request", json=payload)
+```
+
+### 3. State Manager Pub/Sub
+Global durum paylaşımı ve değişim bildirimleri için.
+
+```python
+# Durum yazma
+await client.post("/state/set/emotions", json={"joy": 0.8, "curiosity": 0.5})
+
+# Durum okuma
+state = await client.get("/state/get/emotions")
+```
+
+### 4. Interactions Event Sistemi
+Modüller arası olay bildirimi için.
+
+```python
+# Olay bildirme
+await client.post("/interactions/event", json={
+    "source": "wakeword",
+    "event": "wakeword.detected",
+    "data": {"keyword": "hey_sentry"}
+})
+```
+
+## Bağımlılık Haritası
+
+```mermaid
+graph LR
+    subgraph Algı
+        camera --> vlm_bridge
+        speech --> autonomy
+        wakeword --> speech
+        wakeword --> arduino_serial
+    end
+
+    subgraph Beyin
+        autonomy --> ollama
+        autonomy --> speak
+        autonomy --> neopixel
+        autonomy --> animate
+        autonomy --> vlm_bridge
+        agent_core --> ollama
+        agent_core --> autonomy
+    end
+
+    subgraph Eylem
+        animate --> arduino_serial
+        vlm_bridge --> arduino_serial
+        calibration --> arduino_serial
+    end
+
+    subgraph Etkileşim
+        interactions --> neopixel
+        interactions --> hardware
+    end
+```
+
+## Yeni Bağlantı Ekleme Prosedürü
+
+### Adım 1: Bağlantı Analizi
+1. Kaynak modül ve hedef modül belirle
+2. İletişim türünü seç (HTTP / Arduino / State / Event)
+3. Veri formatını belirle (JSON schema)
+4. Hata senaryolarını planla (timeout, modül çökmesi)
+
+### Adım 2: Implementasyon
+1. Kaynak modülde ServiceClient benzeri çağrı ekle
+2. Hedef modülde endpoint/handler varsa kullan, yoksa oluştur
+3. Timeout değeri belirle (varsayılan: 1.0s, kritik: 1.5s)
+4. Hata yakalama ekle (try/except, robot hayatta kalmalı)
+
+### Adım 3: Test
+1. Mock HTTP ile kaynak modülü test et
+2. Hedef modül endpoint'ini doğrudan test et
+3. Entegrasyon testi: ikisini birlikte test et
+
+### Adım 4: Dokümantasyon
+1. Her iki modülün `architecture_*.md`'sini güncelle
+2. `.sentrybot/context/api-surface.md`'yi güncelle
+3. `.sentrybot/context/module-registry.md`'yi güncelle (bağımlılık sütunu)
+
+## Gateway Bootstrap Sırası
+
+Modüller arası bağımlılık bootstrap sırasını etkiler:
+
+```
+1. logwrapper (log altyapısı — en önce)
+2. state_manager (global durum deposu)
+3. arduino_serial (donanım katmanı)
+4. hardware, camera (algı katmanı)
+5. neopixel, speak, animate, piservo, oled_faces (eylem katmanı)
+6. speech, wakeword (ses girişi)
+7. ollama (LLM servisi)
+8. vlm_bridge (görüntü işleme)
+9. interactions (kural motoru — diğer modüllere bağımlı)
+10. autonomy, agent_core (beyin — en son)
+```
+
+Bu sıra `modules/gateway/services/bootstrap.py`'de korunmalıdır.
+
+## Kısıtlamalar
+
+- Modüller birbirine **doğrudan import** yapmamalı — sadece HTTP API üzerinden konuşmalı
+- Arduino komutları mutlaka `contract.py` builder ile oluşturulmalı
+- Timeout olmadan HTTP çağrısı yapılmamalı
+- Bir modülün çökmesi diğer modülleri durdurmamalı (try/except zorunlu)
+- Döngüsel bağımlılık oluşturulmamalı
+
+## Çıktı Formatı
+
+```
+## Modüller Arası Etkileşim Raporu
+
+- **Kaynak Modül:** <modül>
+- **Hedef Modül:** <modül>
+- **İletişim Türü:** HTTP API / Arduino / State / Event
+- **Endpoint:** <endpoint>
+- **Veri Formatı:** <JSON schema>
+- **Timeout:** <süre>
+- **Hata Stratejisi:** <strateji>
+- **Test:** Tamamlandı / Bekliyor
+```

--- a/.sentrybot/agents/module-creator.md
+++ b/.sentrybot/agents/module-creator.md
@@ -1,0 +1,136 @@
+# Agent: Module Creator — Yeni Modül Oluşturma
+
+> Bu agent, SentryBOT deposuna sıfırdan yeni modül ekleme sürecini yönetir.
+
+## Kimlik
+
+- **Ad:** module-creator
+- **Rol:** Yeni SentryBOT modülü oluşturma uzmanı
+- **Hedef:** DryCode kurallarına uygun, test edilebilir, belgelenmiş modül iskeleti üretmek
+
+## Ön Koşullar
+
+Bu agent çalışmadan önce şu dosyaları oku:
+1. `.sentrybot/context/module-registry.md` — Mevcut modüller
+2. `.sentrybot/context/conventions.md` — Kod kuralları
+3. `.sentrybot/context/architecture-summary.md` — Mimari yapı
+4. `.github/copilot-instructions.md` — Genel talimatlar
+
+## İş Akışı
+
+```mermaid
+flowchart TD
+    A[Kullanıcı: Yeni modül talebi] --> B[module-registry.md oku]
+    B --> C{İlişkili modüller var mı?}
+    C -- Evet --> D[İlişkili modülleri incele]
+    C -- Hayır --> E[Doğrudan scaffold başlat]
+    D --> E
+    E --> F[scaffold-module skill çalıştır]
+    F --> G{Arduino komutu gerekli mi?}
+    G -- Evet --> H[arduino-contract skill çalıştır]
+    G -- Hayır --> I[gateway-bootstrap skill çalıştır]
+    H --> I
+    I --> J[write-tests skill çalıştır]
+    J --> K[write-architecture-doc skill çalıştır]
+    K --> L[create-pr skill çalıştır]
+    L --> M[Sonuç raporu]
+```
+
+## Adım Adım Prosedür
+
+### Adım 1: Keşif ve Analiz
+1. `.sentrybot/context/module-registry.md` dosyasını oku
+2. Talep edilen modülün hangi **katmana** ait olduğunu belirle (Algı/Beyin/AI/Eylem/Arka Plan)
+3. Bu katmandaki mevcut modülleri listele
+4. En az 2 ilişkili modülün kodunu incele:
+   - `x<Name>Service.py` — Servis başlatma kalıbı
+   - `config_loader.py` — Config okuma kalıbı
+   - `api/router.py` — API endpoint kalıbı
+   - `tests/test_smoke.py` — Test kalıbı
+
+### Adım 2: Modül İskeleti Oluşturma
+**Skill:** `.sentrybot/skills/scaffold-module.md`
+
+Şu dosyaları oluştur:
+```
+modules/<module_name>/
+├── __init__.py
+├── x<ModuleName>Service.py
+├── config_loader.py
+├── config/
+│   └── config.yml
+├── api/
+│   ├── __init__.py
+│   └── router.py
+├── services/
+│   └── __init__.py
+├── tests/
+│   └── test_smoke.py
+├── architecture_<module_name>.md
+└── README.md
+```
+
+### Adım 3: Arduino Entegrasyonu (Gerekirse)
+**Skill:** `.sentrybot/skills/arduino-contract.md`
+
+Eğer modül Arduino'ya komut gönderecekse:
+1. `modules/arduino_serial/contract.py`'ye `build_<cmd>` fonksiyonu ekle
+2. Validator fonksiyonu ekle
+3. Gateway router'ına `/arduino/request` çağrısı ekle
+4. Contract test yaz
+
+### Adım 4: Gateway'e Kayıt
+**Skill:** `.sentrybot/skills/gateway-bootstrap.md`
+
+1. `modules/gateway/services/bootstrap.py`'ye `_include_<module>` fonksiyonu ekle
+2. `modules/gateway/config/config.yml`'ye `include.<module>: true` ekle
+
+### Adım 5: Test Yazma
+**Skill:** `.sentrybot/skills/write-tests.md`
+
+En az şunları içermeli:
+- `test_smoke.py` — Import testi, config yükleme testi
+- Service class instantiation testi
+- API endpoint testi (mock ile)
+
+### Adım 6: Mimari Dokümantasyon
+**Skill:** `.sentrybot/skills/write-architecture-doc.md`
+
+`architecture_<module_name>.md` dosyası:
+- Genel bakış
+- Mermaid veri akışı diyagramı
+- Modüller arası etkileşim tablosu
+- Tasarım kararları
+
+### Adım 7: PR Hazırlama
+**Skill:** `.sentrybot/skills/create-pr.md`
+
+PR açıklamasında şunlar bulunmalı:
+- Yeni modülün görevi ve katmanı
+- Arduino kontrat uyumu (gerekirse)
+- Test sonuçları
+- Etkilenen modüller
+
+## Çıktı Formatı
+
+Agent tamamlandığında şu raporu üretir:
+
+```
+## Modül Oluşturma Raporu
+
+- **Modül:** <module_name>
+- **Katman:** <katman>
+- **Dosya Sayısı:** <sayı>
+- **Test Sayısı:** <sayı>
+- **Arduino Kontrat:** Evet/Hayır
+- **Gateway Kaydı:** Tamamlandı
+- **İlişkili Modüller:** <liste>
+- **PR Hazır:** Evet/Hayır
+```
+
+## Kısıtlamalar
+
+- **Asla** mevcut modüllerin kodunu değiştirme (sadece gateway bootstrap ve contract.py hariç)
+- **Asla** hardcode config değeri kullanma
+- **Asla** gereksiz bağımlılık ekleme
+- Arduino komutu gönderecekse **mutlaka** contract.py builder kullan

--- a/.sentrybot/agents/module-editor.md
+++ b/.sentrybot/agents/module-editor.md
@@ -1,0 +1,116 @@
+# Agent: Module Editor — Mevcut Modül Düzenleme
+
+> Bu agent, mevcut SentryBOT modüllerinde değişiklik yapma sürecini yönetir.
+
+## Kimlik
+
+- **Ad:** module-editor
+- **Rol:** Mevcut modül düzenleme, yeni endpoint/service/config ekleme uzmanı
+- **Hedef:** Mevcut yapıyı bozmadan, DryCode kurallarına uygun değişiklik yapmak
+
+## Ön Koşullar
+
+Bu agent çalışmadan önce şu dosyaları oku:
+1. Hedef modülün `architecture_<name>.md` dosyası
+2. Hedef modülün `config/config.yml` dosyası
+3. Hedef modülün `x<Name>Service.py` dosyası
+4. `.sentrybot/context/conventions.md`
+5. `.sentrybot/context/module-registry.md`
+
+## İş Akışı
+
+```mermaid
+flowchart TD
+    A[Kullanıcı: Modül düzenleme talebi] --> B[Hedef modülü analiz et]
+    B --> C{Değişiklik türü?}
+    C -- Yeni endpoint --> D[add-api-endpoint skill]
+    C -- Yeni service --> E[add-service-class skill]
+    C -- Config değişikliği --> F[update-config skill]
+    C -- Bug fix --> G[Doğrudan düzelt]
+    C -- Refactor --> H[Kapsamlı inceleme]
+    D --> I[write-tests skill]
+    E --> I
+    F --> I
+    G --> I
+    H --> I
+    I --> J[write-architecture-doc skill güncelle]
+    J --> K{Arduino etkisi var mı?}
+    K -- Evet --> L[arduino-contract skill kontrol]
+    K -- Hayır --> M[create-pr skill]
+    L --> M
+```
+
+## Değişiklik Türleri ve Prosedürleri
+
+### A. Yeni API Endpoint Ekleme
+**Skill:** `.sentrybot/skills/add-api-endpoint.md`
+
+1. Mevcut `api/router.py` dosyasını oku
+2. Mevcut endpoint naming pattern'ini takip et
+3. Yeni route fonksiyonu ekle
+4. Gerekirse `services/` altında yeni service class oluştur
+5. Smoke test'e yeni endpoint testi ekle
+6. Architecture doc'u güncelle
+
+### B. Yeni Service Class Ekleme
+**Skill:** `.sentrybot/skills/add-service-class.md`
+
+1. `services/` dizinindeki mevcut class'ları incele
+2. Naming convention'a uy: `<İşlev>Service`, `<İşlev>Manager`, `<İşlev>Handler`
+3. `__init__.py`'ye re-export ekle
+4. `x<Name>Service.py`'den başlatma kodunu ekle
+5. Unit test yaz
+
+### C. Config Değişikliği
+**Skill:** `.sentrybot/skills/update-config.md`
+
+1. `config/config.yml`'ye yeni alan ekle
+2. `config_loader.py`'de yeni alanı oku ve varsayılan değer ata
+3. Eğer merkezi config'i de etkiliyorsa `config/agent.yaml`'ı güncelle
+4. README'deki config tablosunu güncelle
+
+### D. Bug Fix
+1. Hatayı izole et (logları, test çıktılarını incele)
+2. Kök nedeni belirle
+3. Minimum müdahaleyle düzelt
+4. Regression testi ekle
+5. Fix'in diğer modülleri etkilemediğini doğrula
+
+### E. Refactor
+1. Değiştirilecek kodun tüm kullanıcılarını (import eden modülleri) bul
+2. Geriye uyumluluğu koru veya migration planı hazırla
+3. Adım adım refactor yap (bir seferde tek sorumluluk)
+4. Her adımda testlerin geçtiğini doğrula
+
+## Etki Analizi Kontrol Listesi
+
+Değişiklik yapmadan önce şu soruları sor:
+
+- [ ] Bu değişiklik başka modüllerin API çağrılarını etkiliyor mu?
+- [ ] Bu değişiklik config formatını değiştiriyor mu?
+- [ ] Bu değişiklik Arduino kontratını etkiliyor mu?
+- [ ] Bu değişiklik Gateway bootstrap sırasını etkiliyor mu?
+- [ ] Bu değişiklik state_manager'daki key'leri etkiliyor mu?
+- [ ] Bu değişiklik mevcut testleri kırıyor mu?
+
+## Çıktı Formatı
+
+```
+## Modül Düzenleme Raporu
+
+- **Modül:** <module_name>
+- **Değişiklik Türü:** Endpoint / Service / Config / Bug Fix / Refactor
+- **Değiştirilen Dosyalar:** <liste>
+- **Eklenen Dosyalar:** <liste>
+- **Test Güncellemesi:** Evet/Hayır
+- **Architecture Güncellemesi:** Evet/Hayır
+- **Arduino Etkisi:** Yok / Kontrat güncel
+- **Geriye Uyumlu:** Evet/Hayır
+```
+
+## Kısıtlamalar
+
+- Mevcut API imzalarını değiştirirken **geriye uyumluluk** koru
+- Config alanlarını silerken **deprecation uyarısı** ekle
+- Arduino kontratında değişiklik varsa mutlaka `contract.py`'yi güncelle
+- Hiçbir dosyayı silme — deprecate et, sonraki PR'da kaldır

--- a/.sentrybot/context/api-surface.md
+++ b/.sentrybot/context/api-surface.md
@@ -1,0 +1,196 @@
+# SentryBOT — API Yüzey Haritası (API Surface)
+
+> Tüm modüllerin HTTP endpoint'leri bu dosyada listelenmiştir. AI asistanlar yeni endpoint eklerken veya modüller arası iletişim kurarken bu dosyayı referans alır.
+
+## Gateway (Port 8080)
+
+Tüm modüller Gateway üzerinden `/` kökünde mount olur. Her modülün endpoint'leri kendi prefix'i altındadır.
+
+### Core Gateway Endpoints
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/status` | GET | Gateway ve tüm modüllerin durumu |
+| `/health` | GET | Sağlık kontrolü |
+| `/healthz` | GET | Kubernetes-style health check |
+
+---
+
+### Arduino Serial — `/arduino/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/arduino/send` | POST | Fire-and-forget komut gönder |
+| `/arduino/request` | POST | ACK bekleyerek komut gönder (kritik komutlar için) |
+| `/arduino/status` | GET | Bağlantı durumu |
+| `/arduino/telemetry` | GET | Son telemetri verileri |
+
+### Autonomy — `/autonomy/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/autonomy/apply_actions` | POST | LLM action'larını donanıma uygula |
+| `/autonomy/status` | GET | Brain döngüsü durumu |
+| `/autonomy/mood` | GET | Anlık duygu durumu |
+
+### Agent Core — `/agent/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/agent/step` | POST | Tek agent adımı (tool loop) |
+| `/agent/step_stream` | POST | SSE canlı durum + final cevap |
+| `/agent/route_preview` | POST | Router seçim önizleme |
+| `/agent/world_state` | GET | Dünya durumu (pil, sensörler) |
+| `/agent/memory/search` | GET | Epizodik hafıza arama |
+| `/agent/slam/location` | GET | Topolojik konum |
+| `/agent/slam/pathfind` | GET | BFS yol bulma |
+| `/agent/healthz` | GET | Agent durumu (BUSY/IDLE) |
+
+### Camera — `/camera/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/camera/stream` | GET | MJPEG canlı stream |
+| `/camera/snapshot` | GET | Tek kare yakala |
+| `/camera/video` | GET | Video feed URL |
+
+### VLM Bridge — `/vlm/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/vlm/results` | GET/POST | Algılama sonuçları (local/remote) |
+| `/vlm/track` | POST | Pan/tilt takip komutu |
+| `/vlm/follow/start` | POST | Yüz takibini başlat |
+| `/vlm/follow/stop` | POST | Yüz takibini durdur |
+| `/vlm/ask` | POST | VLM'e soru sor (sahne analizi) |
+
+### Speech — `/speech/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/speech/start` | POST | ASR dinlemeyi başlat |
+| `/speech/stop` | POST | ASR dinlemeyi durdur |
+| `/speech/last` | GET | Son tanınan metin |
+| `/speech/direction` | GET | Ses geliş yönü (derece) |
+
+### Speak (TTS) — `/speak/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/speak/say` | POST | Metin sentezle ve oynat |
+| `/speak/stop` | POST | Konuşmayı durdur |
+| `/speak/status` | GET | TTS durumu |
+
+### Ollama (LLM) — `/ollama/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/ollama/chat` | POST | LLM sohbet (persona + history) |
+| `/ollama/translate` | POST | Metin çevirisi |
+| `/ollama/personas` | GET | Mevcut kişilik listesi |
+
+### NeoPixel — `/neopixel/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/neopixel/animate` | POST | LED animasyon tetikle |
+| `/neopixel/set` | POST | Sabit renk ayarla |
+| `/neopixel/off` | POST | LED'leri kapat |
+
+### Animate — `/animate/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/animate/run` | POST | Servo animasyon çalıştır |
+| `/animate/stop` | POST | Animasyonu durdur |
+| `/animate/list` | GET | Mevcut animasyon listesi |
+
+### Interactions — `/interactions/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/interactions/event` | POST | Olay bildir (event push) |
+| `/interactions/metrics` | GET | Anlık metrikler |
+
+### State Manager — `/state/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/state/get/<key>` | GET | Durum oku |
+| `/state/set/<key>` | POST | Durum güncelle |
+| `/state` | GET | Tüm durum |
+
+### PiServo — `/piservo/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/piservo/set` | POST | Kulak servosunu ayarla |
+
+### OLED Faces — `/oled/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/oled/face` | POST | Yüz ifadesi göster |
+| `/oled/text` | POST | Metin göster |
+
+### Hardware — `/hardware/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/hardware/info` | GET | CPU/RAM/sıcaklık/I2C bilgisi |
+
+### Config Center — `/config/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/config` | GET | Config oku |
+| `/config` | POST | Config güncelle |
+
+### Diagnostics — `/diagnostics/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/diagnostics/self_test` | POST | Sistem sağlık testi başlat |
+| `/diagnostics/results` | GET | Son test sonuçları |
+
+### Scheduler — `/scheduler/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/scheduler/jobs` | GET | Zamanlanmış görevler |
+| `/scheduler/jobs` | POST | Yeni görev ekle |
+
+### Telemetry — `/telemetry/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/telemetry/metrics` | GET | Prometheus formatında metrikler |
+
+### Notifier — `/notify/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/notify/send` | POST | Bildirim gönder (Telegram/Discord) |
+
+### OTA — `/ota/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/ota/update` | POST | Firmware güncelleme yükle |
+| `/ota/status` | GET | Güncelleme durumu |
+
+### Logwrapper — `/logs/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/logs/stream` | WS | WebSocket log akışı |
+
+### Calibration — `/calibration/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/calibration/start` | POST | Kalibrasyon moduna gir |
+| `/calibration/set` | POST | Servo açısı gönder |
+| `/calibration/save` | POST | Kalibrasyonu kaydet |
+
+### Social DB — `/social/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/social/people` | GET | Tanınan kişiler listesi |
+| `/social/person/<id>` | GET | Kişi detayı |
+
+### ESP Link — `/esp/`
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/esp/status` | GET | ESP32 bağlantı durumu |
+| `/esp/command` | POST | ESP32'ye komut gönder |
+
+---
+
+## Port Haritası
+
+| Port | Modül | Açıklama |
+|------|-------|----------|
+| 8080 | Gateway | Ana API hub |
+| 8082 | Speech | ASR servisi (standalone) |
+| 8083 | Speak | TTS servisi (standalone) |
+| 8099 | Ollama Service | LLM servisi (standalone) |
+| 8101 | VLM Bridge | Görsel algı servisi (standalone) |
+
+> Not: Standalone portlar modül bağımsız çalıştırıldığında kullanılır. Gateway modunda tüm modüller 8080 portu üzerinden erişilebilir.

--- a/.sentrybot/context/architecture-summary.md
+++ b/.sentrybot/context/architecture-summary.md
@@ -1,0 +1,104 @@
+# SentryBOT — Mimari Özet (Architecture Summary)
+
+> AI asistanlar bu dosyayı okuyarak sistemin büyük resmini anlar. Detaylar için `docs/ARCHITECTURE.md` dosyasına bakın.
+
+## Sistem Genel Bakışı
+
+SentryBOT, Raspberry Pi 5 üzerinde çalışan, modüler mikro-servis mimarisine sahip otonom bir robot platformudur. Arduino ile seri iletişim, OpenCV ile görüntü işleme, Ollama LLM ile yapay zekâ yetenekleri entegre eder.
+
+## 5 Katmanlı Mimari
+
+```mermaid
+flowchart TB
+    subgraph L1["1. ALGI KATMANI"]
+        camera["Camera<br/>MJPEG stream"]
+        speech["Speech<br/>ASR + DOA"]
+        vlm["VLM Bridge<br/>Yüz algılama"]
+        wakeword["Wakeword<br/>Hey Sentry"]
+        hw["Hardware<br/>CPU/RAM/Temp"]
+    end
+
+    subgraph L2["2. BEYİN KATMANI"]
+        gateway["Gateway<br/>API Bootstrapper<br/>Port 8080"]
+        autonomy["Autonomy<br/>Sense-Think-Act"]
+        agent["Agent Core<br/>3-Layer Agent"]
+        state["State Manager<br/>Thread-safe store"]
+        config_c["Config Center<br/>Hot-reload"]
+    end
+
+    subgraph L3["3. AI / RAG KATMANI"]
+        ollama["Ollama<br/>LLM Chat<br/>Port 8099"]
+    end
+
+    subgraph L4["4. EYLEM KATMANI"]
+        arduino["Arduino Serial<br/>NDJSON komut"]
+        animate_m["Animate<br/>YAML servo"]
+        neo["NeoPixel<br/>LED animasyon"]
+        speak_m["Speak (TTS)<br/>Port 8083"]
+        piservo["PiServo<br/>GPIO PWM"]
+        oled["OLED Faces"]
+    end
+
+    subgraph L5["5. ARKA PLAN"]
+        sched["Scheduler"]
+        diag["Diagnostics"]
+        log_m["Logwrapper"]
+        telem["Telemetry"]
+        ota_m["OTA Update"]
+        notif["Notifier"]
+    end
+
+    L1 --> L2
+    L2 --> L3
+    L3 --> L2
+    L2 --> L4
+    L4 --> L5
+```
+
+## Temel Veri Akışı
+
+```
+Wakeword ──trigger──→ Speech (ASR açılır)
+Speech ──metin──→ Autonomy (Sense aşaması)
+Camera ──frame──→ VLM Bridge (yüz algılama)
+VLM Bridge ──kişi bilgisi──→ Autonomy (mood güncelle)
+Autonomy ──soru──→ Ollama (LLM chat)
+Ollama ──yanıt + actions──→ Autonomy (Act aşaması)
+Autonomy ──HTTP──→ Speak (TTS), NeoPixel (LED), Animate (servo)
+Animate/VLM ──serial──→ Arduino Serial ──NDJSON──→ Arduino
+Interactions ──kural motoru──→ NeoPixel
+```
+
+## Gateway Bootstrap Mekanizması
+
+1. `run_robot.py` → `create_app()` çağırır
+2. `bootstrap(app, cfg)` → `config.yml`'deki `include` sözlüğünü okur
+3. Her `include.<module>: true` için `_include_<module>(app, cfg)` çağrılır
+4. Modül başarısızsa → warning loglanır, diğer modüller devam eder
+5. Tüm modüller bağımsız çalışır (Microservice Pattern)
+
+## Agent Core — 3 Katmanlı Ajan
+
+```
+Layer 1: Router/Planner → İsteği uygun sub-agent'lara yönlendirir
+Layer 2: Module Sub-Agent → Domain-specific tool çalıştırır
+Layer 3: Main Persona → Tutarlı final cevap üretir
+```
+
+Tüm katmanlar aynı Ollama modeli üzerinden çalışır (tek model stratejisi: `qwen3.5:9b`).
+
+## Autonomy — Sense-Think-Act Döngüsü
+
+```
+SENSE → Konuşma var mı? Ses yönü değişti mi? Kişi görüldü mü?
+THINK → Duygu bozunması, sıkılma kontrolü, uyku saati kontrolü
+ACT   → LLM yanıtını parse et, donanım HTTP çağrıları yap
+```
+
+## Güvenlik ve Dayanıklılık
+
+- **Owner kontrolü:** VLM + RFID ile sahip doğrulaması
+- **LLM fallback:** JSON parse başarısızsa → regex ile XML tag ayrıştırma
+- **CPU throttling:** VLM FPS sınırı, Wakeword hafif işlem
+- **API timeout:** ServiceClient üzerinde 1s timeout → modül çökse bile robot hayatta
+- **Safety filter:** Servo açı sınırları, stepper hız limiti, lazer süre limiti

--- a/.sentrybot/context/conventions.md
+++ b/.sentrybot/context/conventions.md
@@ -1,0 +1,120 @@
+# SentryBOT — Kod Kuralları ve Kalıplar (Conventions)
+
+> Bu dosya tüm AI asistanlar tarafından kod yazarken uyulması gereken kuralları tanımlar.
+
+## 1. DryCode Prensipleri
+
+- **Tekrar yasak** — Aynı mantığı iki yere yazma, ortak util/helper çıkar.
+- **Sade ve net** — Her dosya tek sorumluluk taşır, uzun fonksiyonlardan kaçın.
+- **Kısa fonksiyonlar** — Her fonksiyon tek bir iş yapar, 30 satırı geçmez.
+- **Gereksiz bağımlılık yasak** — Sadece gerçekten kullanılan kütüphaneleri ekle.
+
+## 2. Modül Yapısı Kuralları
+
+### 2.1 Dosya İsimlendirme
+- Servis başlatıcı: `x<ModuleName>Service.py` (örn: `xSpeakService.py`)
+- Config okuyucu: `config_loader.py`
+- Config dosyası: `config/config.yml`
+- API router: `api/router.py`
+- Mimari doku: `architecture_<module_name>.md`
+
+### 2.2 Çift Kullanım İlkesi
+Her modül hem **kütüphane** (import edilebilir) hem de **servis** (bağımsız çalıştırılabilir) olarak çalışabilmelidir.
+
+### 2.3 Config Kuralları
+- Her modülün kendi `config/config.yml` dosyası olmalı.
+- Config değerleri **asla hardcode** edilmez — sadece YAML'den okunur.
+- Varsayılan ayarlar config.yml içindedir, çevre değişkenleriyle override edilebilir.
+- `config_loader.py` dosyası YAML'i okur ve dict döndürür.
+
+### 2.4 Modül Oluşturma Öncesi İnceleme
+Yeni modül yazmadan önce mutlaka ilişkili mevcut modüller incelenmelidir:
+- Amaç: Tekrarı azaltmak, ortak desenleri korumak
+- Örnek: `wakeword` yazılacaksa → `speech`, `speak`, `interactions`, `autonomy` incelenir
+- İnceleme sonuçları kısa notlarla belgelenir
+
+## 3. Arduino Kontrat Kuralları (Zorunlu)
+
+### 3.1 Tek Kaynak
+Arduino komut şeması için tek kaynak: `modules/arduino_serial/contract.py`
+
+### 3.2 Builder Zorunluluğu
+Pi tarafında Arduino'ya komut gönderen tüm modüller, `contract.py`'deki `build_*` fonksiyonlarını kullanmalıdır. Elle `{"cmd": ...}` payload yazımı yasaktır.
+
+### 3.3 İletişim Yolu
+- Kritik komutlar (`set_servo`, `stepper`, `track`, `pid_*`) → `/arduino/request` (ACK beklenir)
+- Kritik komut timeout: `0.8–1.5s` arası
+- Tek seferlik retry `max_retries=1` önerilir
+
+### 3.4 Yeni Komut Ekleme
+Aynı PR'da 3 şey zorunlu:
+1. `contract.py`'ye builder + validator
+2. Validator unit testi
+3. Gateway davranış testi
+
+### 3.5 `hello` Uyumluluk
+`hello.features` listesinde yoksa:
+- Kritik komutlar → hard-fail
+- Kozmetik komutlar → soft-skip + log
+
+## 4. Kod Tarzı
+
+```python
+# ✅ İyi
+from modules.arduino_serial.contract import build_set_servo
+
+payload = build_set_servo(servo_id=1, angle=90)
+await client.post("/arduino/request", json=payload)
+
+# ❌ Kötü — elle payload
+payload = {"cmd": "set_servo", "id": 1, "value": 90}
+```
+
+- Yalnızca gerekli `import`'lar kullanılır
+- Anlaşılır class isimleri: `AudioRecorder`, `FaceDetector`, `MoodManager`
+- Kod yorumları gerektiğinde eklenir, gereksiz açıklamalardan kaçınılır
+- `# MARK:` yorumları VS Code navigasyonu için kullanılır
+
+## 5. PR ve Topluluk Standartları
+
+### 5.1 PR Şablonu
+`.github/pull_request_template.md` kontrol listesi takip edilir:
+- Değişiklik tipi (hata/özellik/refactor/dokümantasyon/test)
+- Etkilenen modüller
+- Lokal çalıştırma ve test onayı
+- Arduino kontrat kontrolü (uygunsa)
+- Risk ve geri alma planı
+
+### 5.2 Topluluk Dosyaları
+Bu dosyalara uyum zorunludur:
+- `CODE_OF_CONDUCT.md` — Davranış kuralları
+- `CONTRIBUTING.md` — Katkı kılavuzu
+- `SECURITY.md` — Güvenlik politikası
+- `ISSUE_TEMPLATE/` — Bug/Feature şablonları
+
+### 5.3 Güvenlik
+Güvenlik riski içeren bulgular → public issue **değil** → `SECURITY.md` private bildirim akışı
+
+## 6. Donanım Kuralları
+
+- Platform: **Raspberry Pi 5**
+- Arduino ile NDJSON seri haberleşme
+- Görüntü işleme/AI → API ile dış istemcilere devredilir
+- Donanım modülleri bağımsız çalışabilmeli, hataları düzgün ele almalı, loglamalı
+- `config.yml` üzerinden yapılandırılmalı
+
+## 7. Test Kuralları
+
+- Her modülde en az `tests/test_smoke.py` bulunmalı
+- CI: `python -m pytest modules/ -q --maxfail=1`
+- Python 3.10 hedef
+- Donanım bağımlılıkları mock/stub ile test edilir
+- WebRTC VAD, sounddevice gibi opsiyonel paketler CI'da uninstall edilir
+
+## 8. Dokümantasyon Kuralları
+
+- Her modülde `architecture_<name>.md` → Mermaid diyagramları, veri akışı, tasarım kararları
+- Her modülde `README.md` → Kullanım, API, config açıklaması
+- Merkezi mimari: `docs/ARCHITECTURE.md`
+- Backend bilgisi: `.github/backend_knowledge.md`
+- Frontend bilgisi: `.github/frontend_knowledge.md`

--- a/.sentrybot/context/module-registry.md
+++ b/.sentrybot/context/module-registry.md
@@ -1,0 +1,83 @@
+# SentryBOT — Modül Kayıt Defteri (Module Registry)
+
+> AI asistanlar bu dosyayı okuyarak projedeki tüm modülleri, portlarını, görevlerini ve bağımlılıklarını hızla öğrenir.
+
+## Modül Listesi
+
+| # | Modül | Port | Katman | Görev | Arduino Kullanır | Kilit Bağımlılıklar |
+|---|-------|------|--------|-------|-----------------|---------------------|
+| 1 | `gateway` | 8080 | Çekirdek | FastAPI API bootstrapper, tüm modülleri mount eder | Hayır | Tüm modüller |
+| 2 | `autonomy` | — | Çekirdek | Sense-Think-Act beyin döngüsü, duygu motoru, LLM kararları | Evet | ollama, speak, vlm_bridge, arduino_serial |
+| 3 | `agent_core` | — | Çekirdek | 3-katmanlı ajan zekâ (Router→Sub-Agent→Persona), tool calling | Hayır | ollama, autonomy |
+| 4 | `arduino_serial` | — | Eylem | NDJSON seri haberleşme, komut/yanıt kuyruğu | **Kaynak** | — |
+| 5 | `camera` | — | Algı | MJPEG kamera stream, auto-recovery | Hayır | — |
+| 6 | `vlm_bridge` | 8101 | Algı | OpenCV yüz algılama, ORB/FLANN eşleme, CSRT takip, remote VLM | Evet (pan/tilt) | camera, arduino_serial, ollama |
+| 7 | `speech` | 8082 | Ses/Dil | Çok kanallı ASR, Vosk/Whisper, ses yönü (DOA) | Hayır | — |
+| 8 | `speak` | 8083 | Ses/Dil | TTS sentez (pyttsx3/Piper/xTTS), ton/duygu ayarı | Hayır | neopixel (liveliness) |
+| 9 | `wakeword` | — | Ses/Dil | "Hey Sentry" sürekli dinleme (Porcupine/Snowboy) | Evet (buzzer) | speech, arduino_serial |
+| 10 | `ollama` | 8099 | AI/RAG | Ollama LLM chat, persona yönetimi, JSON/XML parse | Hayır | — |
+| 11 | `neopixel` | — | Eylem | 23 duygu paleti, SPI LED animasyonları | Hayır | — |
+| 12 | `interactions` | — | Etkileşim | CPU/ağ metrikleri, kural motoru, NeoPixel tetikleme | Hayır | neopixel, hardware |
+| 13 | `animate` | — | Eylem | YAML servo animasyon oynatıcı | Evet | arduino_serial |
+| 14 | `state_manager` | — | Çekirdek | Thread-safe global durum deposu, pub/sub | Hayır | — |
+| 15 | `piservo` | — | Eylem | Raspberry Pi GPIO PWM kulak servoları | Hayır | — |
+| 16 | `oled_faces` | — | Eylem | OLED ekran yüz ifadeleri | Hayır | — |
+| 17 | `hardware` | — | Algı | CPU/RAM/sıcaklık bilgisi, I2C tarama | Hayır | — |
+| 18 | `config_center` | — | Arka Plan | Merkezi config okuma/yazma, hot-reload | Hayır | — |
+| 19 | `diagnostics` | — | Arka Plan | Sistem sağlık testi (Arduino, kamera, Ollama) | Dolaylı | arduino_serial, camera, ollama |
+| 20 | `scheduler` | — | Arka Plan | Cron benzeri zamanlayıcı | Hayır | — |
+| 21 | `notifier` | — | Arka Plan | Telegram/Discord bildirim gönderici | Hayır | — |
+| 22 | `logwrapper` | — | Arka Plan | WebSocket log yayını, merkezi loglama | Hayır | — |
+| 23 | `telemetry` | — | Arka Plan | Prometheus formatında metrik toplama | Hayır | — |
+| 24 | `ota` | — | Arka Plan | Over-the-air güncelleme, checksum doğrulama | Hayır | — |
+| 25 | `mutagen` | — | Arka Plan | PC↔Pi dosya senkronizasyonu | Hayır | — |
+| 26 | `calibration` | — | Arka Plan | Servo kalibrasyon modu | Evet | arduino_serial |
+| 27 | `esp_link` | — | Etkileşim | ESP32 köprü iletişimi (mDNS web remote) | Dolaylı | — |
+| 28 | `social_db` | — | Veri | SQLite kişi hafızası, ilişki/tanıma seviyeleri | Hayır | — |
+| 29 | `admin_ui` | — | Etkileşim | Web yönetim paneli (statik dosyalar) | Hayır | gateway |
+
+## Mimari Katmanlar
+
+```
+1. ALGI (Sense)     → camera, speech, vlm_bridge, wakeword, hardware
+2. BEYİN (Core)     → gateway, autonomy, agent_core, state_manager, config_center
+3. AI / RAG         → ollama
+4. EYLEM (Act)      → arduino_serial, animate, neopixel, speak, piservo, oled_faces
+5. ARKA PLAN (Bg)   → scheduler, diagnostics, logwrapper, telemetry, ota, mutagen,
+                       calibration, notifier, esp_link, social_db, admin_ui, interactions
+```
+
+## Modül Yapı Kuralı (Standart Şablon)
+
+Her modül şu dosya yapısına uyar:
+
+```
+modules/<module_name>/
+├── __init__.py                     # Re-export, versiyon bilgisi
+├── x<ModuleName>Service.py         # Ana servis başlatıcı
+├── config_loader.py                # config/config.yml okuyucu
+├── config/
+│   ├── config.yml                  # Modüle özgü ayarlar
+│   └── README.md                   # (opsiyonel) config açıklaması
+├── api/
+│   ├── __init__.py
+│   └── router.py                   # FastAPI router endpoint'leri
+├── services/
+│   ├── __init__.py
+│   └── ...                         # İş mantığı sınıfları
+├── tests/
+│   └── test_smoke.py               # Temel testler
+├── architecture_<module_name>.md   # Mimari dokümantasyon
+└── README.md                       # Kullanım kılavuzu
+```
+
+## Arduino Kontratı Kullanan Modüller
+
+Bu modüller `modules/arduino_serial/contract.py` builder fonksiyonlarını kullanmak zorundadır:
+- `arduino_serial` (kaynak)
+- `autonomy`
+- `speech`
+- `vlm_bridge`
+- `animate`
+- `calibration`
+- `wakeword`

--- a/.sentrybot/skills/add-api-endpoint.md
+++ b/.sentrybot/skills/add-api-endpoint.md
@@ -1,0 +1,105 @@
+# Skill: Add API Endpoint — Mevcut Modüle Endpoint Ekleme
+
+> Mevcut bir modüle yeni API endpoint ekleme prosedürü.
+
+## Girdiler
+
+| Parametre | Zorunlu | Açıklama | Örnek |
+|-----------|---------|----------|-------|
+| `MODULE_NAME` | ✅ | Hedef modül | `speak` |
+| `ENDPOINT_PATH` | ✅ | Yeni endpoint yolu | `/volume` |
+| `HTTP_METHOD` | ✅ | HTTP metodu | `POST` |
+| `DESCRIPTION` | ✅ | Endpoint açıklaması | `Ses seviyesini ayarla` |
+
+## Prosedür
+
+### Adım 1: Mevcut Router'ı İncele
+```bash
+# Mevcut endpoint'leri gör
+cat modules/{{MODULE_NAME}}/api/router.py
+```
+
+Kontrol et:
+- Naming convention (fonksiyon isimleri)
+- Parametre alma kalıbı (query param vs body)
+- Response formatı (JSONResponse vs dict)
+- Dependency injection (service instance nasıl aktarılıyor)
+
+### Adım 2: Service Fonksiyonu Oluştur (Gerekirse)
+
+Eğer yeni iş mantığı gerekiyorsa `services/` altına ekle:
+
+```python
+# modules/{{MODULE_NAME}}/services/<yeni_servis>.py
+from __future__ import annotations
+import logging
+
+logger = logging.getLogger("{{MODULE_NAME}}.<yeni_servis>")
+
+
+class <YeniServis>:
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+
+    def execute(self, **kwargs):
+        """İş mantığı."""
+        logger.info("Executing with %s", kwargs)
+        # ...implementasyon...
+        return {"ok": True}
+```
+
+### Adım 3: Router'a Endpoint Ekle
+
+```python
+# modules/{{MODULE_NAME}}/api/router.py içine ekle
+
+@router.{{HTTP_METHOD.lower()}}("{{ENDPOINT_PATH}}")
+async def {{endpoint_function_name}}(request_body: dict = None):
+    """{{DESCRIPTION}}"""
+    try:
+        result = svc.{{service_method}}(**request_body)
+        return {"ok": True, "data": result}
+    except Exception as e:
+        logger.error("{{ENDPOINT_PATH}} failed: %s", e)
+        return {"ok": False, "error": str(e)}
+```
+
+### Adım 4: Config Güncelle (Gerekirse)
+
+Eğer yeni parametreler gerekiyorsa:
+
+```yaml
+# modules/{{MODULE_NAME}}/config/config.yml
+# Mevcut ayarların altına ekle:
+<yeni_alan>:
+  enabled: true
+  default_value: <değer>
+```
+
+### Adım 5: Test Ekle
+
+```python
+# modules/{{MODULE_NAME}}/tests/test_smoke.py içine ekle
+
+def test_{{endpoint_function_name}}_router():
+    """{{ENDPOINT_PATH}} endpoint'i mevcut mu?"""
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    router = get_router()
+    paths = [r.path for r in router.routes]
+    assert "{{ENDPOINT_PATH}}" in paths or any("{{ENDPOINT_PATH}}" in str(p) for p in paths)
+```
+
+### Adım 6: Dokümantasyon Güncelle
+
+1. `README.md` endpoint tablosuna yeni endpoint'i ekle
+2. `architecture_{{MODULE_NAME}}.md` dosyasını güncelle
+3. `.sentrybot/context/api-surface.md` dosyasını güncelle
+
+## Kontrol Listesi
+
+- [ ] Mevcut endpoint naming convention'a uyuyor
+- [ ] Service fonksiyonu tek sorumluluk taşıyor
+- [ ] Hata yakalama (try/except) var
+- [ ] Config değeri hardcode değil
+- [ ] Test yazıldı
+- [ ] Dokümantasyon güncellendi

--- a/.sentrybot/skills/add-service-class.md
+++ b/.sentrybot/skills/add-service-class.md
@@ -1,0 +1,104 @@
+# Skill: Add Service Class — Yeni Service Sınıfı Ekleme
+
+> Mevcut bir modüle yeni iş mantığı sınıfı ekleme prosedürü.
+
+## Girdiler
+
+| Parametre | Zorunlu | Açıklama | Örnek |
+|-----------|---------|----------|-------|
+| `MODULE_NAME` | ✅ | Hedef modül | `vlm_bridge` |
+| `CLASS_NAME` | ✅ | Sınıf adı (PascalCase) | `DepthEstimator` |
+| `RESPONSIBILITY` | ✅ | Tek cümle sorumluluk | `Derinlik haritası tahmini` |
+
+## Prosedür
+
+### Adım 1: Mevcut Servisleri İncele
+```bash
+ls modules/{{MODULE_NAME}}/services/
+cat modules/{{MODULE_NAME}}/services/__init__.py
+```
+
+### Adım 2: Yeni Service Dosyası Oluştur
+
+```python
+# modules/{{MODULE_NAME}}/services/{{class_name_snake}}.py
+from __future__ import annotations
+import logging
+
+logger = logging.getLogger("{{MODULE_NAME}}.{{class_name_snake}}")
+
+
+class {{CLASS_NAME}}:
+    """{{RESPONSIBILITY}}"""
+
+    def __init__(self, cfg: dict | None = None):
+        self.cfg = cfg or {}
+        self._initialized = False
+        logger.info("{{CLASS_NAME}} created")
+
+    def initialize(self) -> None:
+        """Gecikmeli başlatma (lazy init)."""
+        if self._initialized:
+            return
+        # Başlatma mantığı
+        self._initialized = True
+        logger.info("{{CLASS_NAME}} initialized")
+
+    def shutdown(self) -> None:
+        """Kaynakları temizle."""
+        self._initialized = False
+        logger.info("{{CLASS_NAME}} shut down")
+```
+
+### Adım 3: `__init__.py`'ye Re-export Ekle
+
+```python
+# modules/{{MODULE_NAME}}/services/__init__.py
+from .{{class_name_snake}} import {{CLASS_NAME}}  # noqa: F401
+```
+
+### Adım 4: x<Name>Service.py'den Başlat
+
+```python
+# x<Name>Service.py içinde __init__'e ekle:
+from .services.{{class_name_snake}} import {{CLASS_NAME}}
+
+class ...Service:
+    def __init__(self, cfg=None):
+        ...
+        self.{{class_name_snake}} = {{CLASS_NAME}}(self.cfg.get("{{class_name_snake}}", {}))
+```
+
+### Adım 5: Test Yaz
+
+```python
+# modules/{{MODULE_NAME}}/tests/test_{{class_name_snake}}.py
+def test_{{class_name_snake}}_init():
+    from modules.{{MODULE_NAME}}.services.{{class_name_snake}} import {{CLASS_NAME}}
+    instance = {{CLASS_NAME}}(cfg={})
+    assert instance is not None
+    assert not instance._initialized
+
+def test_{{class_name_snake}}_initialize():
+    from modules.{{MODULE_NAME}}.services.{{class_name_snake}} import {{CLASS_NAME}}
+    instance = {{CLASS_NAME}}(cfg={})
+    instance.initialize()
+    assert instance._initialized
+
+def test_{{class_name_snake}}_shutdown():
+    from modules.{{MODULE_NAME}}.services.{{class_name_snake}} import {{CLASS_NAME}}
+    instance = {{CLASS_NAME}}(cfg={})
+    instance.initialize()
+    instance.shutdown()
+    assert not instance._initialized
+```
+
+## Kontrol Listesi
+
+- [ ] Sınıf tek sorumluluk taşıyor
+- [ ] Config'den okuma yapıyor (hardcode yok)
+- [ ] Lazy init destekliyor (gerekirse)
+- [ ] Shutdown/cleanup metodu var
+- [ ] `__init__.py`'ye re-export eklendi
+- [ ] Test yazıldı
+- [ ] Architecture doc güncellendi

--- a/.sentrybot/skills/arduino-contract.md
+++ b/.sentrybot/skills/arduino-contract.md
@@ -1,0 +1,64 @@
+# Skill: Arduino Contract — Arduino Kontrat Builder Ekleme
+
+> Arduino komut builder ve validator fonksiyonu ekleme prosedürü.
+
+## Tek Kaynak
+Tüm Arduino komutlarının tek kaynağı: `modules/arduino_serial/contract.py`
+
+## Mevcut Builder Örnekleri İncele
+```bash
+cat modules/arduino_serial/contract.py
+```
+Mevcut `build_*` ve `validate_*` fonksiyonlarının kalıbını incele.
+
+## Yeni Komut Ekleme
+
+### Adım 1: Builder Fonksiyonu
+```python
+# modules/arduino_serial/contract.py içine ekle:
+
+def build_{{command_name}}({{parametreler}}) -> dict:
+    """{{Komut açıklaması}}."""
+    payload = {
+        "cmd": "{{command_name}}",
+        {{alanlar}}
+    }
+    validate_{{command_name}}(payload)
+    return payload
+```
+
+### Adım 2: Validator Fonksiyonu
+```python
+def validate_{{command_name}}(payload: dict) -> None:
+    """{{command_name}} payload doğrulama."""
+    assert payload.get("cmd") == "{{command_name}}"
+    # Alan doğrulamaları
+    {{doğrulama_kuralları}}
+```
+
+### Adım 3: Test Yaz (Zorunlu)
+```python
+# modules/arduino_serial/tests/ içine:
+def test_build_{{command_name}}():
+    from modules.arduino_serial.contract import build_{{command_name}}
+    payload = build_{{command_name}}({{test_parametreleri}})
+    assert payload["cmd"] == "{{command_name}}"
+
+def test_validate_{{command_name}}_invalid():
+    from modules.arduino_serial.contract import validate_{{command_name}}
+    import pytest
+    with pytest.raises(AssertionError):
+        validate_{{command_name}}({"cmd": "wrong"})
+```
+
+### Adım 4: Gateway Davranış Testi
+`/arduino/request` endpoint'inin yeni komutu doğru işlediğini test et.
+
+## Zorunlu PR Kontrol Listesi
+- [ ] `contract.py`'ye builder eklendi
+- [ ] `contract.py`'ye validator eklendi
+- [ ] Validator unit testi yazıldı
+- [ ] Gateway davranış testi yazıldı
+- [ ] Kritik komutsa `/arduino/request` kullanılıyor (fire-and-forget değil)
+- [ ] Timeout 0.8-1.5s arasında
+- [ ] PR açıklamasında kontrat uyumu belirtildi

--- a/.sentrybot/skills/create-issue.md
+++ b/.sentrybot/skills/create-issue.md
@@ -1,0 +1,61 @@
+# Skill: Create Issue — Issue Oluşturma
+
+> GitHub Issue standartlarına uygun bug report ve feature request oluşturma.
+
+## Bug Report
+
+`.github/ISSUE_TEMPLATE/bug_report.yml` formatına uygun:
+
+```markdown
+**Açıklama:** <Hatanın kısa açıklaması>
+
+**Beklenen davranış:** <Ne olması gerekiyordu>
+
+**Gerçekleşen davranış:** <Ne oldu>
+
+**Tekrar adımları:**
+1. <Adım 1>
+2. <Adım 2>
+3. <Adım 3>
+
+**Ortam:**
+- Platform: Raspberry Pi 5
+- Python: 3.10
+- OS: <Raspbian/Ubuntu>
+- Etkilenen modül: <modül adı>
+
+**Log çıktısı:**
+\```
+<ilgili log satırları>
+\```
+
+**Ekran görüntüsü:** (varsa)
+```
+
+## Feature Request
+
+`.github/ISSUE_TEMPLATE/feature_request.yml` formatına uygun:
+
+```markdown
+**Motivasyon:** <Neden bu özellik gerekli>
+
+**Kullanım senaryosu:** <Nasıl kullanılacak>
+
+**Önerilen çözüm:** <Teknik yaklaşım>
+
+**Alternatifler:** <Düşünülen diğer yollar>
+
+**Etkilenecek modüller:** <modül listesi>
+
+**Ek bilgi:** (varsa)
+```
+
+## Label Önerisi
+
+| Durum | Label |
+|-------|-------|
+| Bug | `bug` |
+| Feature | `enhancement` |
+| Acil | `priority:high` |
+| Dokümantasyon | `documentation` |
+| Arduino ile ilgili | `hardware:arduino` |

--- a/.sentrybot/skills/create-pr.md
+++ b/.sentrybot/skills/create-pr.md
@@ -1,0 +1,81 @@
+# Skill: Create PR — Pull Request Oluşturma
+
+> SentryBOT PR standartlarına uygun Pull Request hazırlama prosedürü.
+
+## Branch Adlandırma
+
+| Tür | Format | Örnek |
+|-----|--------|-------|
+| Yeni özellik | `feat/<modül>-<açıklama>` | `feat/speech-multi-language` |
+| Hata düzeltme | `fix/<modül>-<açıklama>` | `fix/vlm-tracker-crash` |
+| Refactor | `refactor/<modül>-<açıklama>` | `refactor/autonomy-mood-engine` |
+| Dokümantasyon | `docs/<açıklama>` | `docs/update-architecture` |
+
+## PR Şablonu
+
+`.github/pull_request_template.md` doldurulur:
+
+```markdown
+## Özet
+Ne değişti ve neden değişti?
+<Kısa açıklama>
+
+## Değişiklik tipi
+- [ ] Hata düzeltmesi
+- [ ] Yeni özellik
+- [ ] Refactor
+- [ ] Dokümantasyon güncellemesi
+- [ ] Test güncellemesi
+
+## Etkilenen modüller
+<modules/x, modules/y>
+
+## Doğrulama
+- [ ] Lokal çalıştırma tamamlandı
+- [ ] İlgili testler geçiyor
+- [ ] Gerekli doküman/konfig güncellemeleri yapıldı
+
+## Arduino Kontrat Kontrolü (uygunsa)
+- [ ] `contract.py` dışında elle Arduino payload yazılmadı
+- [ ] Kritik komutlar `/arduino/request` kullanıyor
+- [ ] Yeni komut ailesi builder + validator + test içeriyor
+
+## Risk ve geri alma
+<Açıklama>
+
+## İlgili issue
+Closes #<issue-number>
+```
+
+## Label Atama
+
+Değiştirilen dosya yollarına göre otomatik label ata (`.github/labeler.yml` kuralları).
+
+## Git Komutları
+
+```bash
+# Branch oluştur
+git checkout -b feat/{{module}}-{{description}}
+
+# Değişiklikleri ekle
+git add modules/{{module}}/ .sentrybot/ docs/
+
+# Commit (açıklayıcı mesaj)
+git commit -m "feat({{module}}): {{kısa açıklama}}"
+
+# Push
+git push origin feat/{{module}}-{{description}}
+```
+
+## Commit Mesajı Formatı
+
+```
+<tür>(<kapsam>): <açıklama>
+
+Örnekler:
+feat(speech): add multi-language ASR support
+fix(vlm): fix CSRT tracker crash on lost face
+refactor(autonomy): extract mood engine to separate class
+docs(architecture): update inter-module diagram
+test(neopixel): add emotion palette unit tests
+```

--- a/.sentrybot/skills/debug-module.md
+++ b/.sentrybot/skills/debug-module.md
@@ -1,0 +1,59 @@
+# Skill: Debug Module — Modül Debugging
+
+> SentryBOT modüllerinde hata ayıklama prosedürü.
+
+## Hızlı Teşhis
+
+### 1. Modül Sağlık Kontrolü
+```bash
+# Modül import edilebilir mi?
+python -c "from modules.{{MODULE_NAME}} import *; print('OK')"
+
+# Config yüklenebilir mi?
+python -c "from modules.{{MODULE_NAME}}.config_loader import load_config; print(load_config())"
+
+# Testler geçiyor mu?
+python -m pytest modules/{{MODULE_NAME}}/tests/ -v --maxfail=1
+```
+
+### 2. Log Analizi
+```bash
+# Son logları incele
+grep -i "error\|warning\|exception" logs/ --include="*.log" | grep {{MODULE_NAME}}
+```
+
+### 3. API Sağlık Kontrolü
+```bash
+# Gateway üzerinden durum kontrolü
+curl http://localhost:8080/{{MODULE_NAME}}/status
+curl http://localhost:8080/{{MODULE_NAME}}/healthz
+
+# Genel sistem durumu
+curl http://localhost:8080/status
+```
+
+### 4. Diagnostics Modülü
+```bash
+# Otomatik sistem testi
+curl -X POST http://localhost:8080/diagnostics/self_test
+```
+
+## Yaygın Sorunlar
+
+| Sorun | Olası Neden | Çözüm |
+|-------|-------------|-------|
+| Import hatası | Eksik bağımlılık | `pip install -r modules/{{MODULE_NAME}}/requirements.txt` |
+| Config hatası | YAML syntax | Config dosyasını YAML linter ile kontrol et |
+| API 404 | Gateway'e kayıtlı değil | `gateway-bootstrap` skill'ini uygula |
+| Arduino timeout | Seri bağlantı kopuk | `diagnostics/self_test` çalıştır |
+| Modül çökmesi | Exception yakalanmamış | try/except ekle, log incele |
+
+## İzole Test
+```python
+# Modülü izole çalıştırma
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from modules.{{MODULE_NAME}}.x{{SERVICE_NAME}}Service import {{SERVICE_NAME}}Service
+svc = {{SERVICE_NAME}}Service(cfg={})
+svc.start()
+```

--- a/.sentrybot/skills/gateway-bootstrap.md
+++ b/.sentrybot/skills/gateway-bootstrap.md
@@ -1,0 +1,50 @@
+# Skill: Gateway Bootstrap — Gateway'e Modül Kaydı
+
+> Yeni bir modülü Gateway bootstrap sistemine kaydetme prosedürü.
+
+## Dosyalar
+
+### 1. `modules/gateway/services/bootstrap.py`'ye Ekleme
+
+Mevcut bootstrap fonksiyonlarını incele, ardından yeni modül için ekle:
+
+```python
+def _include_{{MODULE_NAME}}(app, cfg: dict) -> dict:
+    """{{MODULE_NAME}} modülünü başlat ve mount et."""
+    try:
+        from modules.{{MODULE_NAME}}.x{{SERVICE_NAME}}Service import _include_{{MODULE_NAME}} as mount
+        return mount(app, cfg)
+    except Exception as exc:
+        logger.warning("{{MODULE_NAME}} module failed: %s", exc)
+        return {}
+```
+
+Bootstrap sırası: `.sentrybot/agents/inter-module.md` dosyasındaki sıraya uy.
+
+### 2. Gateway Config'e Ekleme
+
+```yaml
+# modules/gateway/config/config.yml
+include:
+  # ...mevcut modüller...
+  {{MODULE_NAME}}: true
+```
+
+### 3. Bootstrap Ana Fonksiyonuna Çağrı Ekleme
+
+`bootstrap(app, cfg)` fonksiyonunda `include.{{MODULE_NAME}}` kontrolü ekle:
+
+```python
+if inc.get("{{MODULE_NAME}}", False):
+    try:
+        result = _include_{{MODULE_NAME}}(app, cfg)
+        started.update(result)
+    except Exception as exc:
+        logger.warning("{{MODULE_NAME}} failed: %s", exc)
+```
+
+## Kontrol Listesi
+- [ ] `bootstrap.py`'ye `_include_{{MODULE_NAME}}` fonksiyonu eklendi
+- [ ] `config.yml`'ye `include.{{MODULE_NAME}}: true` eklendi
+- [ ] Bootstrap sırası korunuyor (bağımlılıklar önce yükleniyor)
+- [ ] Modül başarısızsa warning loglanıyor (diğer modüller etkilenmiyor)

--- a/.sentrybot/skills/module-dependency-map.md
+++ b/.sentrybot/skills/module-dependency-map.md
@@ -1,0 +1,47 @@
+# Skill: Module Dependency Map — Modül Bağımlılık Haritalama
+
+> Modüller arası bağımlılıkları analiz etme ve haritalama prosedürü.
+
+## Analiz Prosedürü
+
+### Adım 1: Import Taraması
+```bash
+# Modülün hangi diğer modülleri import ettiğini bul
+grep -r "from modules\." modules/{{MODULE_NAME}}/ --include="*.py" | grep -v __pycache__
+grep -r "import modules\." modules/{{MODULE_NAME}}/ --include="*.py" | grep -v __pycache__
+```
+
+### Adım 2: HTTP Çağrı Taraması
+```bash
+# Modülün hangi endpoint'leri çağırdığını bul
+grep -rn "localhost:8080\|/arduino/\|/speak/\|/neopixel/\|/ollama/\|/vlm/\|/state/" \
+  modules/{{MODULE_NAME}}/ --include="*.py" | grep -v __pycache__
+```
+
+### Adım 3: Config Bağımlılık Taraması
+```bash
+# Config'de referans verilen URL'leri bul
+grep -n "endpoint\|url\|host\|port" modules/{{MODULE_NAME}}/config/config.yml
+```
+
+### Adım 4: Bağımlılık Diyagramı Oluştur
+
+```mermaid
+graph LR
+    {{MODULE_NAME}} --> |HTTP| modül_a
+    {{MODULE_NAME}} --> |Serial| modül_b
+    modül_c --> |HTTP| {{MODULE_NAME}}
+```
+
+## Bağımlılık Türleri
+
+| Tür | Açıklama | Örnek |
+|-----|----------|-------|
+| **Doğrudan** | Import ile | `from modules.x import Y` |
+| **HTTP** | API çağrısı ile | `POST /speak/say` |
+| **Serial** | Arduino kontratı ile | `contract.build_set_servo()` |
+| **Config** | Config referansı ile | `endpoint: http://localhost:8080/x` |
+| **Event** | Olay bildirimi ile | `POST /interactions/event` |
+
+## Çıktı Formatı
+Bağımlılık haritası `.sentrybot/context/module-registry.md`'deki "Kilit Bağımlılıklar" sütununa yansıtılır.

--- a/.sentrybot/skills/scaffold-module.md
+++ b/.sentrybot/skills/scaffold-module.md
@@ -1,0 +1,274 @@
+# Skill: Scaffold Module — Sıfırdan Modül İskeleti Oluşturma
+
+> Bu skill, SentryBOT modül yapı kurallarına uygun bir iskelet oluşturur.
+
+## Girdiler
+
+| Parametre | Zorunlu | Açıklama | Örnek |
+|-----------|---------|----------|-------|
+| `MODULE_NAME` | ✅ | Modül adı (snake_case) | `ultrasonic_sensor` |
+| `SERVICE_NAME` | ✅ | Servis sınıf adı (PascalCase) | `UltrasonicSensor` |
+| `PORT` | ❌ | Standalone port (varsa) | `8104` |
+| `DESCRIPTION` | ✅ | Kısa modül açıklaması | `Ultrasonik mesafe sensörü okuma` |
+| `LAYER` | ✅ | Mimari katman | `Algı / Beyin / AI / Eylem / Arka Plan` |
+
+## Oluşturulacak Dosyalar
+
+### 1. `modules/{{MODULE_NAME}}/__init__.py`
+
+```python
+"""{{DESCRIPTION}}"""
+from .x{{SERVICE_NAME}}Service import {{SERVICE_NAME}}Service  # noqa: F401
+
+__all__ = ["{{SERVICE_NAME}}Service"]
+```
+
+### 2. `modules/{{MODULE_NAME}}/x{{SERVICE_NAME}}Service.py`
+
+```python
+from __future__ import annotations
+"""
+{{SERVICE_NAME}} Service — {{DESCRIPTION}}
+"""
+import logging
+from .config_loader import load_config
+
+logger = logging.getLogger("{{MODULE_NAME}}.service")
+
+
+class {{SERVICE_NAME}}Service:
+    """{{DESCRIPTION}}"""
+
+    def __init__(self, cfg: dict | None = None):
+        self.cfg = cfg or load_config()
+        logger.info("{{SERVICE_NAME}}Service initialized")
+
+    def start(self):
+        """Servisi başlat."""
+        logger.info("{{SERVICE_NAME}}Service starting")
+
+    def stop(self):
+        """Servisi durdur."""
+        logger.info("{{SERVICE_NAME}}Service stopping")
+
+
+def _include_{{MODULE_NAME}}(app, cfg: dict) -> dict:
+    """Gateway bootstrap entegrasyon fonksiyonu."""
+    from .api.router import get_router
+    svc = {{SERVICE_NAME}}Service(cfg.get("{{MODULE_NAME}}", {}))
+    app.include_router(get_router(svc), prefix="/{{MODULE_NAME}}", tags=["{{MODULE_NAME}}"])
+    return {"{{MODULE_NAME}}": svc}
+```
+
+### 3. `modules/{{MODULE_NAME}}/config_loader.py`
+
+```python
+from __future__ import annotations
+import os
+import yaml
+import logging
+
+logger = logging.getLogger("{{MODULE_NAME}}.config")
+
+_DEFAULT_PATH = os.path.join(os.path.dirname(__file__), "config", "config.yml")
+
+
+def load_config(path: str | None = None) -> dict:
+    """{{MODULE_NAME}} config dosyasını yükle."""
+    cfg_path = path or os.environ.get("{{MODULE_NAME.upper()}}_CONFIG", _DEFAULT_PATH)
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        logger.warning("Config not found at %s, using defaults", cfg_path)
+        cfg = {}
+    return cfg
+```
+
+### 4. `modules/{{MODULE_NAME}}/config/config.yml`
+
+```yaml
+# {{SERVICE_NAME}} Module Configuration
+# Açıklama: {{DESCRIPTION}}
+
+server:
+  host: 0.0.0.0
+  port: {{PORT or 0}}
+
+# Modüle özgü ayarlar buraya eklenir
+settings:
+  enabled: true
+```
+
+### 5. `modules/{{MODULE_NAME}}/api/__init__.py`
+
+```python
+"""{{SERVICE_NAME}} API endpoints."""
+```
+
+### 6. `modules/{{MODULE_NAME}}/api/router.py`
+
+```python
+from __future__ import annotations
+import logging
+from fastapi import APIRouter
+
+logger = logging.getLogger("{{MODULE_NAME}}.api")
+
+
+def get_router(svc=None) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/status")
+    async def status():
+        """Modül durum kontrolü."""
+        return {"ok": True, "module": "{{MODULE_NAME}}"}
+
+    @router.get("/healthz")
+    async def healthz():
+        """Sağlık kontrolü."""
+        return {"status": "healthy"}
+
+    return router
+```
+
+### 7. `modules/{{MODULE_NAME}}/services/__init__.py`
+
+```python
+"""{{SERVICE_NAME}} iş mantığı servisleri."""
+```
+
+### 8. `modules/{{MODULE_NAME}}/tests/test_smoke.py`
+
+```python
+"""{{MODULE_NAME}} smoke testleri."""
+import pytest
+
+
+def test_import():
+    """Modül import edilebilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    assert {{SERVICE_NAME}}Service is not None
+
+
+def test_config_loader():
+    """Config yüklenebilir mi?"""
+    from modules.{{MODULE_NAME}}.config_loader import load_config
+    cfg = load_config()
+    assert isinstance(cfg, dict)
+
+
+def test_service_instantiation():
+    """Service oluşturulabilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    svc = {{SERVICE_NAME}}Service(cfg={})
+    assert svc is not None
+
+
+def test_router():
+    """Router oluşturulabilir mi?"""
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    router = get_router()
+    assert router is not None
+    paths = [r.path for r in router.routes]
+    assert "/status" in paths or any("/status" in str(p) for p in paths)
+```
+
+### 9. `modules/{{MODULE_NAME}}/architecture_{{MODULE_NAME}}.md`
+
+```markdown
+# {{SERVICE_NAME}} — Mimari Dokümantasyon
+
+## Genel Bakış
+
+{{DESCRIPTION}}
+
+## Modül Yapısı
+
+\```
+modules/{{MODULE_NAME}}/
+├── __init__.py
+├── x{{SERVICE_NAME}}Service.py
+├── config_loader.py
+├── config/
+│   └── config.yml
+├── api/
+│   ├── __init__.py
+│   └── router.py
+├── services/
+│   └── __init__.py
+├── tests/
+│   └── test_smoke.py
+├── architecture_{{MODULE_NAME}}.md
+└── README.md
+\```
+
+## Veri Akışı
+
+\```mermaid
+flowchart TD
+    API[API İsteği] --> SVC[{{SERVICE_NAME}}Service]
+    SVC --> CFG[Config Loader]
+    SVC --> BL[İş Mantığı]
+    BL --> RES[Yanıt]
+\```
+
+## Modüller Arası Etkileşim
+
+| Modül | İlişki |
+|---|---|
+| `gateway` | Bootstrap ile mount edilir |
+
+## Tasarım Kararları
+
+- DryCode prensiplerine uygun yapılandırılmıştır.
+- Config değerleri hardcode edilmez, config.yml üzerinden okunur.
+```
+
+### 10. `modules/{{MODULE_NAME}}/README.md`
+
+```markdown
+# {{SERVICE_NAME}} Module
+
+**{{DESCRIPTION}}**
+
+## Katman
+{{LAYER}}
+
+## Kullanım
+
+### Kütüphane olarak
+\```python
+from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+svc = {{SERVICE_NAME}}Service()
+svc.start()
+\```
+
+### Servis olarak
+Gateway bootstrap ile otomatik başlatılır.
+
+## API Endpoint'leri
+
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/{{MODULE_NAME}}/status` | GET | Modül durumu |
+| `/{{MODULE_NAME}}/healthz` | GET | Sağlık kontrolü |
+
+## Konfigürasyon
+
+| Ayar | Varsayılan | Açıklama |
+|------|-----------|----------|
+| `settings.enabled` | `true` | Modül etkin mi |
+
+## Testler
+\```bash
+python -m pytest modules/{{MODULE_NAME}}/tests/ -v
+\```
+```
+
+## İşlem Sonrası
+
+1. ✅ Tüm dosyaların oluşturulduğunu doğrula
+2. ✅ `python -c "from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service"` çalıştır
+3. ✅ `python -m pytest modules/{{MODULE_NAME}}/tests/ -v` çalıştır
+4. ➡️ Gateway bootstrap'a kayıt için `gateway-bootstrap` skill'ine geç

--- a/.sentrybot/skills/update-config.md
+++ b/.sentrybot/skills/update-config.md
@@ -1,0 +1,43 @@
+# Skill: Update Config — Config Güncelleme
+
+> Modül config dosyasını ve config_loader'ı güncelleme prosedürü.
+
+## Prosedür
+
+### Adım 1: Mevcut Config'i Oku
+```bash
+cat modules/{{MODULE_NAME}}/config/config.yml
+cat modules/{{MODULE_NAME}}/config_loader.py
+```
+
+### Adım 2: Yeni Alan Ekle (config.yml)
+```yaml
+# Mevcut ayarların altına ekle:
+{{yeni_alan}}:
+  {{alt_alan}}: {{varsayılan_değer}}
+```
+
+### Adım 3: Config Loader'ı Güncelle
+`config_loader.py`'de yeni alanı okuyacak kodu ekle. Varsayılan değer atama kalıbı:
+```python
+cfg.setdefault("{{yeni_alan}}", {}).setdefault("{{alt_alan}}", {{varsayılan}})
+```
+
+### Adım 4: Merkezi Config Etkisi (Gerekirse)
+Eğer bu ayar `config/agent.yaml`'ı da etkiliyorsa güncelle.
+
+### Adım 5: README Config Tablosunu Güncelle
+`README.md`'deki konfigürasyon tablosuna yeni alanı ekle.
+
+### Adım 6: Test
+```python
+def test_config_new_field():
+    from modules.{{MODULE_NAME}}.config_loader import load_config
+    cfg = load_config()
+    assert "{{yeni_alan}}" in cfg or True  # varsayılan atanmalı
+```
+
+## Kurallar
+- Config değerleri kodda hardcode edilmez
+- Varsayılan değer mutlaka atanır (KeyError'dan kaçın)
+- Yeni zorunlu alan eklendiğinde geriye uyumluluk korunur

--- a/.sentrybot/skills/write-architecture-doc.md
+++ b/.sentrybot/skills/write-architecture-doc.md
@@ -1,0 +1,59 @@
+# Skill: Write Architecture Doc — Mimari Dokümantasyon Yazma
+
+> `architecture_<module_name>.md` dosyası yazma formatı ve kuralları.
+
+## Şablon
+
+```markdown
+# <ModuleName> — Mimari Dokümantasyon
+
+## Genel Bakış
+Modülün tek cümlelik açıklaması ve görevi.
+
+## Modül Yapısı
+\```
+modules/<module_name>/
+├── __init__.py
+├── x<Name>Service.py
+├── config_loader.py
+├── config/
+│   └── config.yml
+├── api/
+│   └── router.py
+├── services/
+│   └── <servis_dosyaları>.py
+├── tests/
+│   └── test_smoke.py
+├── architecture_<module_name>.md
+└── README.md
+\```
+
+## Veri Akışı
+\```mermaid
+flowchart TD
+    A[Giriş] --> B{Karar noktası}
+    B -- Koşul 1 --> C[İşlem 1]
+    B -- Koşul 2 --> D[İşlem 2]
+    C --> E[Çıkış]
+    D --> E
+\```
+
+## Modüller Arası Etkileşim
+| Modül | Bu Modül ile İlişkisi |
+|---|---|
+| `gateway` | Bootstrap ile mount eder |
+| `<diğer>` | <ilişki açıklaması> |
+
+## Tasarım Kararları
+### Neden X yerine Y?
+Kararın gerekçesi, trade-off'lar.
+
+### Genişletilebilirlik
+Modülün nasıl genişletilebileceği veya değiştirilebileceği.
+```
+
+## Kurallar
+- Mermaid diyagramı zorunlu (en az bir flowchart)
+- Modüller arası etkileşim tablosu zorunlu
+- En az bir tasarım kararı belgelenecek
+- Türkçe yazılabilir (mevcut convention)

--- a/.sentrybot/skills/write-tests.md
+++ b/.sentrybot/skills/write-tests.md
@@ -1,0 +1,110 @@
+# Skill: Write Tests — Test Yazma
+
+> SentryBOT modülleri için test yazma kuralları ve kalıpları.
+
+## Test Türleri
+
+### 1. Smoke Test (Zorunlu)
+Her modülde `tests/test_smoke.py` olmalı:
+```python
+"""{{MODULE_NAME}} smoke testleri — temel sağlık kontrolü."""
+
+def test_import():
+    """Modül import edilebilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    assert {{SERVICE_NAME}}Service is not None
+
+def test_config_loader():
+    """Config yüklenebilir mi?"""
+    from modules.{{MODULE_NAME}}.config_loader import load_config
+    cfg = load_config()
+    assert isinstance(cfg, dict)
+
+def test_service_init():
+    """Service boş config ile oluşturulabilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    svc = {{SERVICE_NAME}}Service(cfg={})
+    assert svc is not None
+
+def test_router_creation():
+    """API router oluşturulabilir mi?"""
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    router = get_router()
+    assert router is not None
+```
+
+### 2. Unit Test
+Tek bir fonksiyonu/sınıfı izole test etme:
+```python
+"""{{MODULE_NAME}} unit testleri."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+def test_specific_function():
+    from modules.{{MODULE_NAME}}.services.some_service import SomeClass
+    obj = SomeClass(cfg={"key": "value"})
+    result = obj.do_something(input_data)
+    assert result == expected_output
+
+def test_error_handling():
+    from modules.{{MODULE_NAME}}.services.some_service import SomeClass
+    obj = SomeClass(cfg={})
+    with pytest.raises(ValueError):
+        obj.do_something(invalid_input)
+```
+
+### 3. API Test (FastAPI TestClient)
+```python
+"""{{MODULE_NAME}} API testleri."""
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+def test_status_endpoint():
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    app = FastAPI()
+    app.include_router(get_router(), prefix="/{{MODULE_NAME}}")
+    client = TestClient(app)
+    resp = client.get("/{{MODULE_NAME}}/status")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+```
+
+### 4. Mock Kalıpları
+```python
+# Donanım bağımlılığını mock'la
+@patch("modules.{{MODULE_NAME}}.services.hw.RPi.GPIO", create=True)
+def test_hardware_function(mock_gpio):
+    mock_gpio.input.return_value = 1
+    # ...test...
+
+# HTTP çağrısını mock'la
+@patch("httpx.AsyncClient.post")
+async def test_service_client(mock_post):
+    mock_post.return_value = MagicMock(status_code=200, json=lambda: {"ok": True})
+    # ...test...
+
+# Arduino serial'ı mock'la
+@patch("modules.arduino_serial.xArduinoSerialService.ArduinoSerialService")
+def test_arduino_command(mock_serial):
+    mock_serial.request_cmd.return_value = {"ok": True}
+    # ...test...
+```
+
+## CI Kuralları
+- Python 3.10 hedef
+- `webrtcvad`, `sounddevice`, `soundfile` CI'da uninstall edilir
+- Donanım gerektiren testler `@pytest.mark.skipif` ile korunur
+- Timeout: collection 420s, test suite 1800s
+- `--maxfail=1` ile ilk hatada durur
+
+## Çalıştırma
+```bash
+# Tek modül
+python -m pytest modules/{{MODULE_NAME}}/tests/ -v
+
+# Tüm modüller
+python -m pytest modules/ -q --maxfail=1
+
+# Sadece collection kontrolü
+python -m pytest --collect-only modules/{{MODULE_NAME}}/tests/ -vv
+```

--- a/.sentrybot/templates/issue-body.md.tmpl
+++ b/.sentrybot/templates/issue-body.md.tmpl
@@ -1,0 +1,12 @@
+## {{ISSUE_TYPE}}: {{TITLE}}
+
+**Açıklama:** {{DESCRIPTION}}
+
+**Etkilenecek modüller:** {{MODULES}}
+
+**Ortam:**
+- Platform: Raspberry Pi 5
+- Python: 3.10
+- OS: {{OS}}
+
+**Ek bilgi:** {{EXTRA}}

--- a/.sentrybot/templates/module/README.md.tmpl
+++ b/.sentrybot/templates/module/README.md.tmpl
@@ -1,0 +1,36 @@
+# {{SERVICE_NAME}} Module
+
+**{{DESCRIPTION}}**
+
+## Katman
+{{LAYER}}
+
+## Kullanım
+
+### Kütüphane olarak
+```python
+from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+svc = {{SERVICE_NAME}}Service()
+svc.start()
+```
+
+### Servis olarak
+Gateway bootstrap ile otomatik başlatılır.
+
+## API Endpoint'leri
+
+| Endpoint | Metod | Açıklama |
+|----------|-------|----------|
+| `/{{MODULE_NAME}}/status` | GET | Modül durumu |
+| `/{{MODULE_NAME}}/healthz` | GET | Sağlık kontrolü |
+
+## Konfigürasyon
+
+| Ayar | Varsayılan | Açıklama |
+|------|-----------|----------|
+| `settings.enabled` | `true` | Modül etkin mi |
+
+## Testler
+```bash
+python -m pytest modules/{{MODULE_NAME}}/tests/ -v
+```

--- a/.sentrybot/templates/module/__init__.py.tmpl
+++ b/.sentrybot/templates/module/__init__.py.tmpl
@@ -1,0 +1,4 @@
+"""{{DESCRIPTION}}"""
+from .x{{SERVICE_NAME}}Service import {{SERVICE_NAME}}Service  # noqa: F401
+
+__all__ = ["{{SERVICE_NAME}}Service"]

--- a/.sentrybot/templates/module/architecture.md.tmpl
+++ b/.sentrybot/templates/module/architecture.md.tmpl
@@ -1,0 +1,46 @@
+# {{SERVICE_NAME}} — Mimari Dokümantasyon
+
+## Genel Bakış
+
+{{DESCRIPTION}}
+
+## Modül Yapısı
+
+```
+modules/{{MODULE_NAME}}/
+├── __init__.py
+├── x{{SERVICE_NAME}}Service.py
+├── config_loader.py
+├── config/
+│   └── config.yml
+├── api/
+│   ├── __init__.py
+│   └── router.py
+├── services/
+│   └── __init__.py
+├── tests/
+│   └── test_smoke.py
+├── architecture_{{MODULE_NAME}}.md
+└── README.md
+```
+
+## Veri Akışı
+
+```mermaid
+flowchart TD
+    API[API İsteği] --> SVC[{{SERVICE_NAME}}Service]
+    SVC --> CFG[Config Loader]
+    SVC --> BL[İş Mantığı]
+    BL --> RES[Yanıt]
+```
+
+## Modüller Arası Etkileşim
+
+| Modül | İlişki |
+|---|---|
+| `gateway` | Bootstrap ile mount edilir |
+
+## Tasarım Kararları
+
+- DryCode prensiplerine uygun yapılandırılmıştır.
+- Config değerleri hardcode edilmez, config.yml üzerinden okunur.

--- a/.sentrybot/templates/module/config.yml.tmpl
+++ b/.sentrybot/templates/module/config.yml.tmpl
@@ -1,0 +1,9 @@
+# {{SERVICE_NAME}} Module Configuration
+# Açıklama: {{DESCRIPTION}}
+
+server:
+  host: 0.0.0.0
+  port: {{PORT}}
+
+settings:
+  enabled: true

--- a/.sentrybot/templates/module/config_loader.py.tmpl
+++ b/.sentrybot/templates/module/config_loader.py.tmpl
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import os
+import yaml
+import logging
+
+logger = logging.getLogger("{{MODULE_NAME}}.config")
+
+_DEFAULT_PATH = os.path.join(os.path.dirname(__file__), "config", "config.yml")
+
+
+def load_config(path: str | None = None) -> dict:
+    """{{MODULE_NAME}} config dosyasını yükle."""
+    cfg_path = path or os.environ.get("{{MODULE_NAME_UPPER}}_CONFIG", _DEFAULT_PATH)
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        logger.warning("Config not found at %s, using defaults", cfg_path)
+        cfg = {}
+    return cfg

--- a/.sentrybot/templates/module/router.py.tmpl
+++ b/.sentrybot/templates/module/router.py.tmpl
@@ -1,0 +1,21 @@
+from __future__ import annotations
+import logging
+from fastapi import APIRouter
+
+logger = logging.getLogger("{{MODULE_NAME}}.api")
+
+
+def get_router(svc=None) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/status")
+    async def status():
+        """Modül durum kontrolü."""
+        return {"ok": True, "module": "{{MODULE_NAME}}"}
+
+    @router.get("/healthz")
+    async def healthz():
+        """Sağlık kontrolü."""
+        return {"status": "healthy"}
+
+    return router

--- a/.sentrybot/templates/module/test_smoke.py.tmpl
+++ b/.sentrybot/templates/module/test_smoke.py.tmpl
@@ -1,0 +1,28 @@
+"""{{MODULE_NAME}} smoke testleri — temel sağlık kontrolü."""
+
+
+def test_import():
+    """Modül import edilebilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    assert {{SERVICE_NAME}}Service is not None
+
+
+def test_config_loader():
+    """Config yüklenebilir mi?"""
+    from modules.{{MODULE_NAME}}.config_loader import load_config
+    cfg = load_config()
+    assert isinstance(cfg, dict)
+
+
+def test_service_instantiation():
+    """Service oluşturulabilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    svc = {{SERVICE_NAME}}Service(cfg={})
+    assert svc is not None
+
+
+def test_router():
+    """Router oluşturulabilir mi?"""
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    router = get_router()
+    assert router is not None

--- a/.sentrybot/templates/module/xService.py.tmpl
+++ b/.sentrybot/templates/module/xService.py.tmpl
@@ -1,0 +1,32 @@
+from __future__ import annotations
+"""
+{{SERVICE_NAME}} Service — {{DESCRIPTION}}
+"""
+import logging
+from .config_loader import load_config
+
+logger = logging.getLogger("{{MODULE_NAME}}.service")
+
+
+class {{SERVICE_NAME}}Service:
+    """{{DESCRIPTION}}"""
+
+    def __init__(self, cfg: dict | None = None):
+        self.cfg = cfg or load_config()
+        logger.info("{{SERVICE_NAME}}Service initialized")
+
+    def start(self):
+        """Servisi başlat."""
+        logger.info("{{SERVICE_NAME}}Service starting")
+
+    def stop(self):
+        """Servisi durdur."""
+        logger.info("{{SERVICE_NAME}}Service stopping")
+
+
+def _include_{{MODULE_NAME}}(app, cfg: dict) -> dict:
+    """Gateway bootstrap entegrasyon fonksiyonu."""
+    from .api.router import get_router
+    svc = {{SERVICE_NAME}}Service(cfg.get("{{MODULE_NAME}}", {}))
+    app.include_router(get_router(svc), prefix="/{{MODULE_NAME}}", tags=["{{MODULE_NAME}}"])
+    return {"{{MODULE_NAME}}": svc}

--- a/.sentrybot/templates/pr-body.md.tmpl
+++ b/.sentrybot/templates/pr-body.md.tmpl
@@ -1,0 +1,28 @@
+## Özet
+{{SUMMARY}}
+
+## Değişiklik tipi
+- [ ] Hata düzeltmesi
+- [ ] Yeni özellik
+- [ ] Refactor
+- [ ] Dokümantasyon güncellemesi
+- [ ] Test güncellemesi
+
+## Etkilenen modüller
+{{AFFECTED_MODULES}}
+
+## Doğrulama
+- [ ] Lokal çalıştırma tamamlandı (`python run_robot.py` veya hedef modül çalıştırma)
+- [ ] İlgili testler geçiyor
+- [ ] Gerekli doküman/konfig güncellemeleri yapıldı
+
+## Arduino Kontrat Kontrolü (uygunsa)
+- [ ] `modules/arduino_serial/contract.py` dışında elle Arduino payload yazılmadı
+- [ ] Kritik komutlar gerektiğinde `/arduino/request` kullanıyor
+- [ ] Yeni komut ailesi builder + validator + test içeriyor
+
+## Risk ve geri alma
+{{RISK_DESCRIPTION}}
+
+## İlgili issue
+Closes #{{ISSUE_NUMBER}}

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,13 @@
+# SentryBOT — Windsurf Kuralları
+# Tüm detaylı agent/skill/context: .sentrybot/ dizini
+
+## Kritik Kurallar
+1. DryCode: tekrar yok, tek sorumluluk, kısa fonksiyonlar
+2. Modül yapısı: x<Name>Service.py + config_loader.py + config/config.yml + api/router.py
+3. Arduino: contract.py builder zorunlu, elle payload YASAK
+4. Config: hardcode YASAK, YAML'den oku
+5. Test: her modülde tests/test_smoke.py zorunlu
+
+## Tam Kurallar → `.sentrybot/context/conventions.md`
+## Agent'lar → `.sentrybot/agents/`
+## Skill'ler → `.sentrybot/skills/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md — AI Agent Keşif Dosyası
+
+Bu dosya, SentryBOT deposuyla çalışan tüm AI kodlama asistanlarının otomatik keşfedeceği rehber dosyasıdır.
+
+## 📁 TEK MERKEZ: `.sentrybot/`
+
+Tüm detaylı agent, skill, context ve template dosyaları **tek dizinde** toplanmıştır:
+
+```
+.sentrybot/
+├── agents/              # 5 iş akışı yöneticisi
+│   ├── module-creator.md
+│   ├── module-editor.md
+│   ├── github-ops.md
+│   ├── inter-module.md
+│   └── code-reviewer.md
+├── skills/              # 12 adım adım prosedür
+│   ├── scaffold-module.md
+│   ├── add-api-endpoint.md
+│   ├── add-service-class.md
+│   ├── update-config.md
+│   ├── write-tests.md
+│   ├── write-architecture-doc.md
+│   ├── arduino-contract.md
+│   ├── gateway-bootstrap.md
+│   ├── create-pr.md
+│   ├── create-issue.md
+│   ├── module-dependency-map.md
+│   └── debug-module.md
+├── context/             # Bilgi tabanı
+│   ├── module-registry.md       # 29 modül listesi
+│   ├── api-surface.md           # Tüm HTTP endpoint'ler
+│   ├── architecture-summary.md  # Mimari özet
+│   └── conventions.md           # Kod kuralları
+└── templates/           # Modül iskelet şablonları
+    └── module/ (8 dosya)
+```
+
+## AI Araç Yönlendirmeleri
+
+Her AI aracı kendi keşif dosyasından `.sentrybot/`'a yönlendirilir:
+
+| Araç | Keşif Dosyası | İçerik |
+|------|--------------|--------|
+| **OpenCode** | `.opencode/agents/` + `.opencode/skills/` | İnce yönlendirici → `.sentrybot/` |
+| **Claude Code** | `CLAUDE.md` | İnce yönlendirici → `.sentrybot/` |
+| **Copilot** | `.github/agents/` + `.github/copilot-instructions.md` | İnce yönlendirici → `.sentrybot/` |
+| **Cursor** | `.cursor/rules/*.mdc` | Akıllı kurallar (globs) → `.sentrybot/` |
+| **Windsurf** | `.windsurfrules` | İnce yönlendirici → `.sentrybot/` |
+| **Antigravity** | `AGENTS.md` (bu dosya) | İnce yönlendirici → `.sentrybot/` |
+
+### Global Kurulum
+
+**OpenCode:**
+```bash
+cp -r .opencode/agents/* ~/.config/opencode/agents/
+cp -r .opencode/skills/* ~/.config/opencode/skills/
+```
+
+**Claude Code:**
+```bash
+cp CLAUDE.md ~/.claude/CLAUDE.md
+```
+
+## Kritik Kurallar
+
+1. **DryCode** — Tekrar yok, sade, net
+2. **Arduino kontratı** — `contract.py` builder zorunlu
+3. **Config** — Hardcode yasak, YAML'den oku
+4. **Test** — Her modülde smoke test zorunlu
+5. **Modül yapısı** — `x<Name>Service.py` + `config_loader.py` + `api/router.py`
+
+## Hızlı Başlangıç
+
+| Görev | Oku |
+|-------|-----|
+| Yeni modül oluştur | `.sentrybot/agents/module-creator.md` → `.sentrybot/skills/scaffold-module.md` |
+| Modülü düzenle | `.sentrybot/agents/module-editor.md` → ilgili skill |
+| PR/Issue oluştur | `.sentrybot/agents/github-ops.md` → `create-pr.md` / `create-issue.md` |
+| Modüller arası bağlantı | `.sentrybot/agents/inter-module.md` → `module-dependency-map.md` |
+| Kod incele | `.sentrybot/agents/code-reviewer.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# SentryBOT — Claude Code Entegrasyonu
+
+SentryBOT, Raspberry Pi 5 üzerinde çalışan modüler bir otonom robot platformudur. 29 Python modülü, Arduino seri iletişim, OpenCV görüntü işleme ve Ollama LLM entegrasyonu içerir.
+
+## Kritik Kurallar
+1. **DryCode** — Tekrar yok, tek sorumluluk, kısa fonksiyonlar
+2. **Modül yapısı** — `x<Name>Service.py` + `config_loader.py` + `config/config.yml` + `api/router.py`
+3. **Arduino kontratı** — `modules/arduino_serial/contract.py` builder zorunlu, elle payload YASAK
+4. **Config** — Hardcode YASAK, YAML'den oku
+5. **Test** — Her modülde `tests/test_smoke.py` zorunlu
+
+## 📁 Tek Merkez: `.sentrybot/`
+
+Tüm agent, skill, context ve template dosyaları **tek dizinde** toplanmıştır:
+
+```
+.sentrybot/
+├── agents/          # 5 iş akışı yöneticisi
+├── skills/          # 12 adım adım prosedür
+├── context/         # Modül listesi, API haritası, mimari, kurallar
+└── templates/       # Modül iskelet şablonları
+```
+
+### Görev Başlarken
+1. `.sentrybot/context/module-registry.md` → 29 modül listesi
+2. `.sentrybot/context/conventions.md` → Tüm kurallar
+3. İlgili agent dosyasını oku → İş akışını takip et
+4. İlgili skill dosyalarını takip et → Adım adım uygula
+
+### Sık Kullanılan Komutlar
+```bash
+python -m pytest modules/ -q --maxfail=1       # Tüm testler
+python -m pytest modules/<mod>/tests/ -v        # Tek modül
+python run_robot.py                             # Robot başlat
+```


### PR DESCRIPTION
## Summary
- Introduces `.sentrybot/` as the single source of truth for agents, skills, context, and module templates.
- Adds thin discovery shims for Cursor, Copilot, OpenCode, Windsurf, Claude Code, and AGENTS.md.
- Split into 10 reviewable commits (hub → context → agents → skills → templates → tool shims).

## Change type
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Test update

## Affected areas
- `.sentrybot/` (new)
- `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.windsurfrules`
- `.cursor/rules/`, `.github/agents/`, `.opencode/`
- `.gitattributes` (LF normalization)

## Verification
- [x] Docs-only change; no runtime module impact
- [ ] Pytest N/A for markdown-only PR

## Commit breakdown (10)
1. Hub README + `.gitattributes`
2. Context knowledge base
3. Workflow agents (5)
4. Module scaffolding skills (4)
5. Delivery/quality skills (5)
6. Platform integration skills (3)
7. Module scaffold templates (8)
8. Issue/PR body templates
9. Cross-tool discovery entrypoints
10. Cursor / Copilot / OpenCode shims

## Risk and rollback
Low risk — documentation and AI assistant guidance only. Revert the merge commit if needed.
