### PR TITLE
fix: companion stability audit (gateway URL, speech, vision, expression)

### DIFF
--- a/.cursor/rules/arduino-contract.mdc
+++ b/.cursor/rules/arduino-contract.mdc
@@ -1,7 +1,6 @@
 ---
-description: "Arduino serial modülüyle çalışırken veya donanım komutu gönderen kod yazarken aktif olur."
-globs: ["modules/arduino_serial/**", "modules/autonomy/**", "modules/vlm_bridge/**", "modules/animate/**", "modules/calibration/**"]
-alwaysApply: false
+description: "Arduino seri iletişimi, donanım komutları ve contract.py kullanımı kuralları."
+alwaysApply: true
 ---
 
 # Arduino Kontrat Kuralları

--- a/.cursor/rules/github-ops.mdc
+++ b/.cursor/rules/github-ops.mdc
@@ -1,7 +1,6 @@
 ---
-description: "GitHub işlemleri, PR veya Issue hazırlarken aktif olur."
-globs: [".github/**"]
-alwaysApply: false
+description: "GitHub işlemleri, PR, Issue veya CI süreçleri yönetimi."
+alwaysApply: true
 ---
 
 # GitHub İşlemleri

--- a/.cursor/rules/module-operations.mdc
+++ b/.cursor/rules/module-operations.mdc
@@ -1,7 +1,6 @@
 ---
-description: "Yeni modül oluşturma veya modül iskeleti üretme talebi geldiğinde aktif olur."
-globs: ["modules/**/x*Service.py", "modules/**/__init__.py"]
-alwaysApply: false
+description: "Yeni modül oluşturma, modül düzenleme veya modül iskeleti üretme işlemleri."
+alwaysApply: true
 ---
 
 # Modül Oluşturma / Düzenleme

--- a/.cursor/rules/sentrybot-core.mdc
+++ b/.cursor/rules/sentrybot-core.mdc
@@ -13,8 +13,25 @@ alwaysApply: true
 5. **Modül yapısı** — `x<Name>Service.py` + `config_loader.py` + `api/router.py`
 
 ## Agent & Skill Sistemi
-Tüm detaylı prosedürler `.sentrybot/` dizininde:
-- `.sentrybot/agents/` — 5 iş akışı yöneticisi
-- `.sentrybot/skills/` — 12 adım adım prosedür
-- `.sentrybot/context/` — Modül listesi, API haritası, mimari özet, kurallar
-- `.sentrybot/templates/` — Modül iskelet şablonları
+Tüm detaylı prosedürler ve roller `.sentrybot/` dizininde tanımlanmıştır. Bir işlem yaparken **MUTLAKA** ilgili dosyayı okumalı ve oradaki adımları uygulamalısın.
+
+### 🤖 İş Akışı Yöneticileri (Agents)
+- **Yeni Modül Oluşturma**: `.sentrybot/agents/module-creator.md`
+- **Mevcut Modül Düzenleme**: `.sentrybot/agents/module-editor.md`
+- **GitHub İşlemleri (PR, Issue, CI)**: `.sentrybot/agents/github-ops.md`
+- **Modüller Arası Etkileşim**: `.sentrybot/agents/inter-module.md`
+- **Kod İnceleme**: `.sentrybot/agents/code-reviewer.md`
+
+### 🛠️ Adım Adım Prosedürler (Skills)
+- **Modül İskeleti Oluşturma**: `.sentrybot/skills/scaffold-module.md`
+- **API Endpoint Ekleme**: `.sentrybot/skills/add-api-endpoint.md`
+- **Service Class Ekleme**: `.sentrybot/skills/add-service-class.md`
+- **Config Güncelleme**: `.sentrybot/skills/update-config.md`
+- **Test Yazma**: `.sentrybot/skills/write-tests.md`
+- **Mimari Doküman Yazma**: `.sentrybot/skills/write-architecture-doc.md`
+- **Arduino Kontrat Ekleme**: `.sentrybot/skills/arduino-contract.md`
+- **Gateway Modül Kaydı**: `.sentrybot/skills/gateway-bootstrap.md`
+- **PR Oluşturma**: `.sentrybot/skills/create-pr.md`
+- **Issue Oluşturma**: `.sentrybot/skills/create-issue.md`
+- **Modül Bağımlılık Haritası**: `.sentrybot/skills/module-dependency-map.md`
+- **Modül Hata Ayıklama (Debug)**: `.sentrybot/skills/debug-module.md`

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,7 +1,6 @@
 ---
-description: "Test yazarken veya test dosyalarıyla çalışırken aktif olur."
-globs: ["modules/**/tests/**", "**/test_*.py"]
-alwaysApply: false
+description: "Test yazma kuralları ve smoke test gereksinimleri."
+alwaysApply: true
 ---
 
 # Test Kuralları

--- a/.cursor/skills/add-api-endpoint/SKILL.md
+++ b/.cursor/skills/add-api-endpoint/SKILL.md
@@ -1,0 +1,110 @@
+﻿---
+name: add-api-endpoint
+description: SentryBOT: Add API Endpoint â€” Mevcut ModÃ¼le Endpoint Ekleme. Source: .sentrybot/skills/add-api-endpoint.md
+---
+# Skill: Add API Endpoint â€” Mevcut ModÃ¼le Endpoint Ekleme
+
+> Mevcut bir modÃ¼le yeni API endpoint ekleme prosedÃ¼rÃ¼.
+
+## Girdiler
+
+| Parametre | Zorunlu | AÃ§Ä±klama | Ã–rnek |
+|-----------|---------|----------|-------|
+| `MODULE_NAME` | âœ… | Hedef modÃ¼l | `speak` |
+| `ENDPOINT_PATH` | âœ… | Yeni endpoint yolu | `/volume` |
+| `HTTP_METHOD` | âœ… | HTTP metodu | `POST` |
+| `DESCRIPTION` | âœ… | Endpoint aÃ§Ä±klamasÄ± | `Ses seviyesini ayarla` |
+
+## ProsedÃ¼r
+
+### AdÄ±m 1: Mevcut Router'Ä± Ä°ncele
+```bash
+# Mevcut endpoint'leri gÃ¶r
+cat modules/{{MODULE_NAME}}/api/router.py
+```
+
+Kontrol et:
+- Naming convention (fonksiyon isimleri)
+- Parametre alma kalÄ±bÄ± (query param vs body)
+- Response formatÄ± (JSONResponse vs dict)
+- Dependency injection (service instance nasÄ±l aktarÄ±lÄ±yor)
+
+### AdÄ±m 2: Service Fonksiyonu OluÅŸtur (Gerekirse)
+
+EÄŸer yeni iÅŸ mantÄ±ÄŸÄ± gerekiyorsa `services/` altÄ±na ekle:
+
+```python
+# modules/{{MODULE_NAME}}/services/<yeni_servis>.py
+from __future__ import annotations
+import logging
+
+logger = logging.getLogger("{{MODULE_NAME}}.<yeni_servis>")
+
+
+class <YeniServis>:
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+
+    def execute(self, **kwargs):
+        """Ä°ÅŸ mantÄ±ÄŸÄ±."""
+        logger.info("Executing with %s", kwargs)
+        # ...implementasyon...
+        return {"ok": True}
+```
+
+### AdÄ±m 3: Router'a Endpoint Ekle
+
+```python
+# modules/{{MODULE_NAME}}/api/router.py iÃ§ine ekle
+
+@router.{{HTTP_METHOD.lower()}}("{{ENDPOINT_PATH}}")
+async def {{endpoint_function_name}}(request_body: dict = None):
+    """{{DESCRIPTION}}"""
+    try:
+        result = svc.{{service_method}}(**request_body)
+        return {"ok": True, "data": result}
+    except Exception as e:
+        logger.error("{{ENDPOINT_PATH}} failed: %s", e)
+        return {"ok": False, "error": str(e)}
+```
+
+### AdÄ±m 4: Config GÃ¼ncelle (Gerekirse)
+
+EÄŸer yeni parametreler gerekiyorsa:
+
+```yaml
+# modules/{{MODULE_NAME}}/config/config.yml
+# Mevcut ayarlarÄ±n altÄ±na ekle:
+<yeni_alan>:
+  enabled: true
+  default_value: <deÄŸer>
+```
+
+### AdÄ±m 5: Test Ekle
+
+```python
+# modules/{{MODULE_NAME}}/tests/test_smoke.py iÃ§ine ekle
+
+def test_{{endpoint_function_name}}_router():
+    """{{ENDPOINT_PATH}} endpoint'i mevcut mu?"""
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    router = get_router()
+    paths = [r.path for r in router.routes]
+    assert "{{ENDPOINT_PATH}}" in paths or any("{{ENDPOINT_PATH}}" in str(p) for p in paths)
+```
+
+### AdÄ±m 6: DokÃ¼mantasyon GÃ¼ncelle
+
+1. `README.md` endpoint tablosuna yeni endpoint'i ekle
+2. `architecture_{{MODULE_NAME}}.md` dosyasÄ±nÄ± gÃ¼ncelle
+3. `.sentrybot/context/api-surface.md` dosyasÄ±nÄ± gÃ¼ncelle
+
+## Kontrol Listesi
+
+- [ ] Mevcut endpoint naming convention'a uyuyor
+- [ ] Service fonksiyonu tek sorumluluk taÅŸÄ±yor
+- [ ] Hata yakalama (try/except) var
+- [ ] Config deÄŸeri hardcode deÄŸil
+- [ ] Test yazÄ±ldÄ±
+- [ ] DokÃ¼mantasyon gÃ¼ncellendi
+

--- a/.cursor/skills/add-service-class/SKILL.md
+++ b/.cursor/skills/add-service-class/SKILL.md
@@ -1,0 +1,109 @@
+﻿---
+name: add-service-class
+description: SentryBOT: Add Service Class â€” Yeni Service SÄ±nÄ±fÄ± Ekleme. Source: .sentrybot/skills/add-service-class.md
+---
+# Skill: Add Service Class â€” Yeni Service SÄ±nÄ±fÄ± Ekleme
+
+> Mevcut bir modÃ¼le yeni iÅŸ mantÄ±ÄŸÄ± sÄ±nÄ±fÄ± ekleme prosedÃ¼rÃ¼.
+
+## Girdiler
+
+| Parametre | Zorunlu | AÃ§Ä±klama | Ã–rnek |
+|-----------|---------|----------|-------|
+| `MODULE_NAME` | âœ… | Hedef modÃ¼l | `vlm_bridge` |
+| `CLASS_NAME` | âœ… | SÄ±nÄ±f adÄ± (PascalCase) | `DepthEstimator` |
+| `RESPONSIBILITY` | âœ… | Tek cÃ¼mle sorumluluk | `Derinlik haritasÄ± tahmini` |
+
+## ProsedÃ¼r
+
+### AdÄ±m 1: Mevcut Servisleri Ä°ncele
+```bash
+ls modules/{{MODULE_NAME}}/services/
+cat modules/{{MODULE_NAME}}/services/__init__.py
+```
+
+### AdÄ±m 2: Yeni Service DosyasÄ± OluÅŸtur
+
+```python
+# modules/{{MODULE_NAME}}/services/{{class_name_snake}}.py
+from __future__ import annotations
+import logging
+
+logger = logging.getLogger("{{MODULE_NAME}}.{{class_name_snake}}")
+
+
+class {{CLASS_NAME}}:
+    """{{RESPONSIBILITY}}"""
+
+    def __init__(self, cfg: dict | None = None):
+        self.cfg = cfg or {}
+        self._initialized = False
+        logger.info("{{CLASS_NAME}} created")
+
+    def initialize(self) -> None:
+        """Gecikmeli baÅŸlatma (lazy init)."""
+        if self._initialized:
+            return
+        # BaÅŸlatma mantÄ±ÄŸÄ±
+        self._initialized = True
+        logger.info("{{CLASS_NAME}} initialized")
+
+    def shutdown(self) -> None:
+        """KaynaklarÄ± temizle."""
+        self._initialized = False
+        logger.info("{{CLASS_NAME}} shut down")
+```
+
+### AdÄ±m 3: `__init__.py`'ye Re-export Ekle
+
+```python
+# modules/{{MODULE_NAME}}/services/__init__.py
+from .{{class_name_snake}} import {{CLASS_NAME}}  # noqa: F401
+```
+
+### AdÄ±m 4: x<Name>Service.py'den BaÅŸlat
+
+```python
+# x<Name>Service.py iÃ§inde __init__'e ekle:
+from .services.{{class_name_snake}} import {{CLASS_NAME}}
+
+class ...Service:
+    def __init__(self, cfg=None):
+        ...
+        self.{{class_name_snake}} = {{CLASS_NAME}}(self.cfg.get("{{class_name_snake}}", {}))
+```
+
+### AdÄ±m 5: Test Yaz
+
+```python
+# modules/{{MODULE_NAME}}/tests/test_{{class_name_snake}}.py
+def test_{{class_name_snake}}_init():
+    from modules.{{MODULE_NAME}}.services.{{class_name_snake}} import {{CLASS_NAME}}
+    instance = {{CLASS_NAME}}(cfg={})
+    assert instance is not None
+    assert not instance._initialized
+
+def test_{{class_name_snake}}_initialize():
+    from modules.{{MODULE_NAME}}.services.{{class_name_snake}} import {{CLASS_NAME}}
+    instance = {{CLASS_NAME}}(cfg={})
+    instance.initialize()
+    assert instance._initialized
+
+def test_{{class_name_snake}}_shutdown():
+    from modules.{{MODULE_NAME}}.services.{{class_name_snake}} import {{CLASS_NAME}}
+    instance = {{CLASS_NAME}}(cfg={})
+    instance.initialize()
+    instance.shutdown()
+    assert not instance._initialized
+```
+
+## Kontrol Listesi
+
+- [ ] SÄ±nÄ±f tek sorumluluk taÅŸÄ±yor
+- [ ] Config'den okuma yapÄ±yor (hardcode yok)
+- [ ] Lazy init destekliyor (gerekirse)
+- [ ] Shutdown/cleanup metodu var
+- [ ] `__init__.py`'ye re-export eklendi
+- [ ] Test yazÄ±ldÄ±
+- [ ] Architecture doc gÃ¼ncellendi
+

--- a/.cursor/skills/arduino-contract/SKILL.md
+++ b/.cursor/skills/arduino-contract/SKILL.md
@@ -1,0 +1,69 @@
+﻿---
+name: arduino-contract
+description: SentryBOT: Arduino Contract â€” Arduino Kontrat Builder Ekleme. Source: .sentrybot/skills/arduino-contract.md
+---
+# Skill: Arduino Contract â€” Arduino Kontrat Builder Ekleme
+
+> Arduino komut builder ve validator fonksiyonu ekleme prosedÃ¼rÃ¼.
+
+## Tek Kaynak
+TÃ¼m Arduino komutlarÄ±nÄ±n tek kaynaÄŸÄ±: `modules/arduino_serial/contract.py`
+
+## Mevcut Builder Ã–rnekleri Ä°ncele
+```bash
+cat modules/arduino_serial/contract.py
+```
+Mevcut `build_*` ve `validate_*` fonksiyonlarÄ±nÄ±n kalÄ±bÄ±nÄ± incele.
+
+## Yeni Komut Ekleme
+
+### AdÄ±m 1: Builder Fonksiyonu
+```python
+# modules/arduino_serial/contract.py iÃ§ine ekle:
+
+def build_{{command_name}}({{parametreler}}) -> dict:
+    """{{Komut aÃ§Ä±klamasÄ±}}."""
+    payload = {
+        "cmd": "{{command_name}}",
+        {{alanlar}}
+    }
+    validate_{{command_name}}(payload)
+    return payload
+```
+
+### AdÄ±m 2: Validator Fonksiyonu
+```python
+def validate_{{command_name}}(payload: dict) -> None:
+    """{{command_name}} payload doÄŸrulama."""
+    assert payload.get("cmd") == "{{command_name}}"
+    # Alan doÄŸrulamalarÄ±
+    {{doÄŸrulama_kurallarÄ±}}
+```
+
+### AdÄ±m 3: Test Yaz (Zorunlu)
+```python
+# modules/arduino_serial/tests/ iÃ§ine:
+def test_build_{{command_name}}():
+    from modules.arduino_serial.contract import build_{{command_name}}
+    payload = build_{{command_name}}({{test_parametreleri}})
+    assert payload["cmd"] == "{{command_name}}"
+
+def test_validate_{{command_name}}_invalid():
+    from modules.arduino_serial.contract import validate_{{command_name}}
+    import pytest
+    with pytest.raises(AssertionError):
+        validate_{{command_name}}({"cmd": "wrong"})
+```
+
+### AdÄ±m 4: Gateway DavranÄ±ÅŸ Testi
+`/arduino/request` endpoint'inin yeni komutu doÄŸru iÅŸlediÄŸini test et.
+
+## Zorunlu PR Kontrol Listesi
+- [ ] `contract.py`'ye builder eklendi
+- [ ] `contract.py`'ye validator eklendi
+- [ ] Validator unit testi yazÄ±ldÄ±
+- [ ] Gateway davranÄ±ÅŸ testi yazÄ±ldÄ±
+- [ ] Kritik komutsa `/arduino/request` kullanÄ±lÄ±yor (fire-and-forget deÄŸil)
+- [ ] Timeout 0.8-1.5s arasÄ±nda
+- [ ] PR aÃ§Ä±klamasÄ±nda kontrat uyumu belirtildi
+

--- a/.cursor/skills/create-issue/SKILL.md
+++ b/.cursor/skills/create-issue/SKILL.md
@@ -1,0 +1,66 @@
+﻿---
+name: create-issue
+description: SentryBOT: Create Issue â€” Issue OluÅŸturma. Source: .sentrybot/skills/create-issue.md
+---
+# Skill: Create Issue â€” Issue OluÅŸturma
+
+> GitHub Issue standartlarÄ±na uygun bug report ve feature request oluÅŸturma.
+
+## Bug Report
+
+`.github/ISSUE_TEMPLATE/bug_report.yml` formatÄ±na uygun:
+
+```markdown
+**AÃ§Ä±klama:** <HatanÄ±n kÄ±sa aÃ§Ä±klamasÄ±>
+
+**Beklenen davranÄ±ÅŸ:** <Ne olmasÄ± gerekiyordu>
+
+**GerÃ§ekleÅŸen davranÄ±ÅŸ:** <Ne oldu>
+
+**Tekrar adÄ±mlarÄ±:**
+1. <AdÄ±m 1>
+2. <AdÄ±m 2>
+3. <AdÄ±m 3>
+
+**Ortam:**
+- Platform: Raspberry Pi 5
+- Python: 3.10
+- OS: <Raspbian/Ubuntu>
+- Etkilenen modÃ¼l: <modÃ¼l adÄ±>
+
+**Log Ã§Ä±ktÄ±sÄ±:**
+\```
+<ilgili log satÄ±rlarÄ±>
+\```
+
+**Ekran gÃ¶rÃ¼ntÃ¼sÃ¼:** (varsa)
+```
+
+## Feature Request
+
+`.github/ISSUE_TEMPLATE/feature_request.yml` formatÄ±na uygun:
+
+```markdown
+**Motivasyon:** <Neden bu Ã¶zellik gerekli>
+
+**KullanÄ±m senaryosu:** <NasÄ±l kullanÄ±lacak>
+
+**Ã–nerilen Ã§Ã¶zÃ¼m:** <Teknik yaklaÅŸÄ±m>
+
+**Alternatifler:** <DÃ¼ÅŸÃ¼nÃ¼len diÄŸer yollar>
+
+**Etkilenecek modÃ¼ller:** <modÃ¼l listesi>
+
+**Ek bilgi:** (varsa)
+```
+
+## Label Ã–nerisi
+
+| Durum | Label |
+|-------|-------|
+| Bug | `bug` |
+| Feature | `enhancement` |
+| Acil | `priority:high` |
+| DokÃ¼mantasyon | `documentation` |
+| Arduino ile ilgili | `hardware:arduino` |
+

--- a/.cursor/skills/create-pr/SKILL.md
+++ b/.cursor/skills/create-pr/SKILL.md
@@ -1,0 +1,86 @@
+﻿---
+name: create-pr
+description: SentryBOT: Create PR â€” Pull Request OluÅŸturma. Source: .sentrybot/skills/create-pr.md
+---
+# Skill: Create PR â€” Pull Request OluÅŸturma
+
+> SentryBOT PR standartlarÄ±na uygun Pull Request hazÄ±rlama prosedÃ¼rÃ¼.
+
+## Branch AdlandÄ±rma
+
+| TÃ¼r | Format | Ã–rnek |
+|-----|--------|-------|
+| Yeni Ã¶zellik | `feat/<modÃ¼l>-<aÃ§Ä±klama>` | `feat/speech-multi-language` |
+| Hata dÃ¼zeltme | `fix/<modÃ¼l>-<aÃ§Ä±klama>` | `fix/vlm-tracker-crash` |
+| Refactor | `refactor/<modÃ¼l>-<aÃ§Ä±klama>` | `refactor/autonomy-mood-engine` |
+| DokÃ¼mantasyon | `docs/<aÃ§Ä±klama>` | `docs/update-architecture` |
+
+## PR Åablonu
+
+`.github/pull_request_template.md` doldurulur:
+
+```markdown
+## Ã–zet
+Ne deÄŸiÅŸti ve neden deÄŸiÅŸti?
+<KÄ±sa aÃ§Ä±klama>
+
+## DeÄŸiÅŸiklik tipi
+- [ ] Hata dÃ¼zeltmesi
+- [ ] Yeni Ã¶zellik
+- [ ] Refactor
+- [ ] DokÃ¼mantasyon gÃ¼ncellemesi
+- [ ] Test gÃ¼ncellemesi
+
+## Etkilenen modÃ¼ller
+<modules/x, modules/y>
+
+## DoÄŸrulama
+- [ ] Lokal Ã§alÄ±ÅŸtÄ±rma tamamlandÄ±
+- [ ] Ä°lgili testler geÃ§iyor
+- [ ] Gerekli dokÃ¼man/konfig gÃ¼ncellemeleri yapÄ±ldÄ±
+
+## Arduino Kontrat KontrolÃ¼ (uygunsa)
+- [ ] `contract.py` dÄ±ÅŸÄ±nda elle Arduino payload yazÄ±lmadÄ±
+- [ ] Kritik komutlar `/arduino/request` kullanÄ±yor
+- [ ] Yeni komut ailesi builder + validator + test iÃ§eriyor
+
+## Risk ve geri alma
+<AÃ§Ä±klama>
+
+## Ä°lgili issue
+Closes #<issue-number>
+```
+
+## Label Atama
+
+DeÄŸiÅŸtirilen dosya yollarÄ±na gÃ¶re otomatik label ata (`.github/labeler.yml` kurallarÄ±).
+
+## Git KomutlarÄ±
+
+```bash
+# Branch oluÅŸtur
+git checkout -b feat/{{module}}-{{description}}
+
+# DeÄŸiÅŸiklikleri ekle
+git add modules/{{module}}/ .sentrybot/ docs/
+
+# Commit (aÃ§Ä±klayÄ±cÄ± mesaj)
+git commit -m "feat({{module}}): {{kÄ±sa aÃ§Ä±klama}}"
+
+# Push
+git push origin feat/{{module}}-{{description}}
+```
+
+## Commit MesajÄ± FormatÄ±
+
+```
+<tÃ¼r>(<kapsam>): <aÃ§Ä±klama>
+
+Ã–rnekler:
+feat(speech): add multi-language ASR support
+fix(vlm): fix CSRT tracker crash on lost face
+refactor(autonomy): extract mood engine to separate class
+docs(architecture): update inter-module diagram
+test(neopixel): add emotion palette unit tests
+```
+

--- a/.cursor/skills/debug-module/SKILL.md
+++ b/.cursor/skills/debug-module/SKILL.md
@@ -1,0 +1,64 @@
+﻿---
+name: debug-module
+description: SentryBOT: Debug Module â€” ModÃ¼l Debugging. Source: .sentrybot/skills/debug-module.md
+---
+# Skill: Debug Module â€” ModÃ¼l Debugging
+
+> SentryBOT modÃ¼llerinde hata ayÄ±klama prosedÃ¼rÃ¼.
+
+## HÄ±zlÄ± TeÅŸhis
+
+### 1. ModÃ¼l SaÄŸlÄ±k KontrolÃ¼
+```bash
+# ModÃ¼l import edilebilir mi?
+python -c "from modules.{{MODULE_NAME}} import *; print('OK')"
+
+# Config yÃ¼klenebilir mi?
+python -c "from modules.{{MODULE_NAME}}.config_loader import load_config; print(load_config())"
+
+# Testler geÃ§iyor mu?
+python -m pytest modules/{{MODULE_NAME}}/tests/ -v --maxfail=1
+```
+
+### 2. Log Analizi
+```bash
+# Son loglarÄ± incele
+grep -i "error\|warning\|exception" logs/ --include="*.log" | grep {{MODULE_NAME}}
+```
+
+### 3. API SaÄŸlÄ±k KontrolÃ¼
+```bash
+# Gateway Ã¼zerinden durum kontrolÃ¼
+curl http://localhost:8080/{{MODULE_NAME}}/status
+curl http://localhost:8080/{{MODULE_NAME}}/healthz
+
+# Genel sistem durumu
+curl http://localhost:8080/status
+```
+
+### 4. Diagnostics ModÃ¼lÃ¼
+```bash
+# Otomatik sistem testi
+curl -X POST http://localhost:8080/diagnostics/self_test
+```
+
+## YaygÄ±n Sorunlar
+
+| Sorun | OlasÄ± Neden | Ã‡Ã¶zÃ¼m |
+|-------|-------------|-------|
+| Import hatasÄ± | Eksik baÄŸÄ±mlÄ±lÄ±k | `pip install -r modules/{{MODULE_NAME}}/requirements.txt` |
+| Config hatasÄ± | YAML syntax | Config dosyasÄ±nÄ± YAML linter ile kontrol et |
+| API 404 | Gateway'e kayÄ±tlÄ± deÄŸil | `gateway-bootstrap` skill'ini uygula |
+| Arduino timeout | Seri baÄŸlantÄ± kopuk | `diagnostics/self_test` Ã§alÄ±ÅŸtÄ±r |
+| ModÃ¼l Ã§Ã¶kmesi | Exception yakalanmamÄ±ÅŸ | try/except ekle, log incele |
+
+## Ä°zole Test
+```python
+# ModÃ¼lÃ¼ izole Ã§alÄ±ÅŸtÄ±rma
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from modules.{{MODULE_NAME}}.x{{SERVICE_NAME}}Service import {{SERVICE_NAME}}Service
+svc = {{SERVICE_NAME}}Service(cfg={})
+svc.start()
+```
+

--- a/.cursor/skills/gateway-bootstrap/SKILL.md
+++ b/.cursor/skills/gateway-bootstrap/SKILL.md
@@ -1,0 +1,55 @@
+﻿---
+name: gateway-bootstrap
+description: SentryBOT: Gateway Bootstrap â€” Gateway'e ModÃ¼l KaydÄ±. Source: .sentrybot/skills/gateway-bootstrap.md
+---
+# Skill: Gateway Bootstrap â€” Gateway'e ModÃ¼l KaydÄ±
+
+> Yeni bir modÃ¼lÃ¼ Gateway bootstrap sistemine kaydetme prosedÃ¼rÃ¼.
+
+## Dosyalar
+
+### 1. `modules/gateway/services/bootstrap.py`'ye Ekleme
+
+Mevcut bootstrap fonksiyonlarÄ±nÄ± incele, ardÄ±ndan yeni modÃ¼l iÃ§in ekle:
+
+```python
+def _include_{{MODULE_NAME}}(app, cfg: dict) -> dict:
+    """{{MODULE_NAME}} modÃ¼lÃ¼nÃ¼ baÅŸlat ve mount et."""
+    try:
+        from modules.{{MODULE_NAME}}.x{{SERVICE_NAME}}Service import _include_{{MODULE_NAME}} as mount
+        return mount(app, cfg)
+    except Exception as exc:
+        logger.warning("{{MODULE_NAME}} module failed: %s", exc)
+        return {}
+```
+
+Bootstrap sÄ±rasÄ±: `.sentrybot/agents/inter-module.md` dosyasÄ±ndaki sÄ±raya uy.
+
+### 2. Gateway Config'e Ekleme
+
+```yaml
+# modules/gateway/config/config.yml
+include:
+  # ...mevcut modÃ¼ller...
+  {{MODULE_NAME}}: true
+```
+
+### 3. Bootstrap Ana Fonksiyonuna Ã‡aÄŸrÄ± Ekleme
+
+`bootstrap(app, cfg)` fonksiyonunda `include.{{MODULE_NAME}}` kontrolÃ¼ ekle:
+
+```python
+if inc.get("{{MODULE_NAME}}", False):
+    try:
+        result = _include_{{MODULE_NAME}}(app, cfg)
+        started.update(result)
+    except Exception as exc:
+        logger.warning("{{MODULE_NAME}} failed: %s", exc)
+```
+
+## Kontrol Listesi
+- [ ] `bootstrap.py`'ye `_include_{{MODULE_NAME}}` fonksiyonu eklendi
+- [ ] `config.yml`'ye `include.{{MODULE_NAME}}: true` eklendi
+- [ ] Bootstrap sÄ±rasÄ± korunuyor (baÄŸÄ±mlÄ±lÄ±klar Ã¶nce yÃ¼kleniyor)
+- [ ] ModÃ¼l baÅŸarÄ±sÄ±zsa warning loglanÄ±yor (diÄŸer modÃ¼ller etkilenmiyor)
+

--- a/.cursor/skills/module-dependency-map/SKILL.md
+++ b/.cursor/skills/module-dependency-map/SKILL.md
@@ -1,0 +1,52 @@
+﻿---
+name: module-dependency-map
+description: SentryBOT: Module Dependency Map â€” ModÃ¼l BaÄŸÄ±mlÄ±lÄ±k Haritalama. Source: .sentrybot/skills/module-dependency-map.md
+---
+# Skill: Module Dependency Map â€” ModÃ¼l BaÄŸÄ±mlÄ±lÄ±k Haritalama
+
+> ModÃ¼ller arasÄ± baÄŸÄ±mlÄ±lÄ±klarÄ± analiz etme ve haritalama prosedÃ¼rÃ¼.
+
+## Analiz ProsedÃ¼rÃ¼
+
+### AdÄ±m 1: Import TaramasÄ±
+```bash
+# ModÃ¼lÃ¼n hangi diÄŸer modÃ¼lleri import ettiÄŸini bul
+grep -r "from modules\." modules/{{MODULE_NAME}}/ --include="*.py" | grep -v __pycache__
+grep -r "import modules\." modules/{{MODULE_NAME}}/ --include="*.py" | grep -v __pycache__
+```
+
+### AdÄ±m 2: HTTP Ã‡aÄŸrÄ± TaramasÄ±
+```bash
+# ModÃ¼lÃ¼n hangi endpoint'leri Ã§aÄŸÄ±rdÄ±ÄŸÄ±nÄ± bul
+grep -rn "localhost:8080\|/arduino/\|/speak/\|/neopixel/\|/ollama/\|/vlm/\|/state/" \
+  modules/{{MODULE_NAME}}/ --include="*.py" | grep -v __pycache__
+```
+
+### AdÄ±m 3: Config BaÄŸÄ±mlÄ±lÄ±k TaramasÄ±
+```bash
+# Config'de referans verilen URL'leri bul
+grep -n "endpoint\|url\|host\|port" modules/{{MODULE_NAME}}/config/config.yml
+```
+
+### AdÄ±m 4: BaÄŸÄ±mlÄ±lÄ±k DiyagramÄ± OluÅŸtur
+
+```mermaid
+graph LR
+    {{MODULE_NAME}} --> |HTTP| modÃ¼l_a
+    {{MODULE_NAME}} --> |Serial| modÃ¼l_b
+    modÃ¼l_c --> |HTTP| {{MODULE_NAME}}
+```
+
+## BaÄŸÄ±mlÄ±lÄ±k TÃ¼rleri
+
+| TÃ¼r | AÃ§Ä±klama | Ã–rnek |
+|-----|----------|-------|
+| **DoÄŸrudan** | Import ile | `from modules.x import Y` |
+| **HTTP** | API Ã§aÄŸrÄ±sÄ± ile | `POST /speak/say` |
+| **Serial** | Arduino kontratÄ± ile | `contract.build_set_servo()` |
+| **Config** | Config referansÄ± ile | `endpoint: http://localhost:8080/x` |
+| **Event** | Olay bildirimi ile | `POST /interactions/event` |
+
+## Ã‡Ä±ktÄ± FormatÄ±
+BaÄŸÄ±mlÄ±lÄ±k haritasÄ± `.sentrybot/context/module-registry.md`'deki "Kilit BaÄŸÄ±mlÄ±lÄ±klar" sÃ¼tununa yansÄ±tÄ±lÄ±r.
+

--- a/.cursor/skills/scaffold-module/SKILL.md
+++ b/.cursor/skills/scaffold-module/SKILL.md
@@ -1,0 +1,279 @@
+﻿---
+name: scaffold-module
+description: SentryBOT: Scaffold Module â€” SÄ±fÄ±rdan ModÃ¼l Ä°skeleti OluÅŸturma. Source: .sentrybot/skills/scaffold-module.md
+---
+# Skill: Scaffold Module â€” SÄ±fÄ±rdan ModÃ¼l Ä°skeleti OluÅŸturma
+
+> Bu skill, SentryBOT modÃ¼l yapÄ± kurallarÄ±na uygun bir iskelet oluÅŸturur.
+
+## Girdiler
+
+| Parametre | Zorunlu | AÃ§Ä±klama | Ã–rnek |
+|-----------|---------|----------|-------|
+| `MODULE_NAME` | âœ… | ModÃ¼l adÄ± (snake_case) | `ultrasonic_sensor` |
+| `SERVICE_NAME` | âœ… | Servis sÄ±nÄ±f adÄ± (PascalCase) | `UltrasonicSensor` |
+| `PORT` | âŒ | Standalone port (varsa) | `8104` |
+| `DESCRIPTION` | âœ… | KÄ±sa modÃ¼l aÃ§Ä±klamasÄ± | `Ultrasonik mesafe sensÃ¶rÃ¼ okuma` |
+| `LAYER` | âœ… | Mimari katman | `AlgÄ± / Beyin / AI / Eylem / Arka Plan` |
+
+## OluÅŸturulacak Dosyalar
+
+### 1. `modules/{{MODULE_NAME}}/__init__.py`
+
+```python
+"""{{DESCRIPTION}}"""
+from .x{{SERVICE_NAME}}Service import {{SERVICE_NAME}}Service  # noqa: F401
+
+__all__ = ["{{SERVICE_NAME}}Service"]
+```
+
+### 2. `modules/{{MODULE_NAME}}/x{{SERVICE_NAME}}Service.py`
+
+```python
+from __future__ import annotations
+"""
+{{SERVICE_NAME}} Service â€” {{DESCRIPTION}}
+"""
+import logging
+from .config_loader import load_config
+
+logger = logging.getLogger("{{MODULE_NAME}}.service")
+
+
+class {{SERVICE_NAME}}Service:
+    """{{DESCRIPTION}}"""
+
+    def __init__(self, cfg: dict | None = None):
+        self.cfg = cfg or load_config()
+        logger.info("{{SERVICE_NAME}}Service initialized")
+
+    def start(self):
+        """Servisi baÅŸlat."""
+        logger.info("{{SERVICE_NAME}}Service starting")
+
+    def stop(self):
+        """Servisi durdur."""
+        logger.info("{{SERVICE_NAME}}Service stopping")
+
+
+def _include_{{MODULE_NAME}}(app, cfg: dict) -> dict:
+    """Gateway bootstrap entegrasyon fonksiyonu."""
+    from .api.router import get_router
+    svc = {{SERVICE_NAME}}Service(cfg.get("{{MODULE_NAME}}", {}))
+    app.include_router(get_router(svc), prefix="/{{MODULE_NAME}}", tags=["{{MODULE_NAME}}"])
+    return {"{{MODULE_NAME}}": svc}
+```
+
+### 3. `modules/{{MODULE_NAME}}/config_loader.py`
+
+```python
+from __future__ import annotations
+import os
+import yaml
+import logging
+
+logger = logging.getLogger("{{MODULE_NAME}}.config")
+
+_DEFAULT_PATH = os.path.join(os.path.dirname(__file__), "config", "config.yml")
+
+
+def load_config(path: str | None = None) -> dict:
+    """{{MODULE_NAME}} config dosyasÄ±nÄ± yÃ¼kle."""
+    cfg_path = path or os.environ.get("{{MODULE_NAME.upper()}}_CONFIG", _DEFAULT_PATH)
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        logger.warning("Config not found at %s, using defaults", cfg_path)
+        cfg = {}
+    return cfg
+```
+
+### 4. `modules/{{MODULE_NAME}}/config/config.yml`
+
+```yaml
+# {{SERVICE_NAME}} Module Configuration
+# AÃ§Ä±klama: {{DESCRIPTION}}
+
+server:
+  host: 0.0.0.0
+  port: {{PORT or 0}}
+
+# ModÃ¼le Ã¶zgÃ¼ ayarlar buraya eklenir
+settings:
+  enabled: true
+```
+
+### 5. `modules/{{MODULE_NAME}}/api/__init__.py`
+
+```python
+"""{{SERVICE_NAME}} API endpoints."""
+```
+
+### 6. `modules/{{MODULE_NAME}}/api/router.py`
+
+```python
+from __future__ import annotations
+import logging
+from fastapi import APIRouter
+
+logger = logging.getLogger("{{MODULE_NAME}}.api")
+
+
+def get_router(svc=None) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/status")
+    async def status():
+        """ModÃ¼l durum kontrolÃ¼."""
+        return {"ok": True, "module": "{{MODULE_NAME}}"}
+
+    @router.get("/healthz")
+    async def healthz():
+        """SaÄŸlÄ±k kontrolÃ¼."""
+        return {"status": "healthy"}
+
+    return router
+```
+
+### 7. `modules/{{MODULE_NAME}}/services/__init__.py`
+
+```python
+"""{{SERVICE_NAME}} iÅŸ mantÄ±ÄŸÄ± servisleri."""
+```
+
+### 8. `modules/{{MODULE_NAME}}/tests/test_smoke.py`
+
+```python
+"""{{MODULE_NAME}} smoke testleri."""
+import pytest
+
+
+def test_import():
+    """ModÃ¼l import edilebilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    assert {{SERVICE_NAME}}Service is not None
+
+
+def test_config_loader():
+    """Config yÃ¼klenebilir mi?"""
+    from modules.{{MODULE_NAME}}.config_loader import load_config
+    cfg = load_config()
+    assert isinstance(cfg, dict)
+
+
+def test_service_instantiation():
+    """Service oluÅŸturulabilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    svc = {{SERVICE_NAME}}Service(cfg={})
+    assert svc is not None
+
+
+def test_router():
+    """Router oluÅŸturulabilir mi?"""
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    router = get_router()
+    assert router is not None
+    paths = [r.path for r in router.routes]
+    assert "/status" in paths or any("/status" in str(p) for p in paths)
+```
+
+### 9. `modules/{{MODULE_NAME}}/architecture_{{MODULE_NAME}}.md`
+
+```markdown
+# {{SERVICE_NAME}} â€” Mimari DokÃ¼mantasyon
+
+## Genel BakÄ±ÅŸ
+
+{{DESCRIPTION}}
+
+## ModÃ¼l YapÄ±sÄ±
+
+\```
+modules/{{MODULE_NAME}}/
+â”œâ”€â”€ __init__.py
+â”œâ”€â”€ x{{SERVICE_NAME}}Service.py
+â”œâ”€â”€ config_loader.py
+â”œâ”€â”€ config/
+â”‚   â””â”€â”€ config.yml
+â”œâ”€â”€ api/
+â”‚   â”œâ”€â”€ __init__.py
+â”‚   â””â”€â”€ router.py
+â”œâ”€â”€ services/
+â”‚   â””â”€â”€ __init__.py
+â”œâ”€â”€ tests/
+â”‚   â””â”€â”€ test_smoke.py
+â”œâ”€â”€ architecture_{{MODULE_NAME}}.md
+â””â”€â”€ README.md
+\```
+
+## Veri AkÄ±ÅŸÄ±
+
+\```mermaid
+flowchart TD
+    API[API Ä°steÄŸi] --> SVC[{{SERVICE_NAME}}Service]
+    SVC --> CFG[Config Loader]
+    SVC --> BL[Ä°ÅŸ MantÄ±ÄŸÄ±]
+    BL --> RES[YanÄ±t]
+\```
+
+## ModÃ¼ller ArasÄ± EtkileÅŸim
+
+| ModÃ¼l | Ä°liÅŸki |
+|---|---|
+| `gateway` | Bootstrap ile mount edilir |
+
+## TasarÄ±m KararlarÄ±
+
+- DryCode prensiplerine uygun yapÄ±landÄ±rÄ±lmÄ±ÅŸtÄ±r.
+- Config deÄŸerleri hardcode edilmez, config.yml Ã¼zerinden okunur.
+```
+
+### 10. `modules/{{MODULE_NAME}}/README.md`
+
+```markdown
+# {{SERVICE_NAME}} Module
+
+**{{DESCRIPTION}}**
+
+## Katman
+{{LAYER}}
+
+## KullanÄ±m
+
+### KÃ¼tÃ¼phane olarak
+\```python
+from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+svc = {{SERVICE_NAME}}Service()
+svc.start()
+\```
+
+### Servis olarak
+Gateway bootstrap ile otomatik baÅŸlatÄ±lÄ±r.
+
+## API Endpoint'leri
+
+| Endpoint | Metod | AÃ§Ä±klama |
+|----------|-------|----------|
+| `/{{MODULE_NAME}}/status` | GET | ModÃ¼l durumu |
+| `/{{MODULE_NAME}}/healthz` | GET | SaÄŸlÄ±k kontrolÃ¼ |
+
+## KonfigÃ¼rasyon
+
+| Ayar | VarsayÄ±lan | AÃ§Ä±klama |
+|------|-----------|----------|
+| `settings.enabled` | `true` | ModÃ¼l etkin mi |
+
+## Testler
+\```bash
+python -m pytest modules/{{MODULE_NAME}}/tests/ -v
+\```
+```
+
+## Ä°ÅŸlem SonrasÄ±
+
+1. âœ… TÃ¼m dosyalarÄ±n oluÅŸturulduÄŸunu doÄŸrula
+2. âœ… `python -c "from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service"` Ã§alÄ±ÅŸtÄ±r
+3. âœ… `python -m pytest modules/{{MODULE_NAME}}/tests/ -v` Ã§alÄ±ÅŸtÄ±r
+4. â¡ï¸ Gateway bootstrap'a kayÄ±t iÃ§in `gateway-bootstrap` skill'ine geÃ§
+

--- a/.cursor/skills/update-config/SKILL.md
+++ b/.cursor/skills/update-config/SKILL.md
@@ -1,0 +1,48 @@
+﻿---
+name: update-config
+description: SentryBOT: Update Config â€” Config GÃ¼ncelleme. Source: .sentrybot/skills/update-config.md
+---
+# Skill: Update Config â€” Config GÃ¼ncelleme
+
+> ModÃ¼l config dosyasÄ±nÄ± ve config_loader'Ä± gÃ¼ncelleme prosedÃ¼rÃ¼.
+
+## ProsedÃ¼r
+
+### AdÄ±m 1: Mevcut Config'i Oku
+```bash
+cat modules/{{MODULE_NAME}}/config/config.yml
+cat modules/{{MODULE_NAME}}/config_loader.py
+```
+
+### AdÄ±m 2: Yeni Alan Ekle (config.yml)
+```yaml
+# Mevcut ayarlarÄ±n altÄ±na ekle:
+{{yeni_alan}}:
+  {{alt_alan}}: {{varsayÄ±lan_deÄŸer}}
+```
+
+### AdÄ±m 3: Config Loader'Ä± GÃ¼ncelle
+`config_loader.py`'de yeni alanÄ± okuyacak kodu ekle. VarsayÄ±lan deÄŸer atama kalÄ±bÄ±:
+```python
+cfg.setdefault("{{yeni_alan}}", {}).setdefault("{{alt_alan}}", {{varsayÄ±lan}})
+```
+
+### AdÄ±m 4: Merkezi Config Etkisi (Gerekirse)
+EÄŸer bu ayar `config/agent.yaml`'Ä± da etkiliyorsa gÃ¼ncelle.
+
+### AdÄ±m 5: README Config Tablosunu GÃ¼ncelle
+`README.md`'deki konfigÃ¼rasyon tablosuna yeni alanÄ± ekle.
+
+### AdÄ±m 6: Test
+```python
+def test_config_new_field():
+    from modules.{{MODULE_NAME}}.config_loader import load_config
+    cfg = load_config()
+    assert "{{yeni_alan}}" in cfg or True  # varsayÄ±lan atanmalÄ±
+```
+
+## Kurallar
+- Config deÄŸerleri kodda hardcode edilmez
+- VarsayÄ±lan deÄŸer mutlaka atanÄ±r (KeyError'dan kaÃ§Ä±n)
+- Yeni zorunlu alan eklendiÄŸinde geriye uyumluluk korunur
+

--- a/.cursor/skills/write-architecture-doc/SKILL.md
+++ b/.cursor/skills/write-architecture-doc/SKILL.md
@@ -1,0 +1,64 @@
+﻿---
+name: write-architecture-doc
+description: SentryBOT: Write Architecture Doc â€” Mimari DokÃ¼mantasyon Yazma. Source: .sentrybot/skills/write-architecture-doc.md
+---
+# Skill: Write Architecture Doc â€” Mimari DokÃ¼mantasyon Yazma
+
+> `architecture_<module_name>.md` dosyasÄ± yazma formatÄ± ve kurallarÄ±.
+
+## Åablon
+
+```markdown
+# <ModuleName> â€” Mimari DokÃ¼mantasyon
+
+## Genel BakÄ±ÅŸ
+ModÃ¼lÃ¼n tek cÃ¼mlelik aÃ§Ä±klamasÄ± ve gÃ¶revi.
+
+## ModÃ¼l YapÄ±sÄ±
+\```
+modules/<module_name>/
+â”œâ”€â”€ __init__.py
+â”œâ”€â”€ x<Name>Service.py
+â”œâ”€â”€ config_loader.py
+â”œâ”€â”€ config/
+â”‚   â””â”€â”€ config.yml
+â”œâ”€â”€ api/
+â”‚   â””â”€â”€ router.py
+â”œâ”€â”€ services/
+â”‚   â””â”€â”€ <servis_dosyalarÄ±>.py
+â”œâ”€â”€ tests/
+â”‚   â””â”€â”€ test_smoke.py
+â”œâ”€â”€ architecture_<module_name>.md
+â””â”€â”€ README.md
+\```
+
+## Veri AkÄ±ÅŸÄ±
+\```mermaid
+flowchart TD
+    A[GiriÅŸ] --> B{Karar noktasÄ±}
+    B -- KoÅŸul 1 --> C[Ä°ÅŸlem 1]
+    B -- KoÅŸul 2 --> D[Ä°ÅŸlem 2]
+    C --> E[Ã‡Ä±kÄ±ÅŸ]
+    D --> E
+\```
+
+## ModÃ¼ller ArasÄ± EtkileÅŸim
+| ModÃ¼l | Bu ModÃ¼l ile Ä°liÅŸkisi |
+|---|---|
+| `gateway` | Bootstrap ile mount eder |
+| `<diÄŸer>` | <iliÅŸki aÃ§Ä±klamasÄ±> |
+
+## TasarÄ±m KararlarÄ±
+### Neden X yerine Y?
+KararÄ±n gerekÃ§esi, trade-off'lar.
+
+### GeniÅŸletilebilirlik
+ModÃ¼lÃ¼n nasÄ±l geniÅŸletilebileceÄŸi veya deÄŸiÅŸtirilebileceÄŸi.
+```
+
+## Kurallar
+- Mermaid diyagramÄ± zorunlu (en az bir flowchart)
+- ModÃ¼ller arasÄ± etkileÅŸim tablosu zorunlu
+- En az bir tasarÄ±m kararÄ± belgelenecek
+- TÃ¼rkÃ§e yazÄ±labilir (mevcut convention)
+

--- a/.cursor/skills/write-tests/SKILL.md
+++ b/.cursor/skills/write-tests/SKILL.md
@@ -1,0 +1,115 @@
+﻿---
+name: write-tests
+description: SentryBOT: Write Tests â€” Test Yazma. Source: .sentrybot/skills/write-tests.md
+---
+# Skill: Write Tests â€” Test Yazma
+
+> SentryBOT modÃ¼lleri iÃ§in test yazma kurallarÄ± ve kalÄ±plarÄ±.
+
+## Test TÃ¼rleri
+
+### 1. Smoke Test (Zorunlu)
+Her modÃ¼lde `tests/test_smoke.py` olmalÄ±:
+```python
+"""{{MODULE_NAME}} smoke testleri â€” temel saÄŸlÄ±k kontrolÃ¼."""
+
+def test_import():
+    """ModÃ¼l import edilebilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    assert {{SERVICE_NAME}}Service is not None
+
+def test_config_loader():
+    """Config yÃ¼klenebilir mi?"""
+    from modules.{{MODULE_NAME}}.config_loader import load_config
+    cfg = load_config()
+    assert isinstance(cfg, dict)
+
+def test_service_init():
+    """Service boÅŸ config ile oluÅŸturulabilir mi?"""
+    from modules.{{MODULE_NAME}} import {{SERVICE_NAME}}Service
+    svc = {{SERVICE_NAME}}Service(cfg={})
+    assert svc is not None
+
+def test_router_creation():
+    """API router oluÅŸturulabilir mi?"""
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    router = get_router()
+    assert router is not None
+```
+
+### 2. Unit Test
+Tek bir fonksiyonu/sÄ±nÄ±fÄ± izole test etme:
+```python
+"""{{MODULE_NAME}} unit testleri."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+def test_specific_function():
+    from modules.{{MODULE_NAME}}.services.some_service import SomeClass
+    obj = SomeClass(cfg={"key": "value"})
+    result = obj.do_something(input_data)
+    assert result == expected_output
+
+def test_error_handling():
+    from modules.{{MODULE_NAME}}.services.some_service import SomeClass
+    obj = SomeClass(cfg={})
+    with pytest.raises(ValueError):
+        obj.do_something(invalid_input)
+```
+
+### 3. API Test (FastAPI TestClient)
+```python
+"""{{MODULE_NAME}} API testleri."""
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+def test_status_endpoint():
+    from modules.{{MODULE_NAME}}.api.router import get_router
+    app = FastAPI()
+    app.include_router(get_router(), prefix="/{{MODULE_NAME}}")
+    client = TestClient(app)
+    resp = client.get("/{{MODULE_NAME}}/status")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+```
+
+### 4. Mock KalÄ±plarÄ±
+```python
+# DonanÄ±m baÄŸÄ±mlÄ±lÄ±ÄŸÄ±nÄ± mock'la
+@patch("modules.{{MODULE_NAME}}.services.hw.RPi.GPIO", create=True)
+def test_hardware_function(mock_gpio):
+    mock_gpio.input.return_value = 1
+    # ...test...
+
+# HTTP Ã§aÄŸrÄ±sÄ±nÄ± mock'la
+@patch("httpx.AsyncClient.post")
+async def test_service_client(mock_post):
+    mock_post.return_value = MagicMock(status_code=200, json=lambda: {"ok": True})
+    # ...test...
+
+# Arduino serial'Ä± mock'la
+@patch("modules.arduino_serial.xArduinoSerialService.ArduinoSerialService")
+def test_arduino_command(mock_serial):
+    mock_serial.request_cmd.return_value = {"ok": True}
+    # ...test...
+```
+
+## CI KurallarÄ±
+- Python 3.10 hedef
+- `webrtcvad`, `sounddevice`, `soundfile` CI'da uninstall edilir
+- DonanÄ±m gerektiren testler `@pytest.mark.skipif` ile korunur
+- Timeout: collection 420s, test suite 1800s
+- `--maxfail=1` ile ilk hatada durur
+
+## Ã‡alÄ±ÅŸtÄ±rma
+```bash
+# Tek modÃ¼l
+python -m pytest modules/{{MODULE_NAME}}/tests/ -v
+
+# TÃ¼m modÃ¼ller
+python -m pytest modules/ -q --maxfail=1
+
+# Sadece collection kontrolÃ¼
+python -m pytest --collect-only modules/{{MODULE_NAME}}/tests/ -vv
+```
+

--- a/.cursorrules
+++ b/.cursorrules
@@ -11,6 +11,27 @@
 5. Test: her modülde tests/test_smoke.py zorunlu
 
 ## Tam Kurallar → `.sentrybot/context/conventions.md`
-## Agent'lar → `.sentrybot/agents/`
-## Skill'ler → `.sentrybot/skills/`
+
+## 🤖 İş Akışı Yöneticileri (Agents)
+- **Yeni Modül Oluşturma**: `.sentrybot/agents/module-creator.md`
+- **Mevcut Modül Düzenleme**: `.sentrybot/agents/module-editor.md`
+- **GitHub İşlemleri (PR, Issue, CI)**: `.sentrybot/agents/github-ops.md`
+- **Modüller Arası Etkileşim**: `.sentrybot/agents/inter-module.md`
+- **Kod İnceleme**: `.sentrybot/agents/code-reviewer.md`
+
+## 🛠️ Adım Adım Prosedürler (Skills)
+Cursor Agent Skills (import edildi): `.cursor/skills/<skill-name>/SKILL.md` (kaynak: `.sentrybot/skills/`)
+- **Modül İskeleti Oluşturma**: `.cursor/skills/scaffold-module/SKILL.md`
+- **API Endpoint Ekleme**: `.sentrybot/skills/add-api-endpoint.md`
+- **Service Class Ekleme**: `.sentrybot/skills/add-service-class.md`
+- **Config Güncelleme**: `.sentrybot/skills/update-config.md`
+- **Test Yazma**: `.sentrybot/skills/write-tests.md`
+- **Mimari Doküman Yazma**: `.sentrybot/skills/write-architecture-doc.md`
+- **Arduino Kontrat Ekleme**: `.sentrybot/skills/arduino-contract.md`
+- **Gateway Modül Kaydı**: `.sentrybot/skills/gateway-bootstrap.md`
+- **PR Oluşturma**: `.sentrybot/skills/create-pr.md`
+- **Issue Oluşturma**: `.sentrybot/skills/create-issue.md`
+- **Modül Bağımlılık Haritası**: `.sentrybot/skills/module-dependency-map.md`
+- **Modül Hata Ayıklama (Debug)**: `.sentrybot/skills/debug-module.md`
+
 ## Cursor MDC kuralları → `.cursor/rules/`

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -55,7 +55,7 @@ runtime_profile:
           enabled: true
           provider: google_ai_studio
         ollama:
-          endpoint: "http://127.0.0.1:8080/ollama/chat"
+          endpoint: "@gateway/ollama/chat"
           timeout: 12.0
       arduino_serial:
         esp_base_url: "http://10.88.255.55:8080"
@@ -83,7 +83,7 @@ runtime_profile:
           model: "qwen3-vl:8b"
           timeout_s: 18
         ollama:
-          endpoint: "http://127.0.0.1:8080/ollama/chat"
+          endpoint: "@gateway/ollama/chat"
           model: "qwen3.5:9b"
           timeout: 12.0
       arduino_serial:
@@ -99,7 +99,7 @@ ollama_service:
     default: sentry
     dir: modules/ollama/config/personalities
   actions:
-    endpoint: http://localhost:8080/autonomy/apply_actions
+    endpoint: "@gateway/autonomy/apply_actions"
     default_apply: true
     timeout: 1.5
   translation:
@@ -114,7 +114,8 @@ vlm_bridge:
     port: 8101
   vision:
     processing_mode: local
-    camera_source: "http://127.0.0.1:8080/camera/video"
+    camera_source: "@gateway/camera/video"
+    context_max_age_s: 45
     confidence_threshold: 0.5
     face_match:
       ratio_test: 0.72
@@ -163,7 +164,7 @@ vlm_bridge:
   robot:
     host: "localhost"
   ollama:
-    endpoint: "http://localhost:8080/ollama/chat"
+    endpoint: "@gateway/ollama/chat"
     model: "qwen3.5:9b"
     timeout: 12.0
     num_predict: 160
@@ -179,12 +180,12 @@ vlm_bridge:
     endpoint: "http://localhost:8083/speak/say"
   translation:
     enabled: false
-    endpoint: "http://localhost:8080/ollama/translate"
+    endpoint: "@gateway/ollama/translate"
     source_lang: auto
     target_lang: tr
     timeout: 1.5
   actions:
-    endpoint: "http://localhost:8080/autonomy/apply_actions"
+    endpoint: "@gateway/autonomy/apply_actions"
     default_apply: true
     timeout: 1.5
 
@@ -245,7 +246,7 @@ speak:
       speaker_wav: null
   liveliness:
     enabled: true
-    interactions_base_url: http://localhost:8080/interactions
+    interactions_base_url: "@gateway/interactions"
     speech_effect:
       name: PULSE
       tone_effect_map:
@@ -318,12 +319,17 @@ speech:
       slew_deg_per_s: 120.0
       energy_threshold: 1000
 
+actions:
+  gateway_base_url: "http://127.0.0.1:8080"
+  http_timeout_s: 2.5
+
 tri_layer:
   enabled: true
   router:
     max_subagents: 3
     default_modules:
-      - vlm_bridge
+      - autonomy
+      - agent_core
   subagent:
     max_steps: 4
   persona:

--- a/modules/agent_core/services/agent.py
+++ b/modules/agent_core/services/agent.py
@@ -52,6 +52,19 @@ class AgentOrchestrator:
         self.config = config
         self.autonomy_client = autonomy_client
 
+        actions_cfg = config.get("actions", {}) if isinstance(config.get("actions", {}), dict) else {}
+        try:
+            from modules.gateway.url import resolve_config_url, resolve_gateway_base_url
+
+            default_gw = resolve_gateway_base_url(self.config)
+            raw_gw = str(actions_cfg.get("gateway_base_url", default_gw)).strip()
+            self._gateway_base_url = resolve_config_url(raw_gw, default_gw).rstrip("/")
+        except Exception:
+            self._gateway_base_url = str(
+                actions_cfg.get("gateway_base_url", "http://127.0.0.1:8080")
+            ).rstrip("/")
+        self._action_http_timeout_s = float(actions_cfg.get("http_timeout_s", 2.5))
+
         # LLM settings
         agent_cfg = config.get("agent", {})
         self.model = agent_cfg.get("model", "llama3.2:3b-q4_K_M")
@@ -149,21 +162,18 @@ class AgentOrchestrator:
             tool_execution_arbiter=self.tool_execution_arbiter,
             vision_arbiter=self.vision_arbiter,
             vlm_ask_timeout_s=float((config.get("tool_execution", {}) or {}).get("timeout_s", 22.0)),
+            gateway_base_url=self._gateway_base_url,
         )
 
         # Background threads
         self.sensor_loop = SensorFeedbackLoop(self.world_state, client=autonomy_client)
         self.idle_system = IdleBehaviorSystem(self, client=autonomy_client)
-        if self.autonomy_client and hasattr(self.autonomy_client, "set_speech_tracking"):
+        if self.autonomy_client and hasattr(self.autonomy_client, "set_stt_suppressed"):
             self.speech_arbiter.set_tts_state_callback(
-                lambda active: self.autonomy_client.set_speech_tracking(not bool(active))
+                lambda active: self.autonomy_client.set_stt_suppressed(bool(active))
             )
         if self.autonomy_client and hasattr(self.autonomy_client, "stop_speaking"):
             self.speech_arbiter.set_stop_playback_fn(self.autonomy_client.stop_speaking)
-        # Gateway base URL for HTTP-fronted arbiter actions (head/vision/follow).
-        actions_cfg = config.get("actions", {}) if isinstance(config.get("actions", {}), dict) else {}
-        self._gateway_base_url = str(actions_cfg.get("gateway_base_url", "http://127.0.0.1:8080")).rstrip("/")
-        self._action_http_timeout_s = float(actions_cfg.get("http_timeout_s", 2.5))
         self._register_action_handlers()
 
         self.last_run = 0.0
@@ -183,6 +193,8 @@ class AgentOrchestrator:
         default_modules = router_cfg.get("default_modules", ["autonomy", "agent_core"])
         if not isinstance(default_modules, list):
             default_modules = ["autonomy", "agent_core"]
+        if not self._camera_input_available():
+            default_modules = [m for m in default_modules if str(m).strip().lower() != "vlm_bridge"]
 
         profile_overrides = tri_cfg.get("profiles") if isinstance(tri_cfg.get("profiles"), dict) else None
         self.subagent_profiles = build_subagent_profiles(profile_overrides)
@@ -502,6 +514,21 @@ class AgentOrchestrator:
             else:
                 plan.append({"module": m, "goal": "Execute domain-specific reasoning."})
         return plan
+
+    def _camera_input_available(self) -> bool:
+        try:
+            from modules.gateway.url import gateway_url, resolve_gateway_base_url
+
+            base = resolve_gateway_base_url()
+            import requests
+
+            resp = requests.get(gateway_url(base, "/camera/healthz"), timeout=0.35)
+            if resp.status_code != 200:
+                return False
+            data = resp.json() if resp.content else {}
+            return bool((data or {}).get("ok", False))
+        except Exception:
+            return False
 
     def _resolve_ollama_base_url(self, agent_cfg: Dict[str, Any]) -> str:
         llm_cfg = self.config.get("llm", {}) or {}

--- a/modules/agent_core/services/tools.py
+++ b/modules/agent_core/services/tools.py
@@ -19,6 +19,7 @@ class ToolRegistry:
         tool_execution_arbiter=None,
         vision_arbiter=None,
         vlm_ask_timeout_s: float = 22.0,
+        gateway_base_url: str = "",
     ):
         self.client = client
         self.memory = memory
@@ -28,6 +29,16 @@ class ToolRegistry:
         self.tool_execution_arbiter = tool_execution_arbiter
         self.vision_arbiter = vision_arbiter
         self.vlm_ask_timeout_s = float(vlm_ask_timeout_s)
+        if gateway_base_url:
+            gw = str(gateway_base_url).rstrip("/")
+        else:
+            try:
+                from modules.gateway.url import resolve_gateway_base_url
+
+                gw = resolve_gateway_base_url()
+            except Exception:
+                gw = "http://127.0.0.1:8080"
+        self._gateway_base_url = gw
         self.status_hook: Optional[Callable[[Dict[str, Any]], None]] = None
 
         self.tools: Dict[str, Callable] = {}
@@ -37,11 +48,32 @@ class ToolRegistry:
 
     # ── Vision arbitration helpers ───────────────────────────────────
     _VLM_TOOL_NAMES: frozenset = frozenset({
+        "get_vision",
         "get_visual_context",
         "describe_scene",
         "ask_vlm_about_scene",
         "focus_person",
     })
+
+    def _url(self, path: str) -> str:
+        return f"{self._gateway_base_url}/{str(path).lstrip('/')}"
+
+    def _camera_input_available(self) -> bool:
+        try:
+            import requests
+
+            resp = requests.get(self._url("camera/healthz"), timeout=0.5)
+            if resp.status_code != 200:
+                return False
+            data = resp.json()
+            if not isinstance(data, dict):
+                return False
+            return bool(data.get("ok")) and not bool(data.get("gave_up", False))
+        except Exception:
+            return False
+
+    def _vision_unavailable_message(self) -> str:
+        return "Kamera görüntüsü şu an kullanılamıyor; görme araçları devre dışı."
 
     def _acquire_vision(self, tool_name: str) -> bool:
         if self.vision_arbiter is None or tool_name not in self._VLM_TOOL_NAMES:
@@ -81,6 +113,13 @@ class ToolRegistry:
                     })
                     return f"Error executing {tool_name}: resource busy"
                 acquired = True
+            if tool_name in self._VLM_TOOL_NAMES and not self._camera_input_available():
+                self._emit_status({
+                    "type": "tool_error",
+                    "tool": tool_name,
+                    "error": "camera_unavailable",
+                })
+                return self._vision_unavailable_message()
             if not self._acquire_vision(tool_name):
                 self._emit_status({
                     "type": "tool_error",
@@ -613,7 +652,7 @@ class ToolRegistry:
             return "Error: Vision client disconnected."
         try:
             import requests
-            resp = requests.get("http://127.0.0.1:8080/vlm/context/latest", timeout=2.0)
+            resp = requests.get(self._url("vlm/context/latest"), timeout=2.0)
             if resp.status_code == 200:
                 data = resp.json()
                 if data.get("available"):
@@ -630,7 +669,7 @@ class ToolRegistry:
                         parts.append(f"Hazards: {hazards}")
                     parts.append(f"Importance: {ctx.get('importance_score', 0.0)}")
                     return " | ".join(parts) if parts else "Scene is empty."
-                refresh = requests.post("http://127.0.0.1:8080/vlm/context/refresh", timeout=8.0)
+                refresh = requests.post(self._url("vlm/context/refresh"), timeout=8.0)
                 if refresh.status_code == 200:
                     rdata = refresh.json()
                     rctx = rdata.get("context") or {}
@@ -648,7 +687,7 @@ class ToolRegistry:
             return "Error: Vision client disconnected."
         try:
             import requests
-            resp = requests.get("http://127.0.0.1:8080/vlm/context/latest", timeout=2.0)
+            resp = requests.get(self._url("vlm/context/latest"), timeout=2.0)
             if resp.status_code == 200:
                 data = resp.json()
                 ctx = data.get("context", {})
@@ -665,7 +704,7 @@ class ToolRegistry:
         try:
             import requests
             resp = requests.post(
-                "http://127.0.0.1:8080/vlm/person/remember",
+                self._url("vlm/person/remember"),
                 json={"name": name, "relationship": relationship, "recognition_level": recognition_level},
                 timeout=2.0,
             )
@@ -680,7 +719,7 @@ class ToolRegistry:
         try:
             import requests
             resp = requests.post(
-                "http://127.0.0.1:8080/vlm/person/relationship",
+                self._url("vlm/person/relationship"),
                 json={"person_id": person_id, "relationship": relationship, "recognition_level": recognition_level},
                 timeout=2.0,
             )
@@ -695,7 +734,7 @@ class ToolRegistry:
         try:
             import requests
             resp = requests.post(
-                "http://127.0.0.1:8080/vlm/ask",
+                self._url("vlm/ask"),
                 json={"question": question},
                 timeout=max(2.0, float(self.vlm_ask_timeout_s)),
             )
@@ -706,7 +745,7 @@ class ToolRegistry:
         except Exception as exc:
             try:
                 import requests
-                ctx_resp = requests.get("http://127.0.0.1:8080/vlm/context/latest", timeout=2.0)
+                ctx_resp = requests.get(self._url("vlm/context/latest"), timeout=2.0)
                 if ctx_resp.status_code == 200:
                     data = ctx_resp.json()
                     if data.get("available"):
@@ -723,7 +762,7 @@ class ToolRegistry:
         try:
             import requests
             resp = requests.post(
-                "http://127.0.0.1:8080/vlm/focus/person",
+                self._url("vlm/focus/person"),
                 json={"name": name},
                 timeout=2.0,
             )
@@ -738,7 +777,7 @@ class ToolRegistry:
         try:
             import requests
             resp = requests.post(
-                "http://127.0.0.1:8080/vlm/follow/owner/start",
+                self._url("vlm/follow/owner/start"),
                 timeout=2.0,
             )
             if resp.status_code == 200:
@@ -752,7 +791,7 @@ class ToolRegistry:
         try:
             import requests
             resp = requests.post(
-                "http://127.0.0.1:8080/vlm/follow/stop",
+                self._url("vlm/follow/stop"),
                 timeout=2.0,
             )
             if resp.status_code == 200:
@@ -768,7 +807,7 @@ class ToolRegistry:
         try:
             import requests
             resp = requests.post(
-                "http://127.0.0.1:8080/agent/actions/queue",
+                self._url("agent/actions/queue"),
                 json={
                     "type": action_type,
                     "priority": priority,
@@ -788,7 +827,7 @@ class ToolRegistry:
     def get_action_status(self) -> str:
         try:
             import requests
-            resp = requests.get("http://127.0.0.1:8080/agent/actions/status", timeout=2.0)
+            resp = requests.get(self._url("agent/actions/status"), timeout=2.0)
             if resp.status_code == 200:
                 return str(resp.json())
             return f"Action status failed: HTTP {resp.status_code}"
@@ -799,7 +838,7 @@ class ToolRegistry:
         try:
             import requests
             resp = requests.post(
-                "http://127.0.0.1:8080/agent/actions/cancel",
+                self._url("agent/actions/cancel"),
                 json={"action_id": str(action_id)},
                 timeout=2.0,
             )

--- a/modules/agent_core/tests/test_arbiter_chain.py
+++ b/modules/agent_core/tests/test_arbiter_chain.py
@@ -5,6 +5,7 @@ arbiter snapshot."""
 from __future__ import annotations
 
 from typing import Any, Dict, List
+from unittest.mock import patch
 
 from modules.agent_core.services.action_arbiter import ActionArbiter, ActionRequest
 from modules.agent_core.services.expression_arbiter import ExpressionArbiter
@@ -35,7 +36,8 @@ def test_vision_arbiter_blocks_concurrent_vlm_tools():
     registry = _build_registry(arbiter)
 
     arbiter.acquire("external", ttl_s=10.0)
-    result = registry.execute("describe_scene", {})
+    with patch.object(registry, "_camera_input_available", return_value=True):
+        result = registry.execute("describe_scene", {})
     assert "vision arbiter busy" in result
 
 

--- a/modules/agent_core/tests/test_config_loader_env.py
+++ b/modules/agent_core/tests/test_config_loader_env.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import pytest
+from unittest.mock import patch
 
 from modules.agent_core.config_loader import load_config
 
 
-def test_agent_core_load_config_enforces_strict_single_model_policy(tmp_path: Path):
+def test_agent_core_load_config_enforces_strict_single_model_policy(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("AGENT_OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("SENTRY_GATEWAY_URL", raising=False)
     cfg_file = tmp_path / "agent.yaml"
     cfg_file.write_text(
         """
@@ -18,6 +22,9 @@ agent:
 llm:
   provider: ollama
   model: qwen3.5:9b
+gateway:
+  host: 127.0.0.1
+  port: 11434
 """.strip(),
         encoding="utf-8",
     )
@@ -35,7 +42,8 @@ llm:
     assert cfg["ollama"]["model"] == "qwen3.5:9b"
 
 
-def test_agent_core_load_config_accepts_google_provider(tmp_path: Path):
+def test_agent_core_load_config_accepts_google_provider(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("AGENT_OLLAMA_BASE_URL", raising=False)
     cfg_file = tmp_path / "agent.yaml"
     cfg_file.write_text(
         """
@@ -54,7 +62,8 @@ google_ai_studio:
     assert cfg["agent"]["model"] == "gemini-3-flash-preview"
 
 
-def test_agent_core_load_config_rejects_non_qwen3_5_9b_model(tmp_path: Path):
+def test_agent_core_load_config_rejects_non_qwen3_5_9b_model(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("AGENT_OLLAMA_BASE_URL", raising=False)
     cfg_file = tmp_path / "agent.yaml"
     cfg_file.write_text(
         """

--- a/modules/animate/api/router.py
+++ b/modules/animate/api/router.py
@@ -17,9 +17,20 @@ def get_router(anim: xAnimateService) -> APIRouter:
 
     @r.post("/run")
     def run(name: str, speed: float = 1.0, loop: bool = Query(False)):
-        # run blocking in this thread for simplicity (caller should spawn)
-        ok = anim.run(name, speed=speed, loop=loop)
-        return {"ok": bool(ok)}
+        import threading
+
+        result = {"ok": False}
+
+        def _worker():
+            result["ok"] = bool(anim.run(name, speed=speed, loop=loop))
+
+        t = threading.Thread(target=_worker, daemon=True, name=f"animate-{name}")
+        t.start()
+        t.join(timeout=max(1.0, float(anim.cfg.get("run_timeout_s", 30.0))))
+        if t.is_alive():
+            anim.stop_run()
+            return {"ok": False, "error": "animation timeout"}
+        return {"ok": bool(result["ok"])}
 
     @r.post("/stop")
     def stop():

--- a/modules/arduino_serial/tests/test_smoke.py
+++ b/modules/arduino_serial/tests/test_smoke.py
@@ -1,0 +1,21 @@
+"""arduino_serial smoke tests."""
+
+
+def test_import_service():
+    from modules.arduino_serial.xArduinoSerialService import xArduinoSerialService
+
+    assert xArduinoSerialService is not None
+
+
+def test_config_loader():
+    from modules.arduino_serial.config_loader import load_config
+
+    cfg = load_config()
+    assert isinstance(cfg, dict)
+
+
+def test_contract_builders():
+    from modules.arduino_serial.contract import build_set_servo_cmd, SERVO_INDEX_PAN
+
+    cmd = build_set_servo_cmd(SERVO_INDEX_PAN, 90)
+    assert isinstance(cmd, dict)

--- a/modules/autonomy/config/config.yml
+++ b/modules/autonomy/config/config.yml
@@ -29,21 +29,21 @@ defaults:
       polar_blue: [90, 150, 255]
 
 endpoints:
-  arduino: "http://localhost:8080/arduino"
-  neopixel: "http://localhost:8080/neopixel"
-  speak: "http://localhost:8080/speak"
-  ollama: "http://localhost:8080/ollama"
-  speech: "http://localhost:8080/speech"
-  interactions: "http://localhost:8080/interactions"
-  oled_faces: "http://localhost:8080/oled_faces"
-  state_manager: "http://localhost:8080/state"
-  animate: "http://localhost:8080/animate"
-  vlm: "http://localhost:8080/vlm"
-  vision: "http://localhost:8080/vlm"
-  camera: "http://localhost:8080/camera"
-  notifier: "http://localhost:8080/notify"
-  autonomy: "http://localhost:8080/autonomy"
-  agent_core: "http://localhost:8080/agent"
+  arduino: "@gateway/arduino"
+  neopixel: "@gateway/neopixel"
+  speak: "@gateway/speak"
+  ollama: "@gateway/ollama"
+  speech: "@gateway/speech"
+  interactions: "@gateway/interactions"
+  oled_faces: "@gateway/oled_faces"
+  state_manager: "@gateway/state"
+  animate: "@gateway/animate"
+  vlm: "@gateway/vlm"
+  vision: "@gateway/vlm"
+  camera: "@gateway/camera"
+  notifier: "@gateway/notify"
+  autonomy: "@gateway/autonomy"
+  agent_core: "@gateway/agent"
 
 behaviors:
   idle:
@@ -364,6 +364,6 @@ owner:
     - "delete"
   # Note: Kharuun-specific irreversible triggers removed.
   rfid:
-    endpoint: "http://localhost:8080/arduino/rfid/authorize"
+    endpoint: "@gateway/arduino/rfid/authorize"
     grace_s: 120
     poll_interval_s: 15

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -31,6 +31,8 @@ except ImportError:
 
 logger = logging.getLogger("autonomy")
 
+_PAUSED_OPERATIONAL = frozenset({"sleep", "maintenance", "paused", "off", "shutdown", "resting"})
+
 
 class AutonomyBrain(
     AnimationSupportMixin,
@@ -213,7 +215,18 @@ class AutonomyBrain(
         except Exception:
             pass
 
+    def _companion_paused(self) -> bool:
+        if bool(self.state.get("is_sleeping")):
+            return True
+        try:
+            op = self.client.get_operational_mode()
+            return str(op).strip().lower() in _PAUSED_OPERATIONAL
+        except Exception:
+            return False
+
     def _sense_speech_text(self):
+        if self._companion_paused():
+            return
         try:
             speech = self.client.get_last_speech()
             if speech and speech.get("final") and speech.get("text"):
@@ -221,6 +234,8 @@ class AutonomyBrain(
                 lang = str(speech.get("language") or self.state.get("last_speech_language") or "tr")
                 elapsed = time.time() - self.state["last_speech_time"]
                 if text != self.state["last_speech_text"] and elapsed > self._speech_min_interval_s:
+                    if self._speech_busy:
+                        return
                     self.state["last_speech_text"] = text
                     self.state["last_speech_time"] = time.time()
                     self.state["last_speech_language"] = lang
@@ -247,7 +262,7 @@ class AutonomyBrain(
         self._last_emotion_sync_ts = now
         self.state["last_emotion"] = target_emotion
         self.client.update_emotions([target_emotion])
-        self.client.push_interaction_event(f"emotion.{target_emotion}")
+        self.client.push_interaction_event(f"emotion:{target_emotion}")
         self._apply_emotion_visual_state(target_emotion)
         # Try to run a matching scene for the dominant emotion (e.g. emotion_joy)
         try:
@@ -266,6 +281,14 @@ class AutonomyBrain(
         now = time.time()
         self._ensure_timeline_day()
         self._refresh_rfid_authorization()
+
+        if self._companion_paused() and not self.state.get("is_sleeping"):
+            try:
+                op = self.client.get_operational_mode()
+                if str(op).strip().lower() in _PAUSED_OPERATIONAL:
+                    self.state["is_sleeping"] = str(op).strip().lower() == "sleep"
+            except Exception:
+                pass
 
         self._check_sleep_cycle()
         if self.state["is_sleeping"]:

--- a/modules/autonomy/services/brain_parts/responses.py
+++ b/modules/autonomy/services/brain_parts/responses.py
@@ -178,10 +178,10 @@ class ResponseTagMixin:
 				elif isinstance(name, str) and name:
 					self.client.oled_show(name)
 			elif kind == "arduino":
-				cmd = attrs.get("cmd")
-				if isinstance(cmd, str) and cmd:
-					payload = dict(attrs)
-					self.client.arduino_send(payload)
+				logger.warning(
+					"LLM arduino tag ignored (use contract builders via tools); attrs=%s",
+					list(attrs.keys()) if isinstance(attrs, dict) else attrs,
+				)
 			elif kind in {"stand", "sit", "home", "zero_now"}:
 				self.client.robot_command(kind)
 			elif kind in {"ultra_read", "imu_read", "rfid_last"}:

--- a/modules/autonomy/services/client.py
+++ b/modules/autonomy/services/client.py
@@ -22,12 +22,27 @@ _SENSOR_COMMANDS = {"ultra_read", "imu_read", "rfid_last"}
 
 class ServiceClient:
     def __init__(self, base_urls, config=None):
-        self.urls = base_urls
+        try:
+            from modules.gateway.url import gateway_url, resolve_gateway_base_url, rewrite_loopback_urls
+
+            base = resolve_gateway_base_url()
+            self.urls = rewrite_loopback_urls(dict(base_urls or {}), base)
+            self.urls.setdefault("agent_core", gateway_url(base, "/agent"))
+        except Exception:
+            self.urls = dict(base_urls or {})
         cfg = config or {}
         self.speech_quiet_cfg = dict(cfg.get("speech_quiet_hours", {}))
         self.offline_cfg = dict(cfg.get("offline_mode", {}))
         self.request_timeouts = dict(cfg.get("request_timeouts", {}))
         self._availability_cache = {}
+
+    def _agent_core_url(self) -> str:
+        try:
+            from modules.gateway.url import gateway_url, resolve_gateway_base_url
+
+            return str(self.urls.get("agent_core") or gateway_url(resolve_gateway_base_url(), "/agent"))
+        except Exception:
+            return str(self.urls.get("agent_core") or "http://127.0.0.1:8080/agent")
 
     def _post(self, service, endpoint, json=None, params=None, timeout_s=None):
         url = self.urls.get(service)
@@ -131,24 +146,18 @@ class ServiceClient:
         return self._post("arduino", "/send", payload)
 
     def set_neopixel(self, effect, emotions=None, color=None, duration=None):
-        payload = {"name": effect}
-        if emotions:
-            payload["emotions"] = emotions
-        if color and len(color) == 3:
-            payload["r"], payload["g"], payload["b"] = color
+        name = str(effect or "PULSE").strip().upper() or "PULSE"
+        duration_ms = 800
         if duration is not None:
-            payload["duration"] = duration
-        return self._post("neopixel", "/animate", json=payload)
+            try:
+                duration_ms = max(200, int(float(duration) * 1000))
+            except (TypeError, ValueError):
+                duration_ms = 800
+        return self.set_interaction_effect(name, duration_ms=duration_ms, force=True)
 
     def set_neopixel_segment_effect(self, segment: str, effect: str, color=None, emotions=None, iterations=None):
-        payload = {"name": effect, "segment": str(segment)}
-        if emotions:
-            payload["emotions"] = emotions
-        if color and len(color) == 3:
-            payload["r"], payload["g"], payload["b"] = color
-        if iterations is not None:
-            payload["iterations"] = int(iterations)
-        return self._post("neopixel", "/animate", payload)
+        _ = (segment, color, emotions, iterations)
+        return self.set_neopixel(effect)
 
     def fill_neopixel_segment_color(self, segment: str, r: int, g: int, b: int):
         url = self.urls.get("neopixel")
@@ -279,6 +288,15 @@ class ServiceClient:
         endpoint = "/track/start" if enabled else "/track/stop"
         return self._post("speech", endpoint)
 
+    def set_stt_suppressed(self, suppressed: bool):
+        return self._post("speech", "/stt/suppress", {"enabled": bool(suppressed)}, timeout_s=0.25)
+
+    def get_operational_mode(self) -> str:
+        data = self._get("state_manager", "/get")
+        if isinstance(data, dict):
+            return str(data.get("operational", "idle")).strip().lower() or "idle"
+        return "idle"
+
     def stop_speaking(self):
         return self._post("speak", "/stop", timeout_s=0.35)
 
@@ -286,7 +304,12 @@ class ServiceClient:
         return self._post("speech", "/start", timeout_s=0.35)
 
     def interrupt_agent_speech(self):
-        base = str(self.urls.get("agent_core") or "http://127.0.0.1:8080/agent").rstrip("/")
+        try:
+            from modules.gateway.url import gateway_url, resolve_gateway_base_url
+
+            base = str(self.urls.get("agent_core") or gateway_url(resolve_gateway_base_url(), "/agent")).rstrip("/")
+        except Exception:
+            base = str(self.urls.get("agent_core") or "http://127.0.0.1:8080/agent").rstrip("/")
         try:
             resp = requests.post(f"{base}/speech/interrupt", timeout=0.35)
             return resp.json() if resp.status_code == 200 else None
@@ -340,10 +363,22 @@ class ServiceClient:
             self._availability_cache[svc] = (now, False)
             return False
 
-        endpoint = "/status" if svc == "speak" else "/healthz"
+        endpoint = "/status" if svc in ("speak", "speech") else "/healthz"
         try:
             resp = requests.get(f"{url}{endpoint}", timeout=0.6)
             ok = resp.status_code == 200
+            if ok and svc == "ollama":
+                try:
+                    payload = resp.json()
+                    ok = bool(payload.get("ok", False))
+                except Exception:
+                    ok = False
+            elif ok and svc == "speak":
+                try:
+                    payload = resp.json()
+                    ok = bool(payload.get("ready", False))
+                except Exception:
+                    ok = False
         except Exception:
             ok = False
         self._availability_cache[svc] = (now, ok)
@@ -433,7 +468,7 @@ class ServiceClient:
         if payload is None:
             payload = {}
         # Try routing through agent core endpoint (assuming gateway exposes it at /agent)
-        url = self.urls.get("agent_core") or "http://127.0.0.1:8080/agent"
+        url = self._agent_core_url()
         try:
             resp = requests.post(f"{url}/actions/queue", json={
                 "type": action_type,
@@ -449,7 +484,7 @@ class ServiceClient:
     def emit_agent_event(self, event_type: str, payload: dict | None = None):
         if payload is None:
             payload = {}
-        url = self.urls.get("agent_core") or "http://127.0.0.1:8080/agent"
+        url = self._agent_core_url()
         try:
             resp = requests.post(
                 f"{url}/events",

--- a/modules/autonomy/tests/test_smoke.py
+++ b/modules/autonomy/tests/test_smoke.py
@@ -1,0 +1,21 @@
+"""autonomy smoke tests."""
+
+
+def test_import_brain():
+    from modules.autonomy.services.brain import AutonomyBrain
+
+    assert AutonomyBrain is not None
+
+
+def test_config_loader():
+    from modules.autonomy.config_loader import load_config
+
+    cfg = load_config()
+    assert isinstance(cfg, dict)
+
+
+def test_service_client_urls():
+    from modules.autonomy.services.client import ServiceClient
+
+    client = ServiceClient({"state_manager": "http://127.0.0.1:8080/state"})
+    assert client.urls["state_manager"].endswith("/state")

--- a/modules/config_center/agent_yaml_loader.py
+++ b/modules/config_center/agent_yaml_loader.py
@@ -56,9 +56,12 @@ def load_agent_config(explicit_path: Optional[str | os.PathLike[str]] = None) ->
         raise ValueError(f"agent.yaml must be a mapping at top-level: {cfg_path}")
 
     from modules.config_center.google_keys import inject_google_api_key
+    from modules.gateway.url import gateway_base_from_agent_cfg, rewrite_loopback_urls
 
     cfg = apply_runtime_profile(raw)
-    return inject_google_api_key(cfg)
+    cfg = inject_google_api_key(cfg)
+    base = gateway_base_from_agent_cfg(cfg)
+    return rewrite_loopback_urls(cfg, base)
 
 
 def require_dict_section(cfg: Dict[str, Any], section: str) -> Dict[str, Any]:

--- a/modules/diagnostics/services/selftest.py
+++ b/modules/diagnostics/services/selftest.py
@@ -46,7 +46,7 @@ def run_http_checks(
     try:
         import httpx  # type: ignore
     except Exception:
-        return {"ok": True, "note": "httpx not installed; skipped"}
+        return {"ok": False, "note": "httpx not installed", "failed": ["httpx"]}
 
     normalized = _normalize_checks(checks)
     out: Dict[str, Any] = {"ok": True, "failed": [], "degraded": []}
@@ -70,8 +70,21 @@ def run_http_checks(
                 resp = client.request(method, path, timeout=max(0.1, timeout_ms / 1000.0))
                 latency_ms = int((time.perf_counter() - t0) * 1000)
                 status_ok = resp.status_code == 200
+                body_ok = True
+                if path.endswith("/speak/status"):
+                    try:
+                        payload = resp.json()
+                        body_ok = bool(payload.get("ready", False))
+                    except Exception:
+                        body_ok = False
+                elif path.endswith("/speech/status"):
+                    try:
+                        payload = resp.json()
+                        body_ok = bool(payload.get("model_ready", payload.get("listening", False)))
+                    except Exception:
+                        body_ok = False
                 latency_ok = latency_ms <= latency_warn_ms
-                ok = bool(status_ok and latency_ok)
+                ok = bool(status_ok and body_ok and latency_ok)
                 out[name] = {
                     "ok": ok,
                     "critical": critical,

--- a/modules/gateway/__init__.py
+++ b/modules/gateway/__init__.py
@@ -1,1 +1,1 @@
-from .xGatewayService import create_app  # type: ignore
+"""Gateway shared helpers."""

--- a/modules/gateway/api/router.py
+++ b/modules/gateway/api/router.py
@@ -21,8 +21,12 @@ def get_router(cfg: Dict[str, Any], started: Dict[str, object]) -> APIRouter:
         try:
             for name in started.keys():
                 path = None
-                if name in ("arduino", "esp_link", "neopixel", "piservo", "telemetry", "diagnostics", "state_manager", "scheduler", "notifier", "calibration", "config_center", "hardware"):
-                    path = f"/{name}/healthz" if name not in ("telemetry", "diagnostics") else f"/{name}/healthz"
+                if name == "notifier":
+                    path = "/notify/healthz"
+                elif name == "state_manager":
+                    path = "/state/healthz"
+                elif name in ("arduino", "esp_link", "neopixel", "piservo", "telemetry", "diagnostics", "scheduler", "calibration", "config_center", "hardware"):
+                    path = f"/{name}/healthz"
                 elif name == "camera":
                     path = "/camera/healthz"
                 elif name in ("speak", "speech", "wakeword"):

--- a/modules/gateway/config/config.yml
+++ b/modules/gateway/config/config.yml
@@ -34,7 +34,8 @@ speech:
   listening: false
 
 security:
-  enabled: false
+  enabled: true
+  trust_loopback: true
   api_key_header: X-API-Key
   role_header: X-Role
   api_keys: []

--- a/modules/gateway/services/bootstrap.py
+++ b/modules/gateway/services/bootstrap.py
@@ -405,7 +405,13 @@ def _include_vlm_bridge(app: FastAPI, started: Dict[str, object]) -> None:
             logger.warning("vlm_bridge stream start skipped: %s", exc)
     # Mount router and expose processor so other modules can reference it
     try:
-        app.include_router(get_vlm_router(processor, started.get("arduino")))
+        app.include_router(
+            get_vlm_router(
+                processor,
+                started.get("arduino"),
+                gateway_base_url=str(started.get("gateway_base_url", "")),
+            )
+        )
     except Exception:
         # If router mount fails, continue in degraded mode
         pass
@@ -417,15 +423,19 @@ def _include_interactions(app: FastAPI, started: Dict[str, object], cfg: Dict[st
     from modules.interactions.api.router import get_router as get_inter_router  # type: ignore
     from modules.interactions.config_loader import load_config as load_inter_cfg  # type: ignore
     from modules.interactions.services.engine import InteractionEngine  # type: ignore
-    icfg = load_inter_cfg(None, overrides=_agent_section("interactions") or None)
-    # Force interactions to talk to gateway's neopixel endpoint instead of standalone 8092
-    try:
-        port = int(cfg.get("server", {}).get("port", 8080))
-        icfg.setdefault("adapter", {})["http_base_url"] = f"http://127.0.0.1:{port}/neopixel"
-    except Exception:
-        pass
-    # If neopixel runner is already started in-process, pass it to InteractionEngine
-    eng = InteractionEngine(icfg, neo_client=started.get("neopixel"))
+    from modules.gateway.url import gateway_url, rewrite_loopback_urls  # type: ignore
+
+    base = str(started.get("gateway_base_url", "http://127.0.0.1:8080"))
+    icfg = rewrite_loopback_urls(
+        load_inter_cfg(None, overrides=_agent_section("interactions") or None),
+        base,
+    )
+    icfg.setdefault("adapter", {})["http_base_url"] = gateway_url(base, "/neopixel")
+    eng = InteractionEngine(
+        icfg,
+        neo_client=started.get("neopixel"),
+        expression_arbiter=started.get("expression_arbiter"),
+    )
     if _should_autostart_services():
         eng.start()
     else:
@@ -435,9 +445,15 @@ def _include_interactions(app: FastAPI, started: Dict[str, object], cfg: Dict[st
 
 
 def _include_speak(app: FastAPI, started: Dict[str, object]) -> None:
+    from modules.gateway.url import gateway_url  # type: ignore
     from modules.speak.xSpeakService import SpeakService  # type: ignore
     from modules.speak.api.router import get_router as get_speak_router  # type: ignore
+
+    base = str(started.get("gateway_base_url", "http://127.0.0.1:8080"))
     svc = SpeakService()
+    liveliness = svc.cfg.get("liveliness", {}) if isinstance(svc.cfg.get("liveliness", {}), dict) else {}
+    liveliness["interactions_base_url"] = gateway_url(base, "/interactions")
+    svc.cfg["liveliness"] = liveliness
     started["speak"] = svc
     app.include_router(get_speak_router(svc))
     logger.info("module speak mounted")
@@ -474,14 +490,29 @@ def _include_speech(app: FastAPI, started: Dict[str, object]) -> None:
                 pass
     except Exception:
         pass
-    app.include_router(get_speech_router(svc))
+    app.include_router(get_speech_router(svc, gateway_base_url=str(started.get("gateway_base_url", ""))))
     logger.info("module speech mounted")
 
 
 def _include_wakeword(app: FastAPI, started: Dict[str, object]) -> None:
+    from modules.gateway.url import gateway_url  # type: ignore
     from modules.wakeword.xWakewordService import WakewordService  # type: ignore
     from modules.wakeword.api import get_router as get_wakeword_router  # type: ignore
+
+    from modules.wakeword.xWakewordService import WakewordActions  # type: ignore
+
+    base = str(started.get("gateway_base_url", "http://127.0.0.1:8080"))
     svc = WakewordService()
+    actions = dict(svc.cfg.get("actions", {}) or {})
+    actions.update({
+        "speech_start_url": gateway_url(base, "/speech/start"),
+        "speech_stop_url": gateway_url(base, "/speech/stop"),
+        "speak_stop_url": gateway_url(base, "/speak/stop"),
+        "agent_interrupt_url": gateway_url(base, "/agent/speech/interrupt"),
+        "speech_last_url": gateway_url(base, "/speech/last"),
+        "interactions_event_url": gateway_url(base, "/interactions/event"),
+    })
+    svc.actions = WakewordActions(actions)
     if _should_autostart_services():
         svc.start_background()
     else:
@@ -567,11 +598,10 @@ def _include_animate(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.animate.api.router import get_router as get_anim_router  # type: ignore
     ardu = started.get("arduino")
     anim_overrides = _agent_section("animate") or None
-    anim = (
-        xAnimateService(serial=ardu, config_overrides=anim_overrides)
-        if ardu is not None
-        else xAnimateService(config_overrides=anim_overrides)
-    )
+    if ardu is None:
+        logger.warning("animate skipped: arduino module not mounted (no duplicate serial)")
+        return
+    anim = xAnimateService(serial=ardu, config_overrides=anim_overrides)
     if _should_autostart_services() and hasattr(anim, "start"):
         try:
             anim.start()
@@ -590,8 +620,13 @@ def _include_piservo(app: FastAPI, started: Dict[str, object]) -> None:
     from modules.piservo.services.driver import ServoConfig  # type: ignore
     from modules.piservo.services.runner import EarRunner  # type: ignore
     pcfg = _merge_with_agent_section(load_piservo_cfg(None), "piservo")
-    left = ServoConfig(**pcfg.get("left", {"gpio": 12}))
-    right = ServoConfig(**pcfg.get("right", {"gpio": 13}))
+    left_raw = dict(pcfg.get("left", {"gpio": 12}))
+    right_raw = dict(pcfg.get("right", {"gpio": 13}))
+    if started.get("arduino") is not None:
+        left_raw.pop("arduino_index", None)
+        right_raw.pop("arduino_index", None)
+    left = ServoConfig(**left_raw)
+    right = ServoConfig(**right_raw)
     ears = EarRunner(left_cfg=left, right_cfg=right)
     started["piservo"] = ears
     app.include_router(get_piservo_router(ears))
@@ -599,9 +634,17 @@ def _include_piservo(app: FastAPI, started: Dict[str, object]) -> None:
 
 
 def _include_autonomy(app: FastAPI, started: Dict[str, object]) -> None:
+    from modules.gateway.url import patch_service_endpoints  # type: ignore
     from modules.autonomy.xAutonomyService import xAutonomyService  # type: ignore
     from modules.autonomy.api.router import get_router as get_autonomy_router  # type: ignore
-    svc = xAutonomyService(config_overrides=_agent_section("autonomy") or None)
+
+    autonomy_overrides = dict(_agent_section("autonomy") or {})
+    endpoints = dict(autonomy_overrides.get("endpoints", {}) or {})
+    autonomy_overrides["endpoints"] = patch_service_endpoints(
+        endpoints,
+        str(started.get("gateway_base_url", "http://127.0.0.1:8080")),
+    )
+    svc = xAutonomyService(config_overrides=autonomy_overrides)
     if _should_autostart_services():
         svc.start()
     else:
@@ -679,7 +722,10 @@ def _include_oled_faces(app: FastAPI, started: Dict[str, object]) -> None:
     state_store = started.get("state_manager")
     interactions = started.get("interactions")
 
-    svc = xOledFacesService(state_store=state_store)
+    svc = xOledFacesService(
+        state_store=state_store,
+        expression_arbiter=started.get("expression_arbiter"),
+    )
 
     if interactions is not None and hasattr(interactions, "register_event_handler"):
         try:
@@ -697,9 +743,29 @@ def _include_oled_faces(app: FastAPI, started: Dict[str, object]) -> None:
     logger.info("module oled_faces mounted")
 
 
+def _init_gateway_base_url(started: Dict[str, object], cfg: Dict[str, Any]) -> str:
+    from modules.gateway.url import resolve_gateway_base_url  # type: ignore
+
+    base = resolve_gateway_base_url(cfg, started=started)
+    started["gateway_base_url"] = base
+    try:
+        from modules.agent_core.services.expression_arbiter import ExpressionArbiter  # type: ignore
+
+        started.setdefault("expression_arbiter", ExpressionArbiter())
+    except Exception as exc:
+        logger.warning("expression arbiter init skipped: %s", exc)
+    return base
+
+
+_CRITICAL_MODULES = frozenset(
+    {"arduino", "camera", "autonomy", "agent_core", "speech", "wakeword", "speak", "ollama"}
+)
+
+
 def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
     """Start and wire modules according to cfg.include and return started dict."""
     started: Dict[str, object] = {}
+    gateway_base = _init_gateway_base_url(started, cfg)
 
     include = cfg.get("include", {})
 
@@ -707,7 +773,8 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
         try:
             fn()
         except Exception as exc:
-            logger.warning("module %s failed to mount: %s", name or fn.__name__, exc)
+            log = logger.error if name in _CRITICAL_MODULES else logger.warning
+            log("module %s failed to mount: %s", name or fn.__name__, exc)
 
     # social_db is the persistence backbone for identity, mood and rituals; mount first.
     if include.get("social_db", True):
@@ -717,6 +784,9 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
         _try(lambda: _include_arduino(app, started), "arduino")
     if include.get("esp_link"):
         _try(lambda: _include_esp_link(app, started), "esp_link")
+    # Camera before VLM so HTTP healthz / MJPEG exist before stream capture starts.
+    if include.get("camera"):
+        _try(lambda: _include_camera(app, started), "camera")
     if include.get("vlm_bridge"):
         _try(lambda: _include_vlm_bridge(app, started), "vlm_bridge")
     if include.get("neopixel"):
@@ -725,16 +795,14 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
         _try(lambda: _include_interactions(app, started, cfg), "interactions")
     if include.get("speak"):
         _try(lambda: _include_speak(app, started), "speak")
-    if include.get("speech"):
-        _try(lambda: _include_speech(app, started), "speech")
     if include.get("wakeword"):
         _try(lambda: _include_wakeword(app, started), "wakeword")
+    if include.get("speech"):
+        _try(lambda: _include_speech(app, started), "speech")
     if include.get("ollama"):
         _try(lambda: _include_ollama(app, started), "ollama")
     if include.get("logs"):
         _try(lambda: _include_logs(app, started), "logs")
-    if include.get("camera"):
-        _try(lambda: _include_camera(app, started), "camera")
     if include.get("animate"):
         _try(lambda: _include_animate(app, started), "animate")
     if include.get("piservo"):
@@ -819,9 +887,14 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
             )
             Scheduler = __import__("modules.scheduler.services.runner", fromlist=["Scheduler"]).Scheduler
             get_router = __import__("modules.scheduler.api.router", fromlist=["get_router"]).get_router
+            gw_base = str(
+                cfg_sc.get("gateway_base_url")
+                or started.get("gateway_base_url")
+                or f"http://127.0.0.1:{int(cfg.get('server', {}).get('port', 8080))}"
+            )
             sched = Scheduler(
                 jobs=cfg_sc.get("jobs", []),
-                gateway_base_url=str(cfg_sc.get("gateway_base_url", "http://127.0.0.1:8080")),
+                gateway_base_url=gw_base,
             )
             if _should_autostart_services():
                 sched.start()
@@ -961,6 +1034,24 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
             logger.info("onsensor bus -> vlm_bridge subscriber attached")
         except Exception as exc:
             logger.warning("onsensor bus attach failed: %s", exc)
+
+    interactions = started.get("interactions")
+    piservo = started.get("piservo")
+    if interactions is not None and piservo is not None and hasattr(interactions, "register_event_handler"):
+        def _piservo_on_interaction(evt: str, data: Dict[str, Any]) -> None:
+            if evt != "wakeword.detected":
+                return
+            try:
+                if hasattr(piservo, "gesture"):
+                    piservo.gesture("wakeword")
+            except Exception:
+                pass
+
+        try:
+            interactions.register_event_handler(_piservo_on_interaction)
+            logger.info("interactions wakeword -> piservo gesture bridge mounted")
+        except Exception as exc:
+            logger.warning("piservo interactions bridge mount failed: %s", exc)
 
     return started
 

--- a/modules/gateway/tests/test_smoke.py
+++ b/modules/gateway/tests/test_smoke.py
@@ -1,2 +1,12 @@
-def test_placeholder():
-    assert True
+def test_bootstrap_import():
+    from modules.gateway.services.bootstrap import bootstrap
+
+    assert callable(bootstrap)
+
+
+def test_config_loader():
+    from modules.gateway.config_loader import load_config
+
+    cfg = load_config()
+    assert isinstance(cfg, dict)
+    assert "include" in cfg

--- a/modules/gateway/tests/test_url_rewrite.py
+++ b/modules/gateway/tests/test_url_rewrite.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from modules.agent_core.services.expression_arbiter import ExpressionArbiter
+from modules.gateway.url import (
+    gateway_base_from_agent_cfg,
+    resolve_config_url,
+    rewrite_loopback_urls,
+)
+
+
+def test_resolve_config_url_gateway_alias():
+    base = "http://127.0.0.1:9090"
+    assert resolve_config_url("@gateway/camera/video", base) == "http://127.0.0.1:9090/camera/video"
+    assert (
+        resolve_config_url("http://localhost:8080/ollama/chat", base)
+        == "http://127.0.0.1:9090/ollama/chat"
+    )
+
+
+def test_rewrite_nested_config():
+    base = "http://127.0.0.1:8080"
+    cfg = {"actions": {"endpoint": "@gateway/autonomy/apply_actions"}}
+    out = rewrite_loopback_urls(cfg, base)
+    assert out["actions"]["endpoint"] == "http://127.0.0.1:8080/autonomy/apply_actions"
+
+
+def test_gateway_base_from_agent_cfg():
+    cfg = {"actions": {"gateway_base_url": "http://192.168.1.50:8080"}}
+    assert gateway_base_from_agent_cfg(cfg) == "http://192.168.1.50:8080"
+
+
+def test_expression_arbiter_blocks_second_owner():
+    arb = ExpressionArbiter()
+    assert arb.claim_lights("speak") is True
+    assert arb.claim_lights("autonomy") is False
+    assert arb.claim_oled("oled_faces") is True
+    assert arb.claim_oled("interactions") is False
+    arb.release("speak")
+    assert arb.claim_lights("autonomy") is True

--- a/modules/gateway/url.py
+++ b/modules/gateway/url.py
@@ -1,0 +1,134 @@
+"""Resolve gateway base URL for loopback HTTP calls between modules."""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, Mapping, Optional
+
+_LOOPBACK_PREFIXES = (
+    "http://localhost:",
+    "http://127.0.0.1:",
+    "http://0.0.0.0:",
+)
+_GATEWAY_PATH_RE = re.compile(r"^@gateway(?=/|$)")
+
+
+def gateway_base_from_agent_cfg(cfg: Mapping[str, Any], *, port: int = 8080) -> str:
+    """Read gateway base from an already-loaded agent.yaml mapping (no reload)."""
+    actions = cfg.get("actions", {}) if isinstance(cfg.get("actions", {}), dict) else {}
+    explicit = str(actions.get("gateway_base_url", "") or "").strip().rstrip("/")
+    if explicit:
+        return explicit
+
+    for section in ("gateway", "server"):
+        block = cfg.get(section, {})
+        if isinstance(block, dict):
+            try:
+                port = int(block.get("port", port))
+            except (TypeError, ValueError):
+                pass
+            host = str(block.get("host", "127.0.0.1") or "127.0.0.1").strip()
+            if host in ("0.0.0.0", "::"):
+                host = "127.0.0.1"
+            return f"http://{host}:{int(port)}"
+
+    return f"http://127.0.0.1:{int(port)}"
+
+
+def resolve_gateway_base_url(
+    cfg: Optional[Mapping[str, Any]] = None,
+    *,
+    port: int = 8080,
+    started: Optional[Mapping[str, Any]] = None,
+) -> str:
+    if started is not None:
+        explicit = str(started.get("gateway_base_url", "") or "").strip().rstrip("/")
+        if explicit:
+            return explicit
+
+    env = str(os.environ.get("SENTRY_GATEWAY_URL", "") or "").strip().rstrip("/")
+    if env:
+        return env
+
+    if cfg is not None:
+        explicit = str(cfg.get("gateway_base_url", "") or "").strip().rstrip("/")
+        if explicit:
+            return explicit
+        return gateway_base_from_agent_cfg(cfg, port=port)
+
+    try:
+        from modules.config_center.agent_yaml_loader import load_agent_config  # type: ignore
+
+        return gateway_base_from_agent_cfg(load_agent_config())
+    except Exception:
+        pass
+
+    return f"http://127.0.0.1:{int(port)}"
+
+
+def gateway_url(base: str, path: str) -> str:
+    return f"{str(base).rstrip('/')}/{str(path).lstrip('/')}"
+
+
+def resolve_config_url(value: str, gateway_base: Optional[str] = None) -> str:
+    """Resolve @gateway/... aliases and loopback :8080 URLs to the active gateway base."""
+    raw = str(value or "").strip()
+    if not raw:
+        return raw
+    base = str(gateway_base or resolve_gateway_base_url()).rstrip("/")
+
+    if _GATEWAY_PATH_RE.match(raw):
+        path = raw[len("@gateway") :]
+        return gateway_url(base, path or "/")
+
+    for prefix in _LOOPBACK_PREFIXES:
+        if raw.lower().startswith(prefix):
+            suffix = raw.split(":", 2)[-1]
+            if "/" in suffix:
+                path = "/" + suffix.split("/", 1)[1]
+            else:
+                path = ""
+            return gateway_url(base, path)
+    return raw
+
+
+def rewrite_loopback_urls(obj: Any, gateway_base: str) -> Any:
+    """Recursively rewrite @gateway/ and loopback :8080 URLs in nested config dicts."""
+    base = str(gateway_base or "").rstrip("/")
+    if isinstance(obj, str):
+        return resolve_config_url(obj, base)
+    if isinstance(obj, dict):
+        return {k: rewrite_loopback_urls(v, base) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [rewrite_loopback_urls(v, base) for v in obj]
+    return obj
+
+
+def patch_service_endpoints(endpoints: Dict[str, Any], gateway_base: str) -> Dict[str, Any]:
+    """Rewrite autonomy-style endpoint map to use a single gateway base."""
+    base = str(gateway_base or "").rstrip("/")
+    if not base:
+        return endpoints
+
+    service_paths = {
+        "arduino": "/arduino",
+        "neopixel": "/neopixel",
+        "speak": "/speak",
+        "ollama": "/ollama",
+        "speech": "/speech",
+        "interactions": "/interactions",
+        "oled_faces": "/oled_faces",
+        "state_manager": "/state",
+        "animate": "/animate",
+        "vlm": "/vlm",
+        "vision": "/vlm",
+        "camera": "/camera",
+        "notifier": "/notify",
+        "autonomy": "/autonomy",
+        "agent_core": "/agent",
+    }
+
+    out = dict(endpoints or {})
+    for key, path_suffix in service_paths.items():
+        out[key] = f"{base}{path_suffix}"
+    return out

--- a/modules/gateway/xGatewayService.py
+++ b/modules/gateway/xGatewayService.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import inspect
 import logging
+import os
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from .config_loader import load_config
@@ -26,13 +27,25 @@ def _listify(value: object) -> list[str]:
     return [text] if text else []
 
 
+def _client_is_loopback(request) -> bool:
+    try:
+        host = str(getattr(request.client, "host", "") or "").strip().lower()
+    except Exception:
+        return False
+    return host in {"127.0.0.1", "::1", "localhost", "testclient"}
+
+
 def _build_security_policy(cfg: dict) -> dict:
     sec = cfg.get("security", {}) if isinstance(cfg.get("security", {}), dict) else {}
     api_keys = set(_listify(sec.get("api_keys", [])))
     admin_keys = set(_listify(sec.get("admin_keys", [])))
+    env_key = str(os.environ.get("SENTRY_API_KEY", "") or "").strip()
+    if env_key:
+        api_keys.add(env_key)
     valid_keys = set(api_keys) | set(admin_keys)
     return {
         "enabled": bool(sec.get("enabled", False)),
+        "trust_loopback": bool(sec.get("trust_loopback", True)),
         "api_key_header": str(sec.get("api_key_header", "X-API-Key")),
         "role_header": str(sec.get("role_header", "X-Role")),
         "exempt_prefixes": _listify(
@@ -143,6 +156,9 @@ def create_app(config_path: str | None = None) -> FastAPI:
 
             # Read-only access is left open by default; write operations require key.
             if method in {"GET", "HEAD"}:
+                return await call_next(request)
+
+            if security.get("trust_loopback", True) and _client_is_loopback(request):
                 return await call_next(request)
 
             key = request.headers.get(security["api_key_header"]) or request.query_params.get("api_key")

--- a/modules/interactions/config/config.yml
+++ b/modules/interactions/config/config.yml
@@ -8,7 +8,7 @@ adapter:
 
 monitor:
   arduino:
-    url: http://localhost:8080/arduino/healthz
+    url: "@gateway/arduino/healthz"
     interval_s: 5
     timeout_s: 0.4
 
@@ -64,20 +64,17 @@ rules:
     priority: medium
     cooldown_ms: 3000
 
+  - id: wakeword_detected
+    when: { event: wakeword.detected }
+    action: { effect: { name: TWINKLE, duration_ms: 700 } }
+    priority: critical
+    cooldown_ms: 800
+
   - id: speech_start
     when: { event: speech.start }
-    action: { effect: { name: RAINBOW_CYCLE, duration_ms: 1000 } }
+    action: { effect: { name: PULSE, duration_ms: 900 } }
     priority: high
-    cooldown_ms: 1000
-
-  - id: speech_start_cute
-    when: { event: speech.start }
-    # Play a visual effect and request a 'cute' sound from Arduino via an event payload.
-    action:
-      effect: { name: RAINBOW_CYCLE, duration_ms: 1000 }
-      arduino: { cute: happy }
-    priority: high
-    cooldown_ms: 1000
+    cooldown_ms: 1200
   - id: speech_end
     when: { event: speech.end }
     action: { effect: { name: COMET, duration_ms: 600 } }

--- a/modules/interactions/config_loader.py
+++ b/modules/interactions/config_loader.py
@@ -61,4 +61,10 @@ def load_config(config_path: Optional[str] = None, overrides: Optional[Dict[str,
     cfg = _merge(base, data)
     if overrides:
         cfg = _merge(cfg, overrides)
+    try:
+        from modules.gateway.url import resolve_gateway_base_url, rewrite_loopback_urls
+
+        cfg = rewrite_loopback_urls(cfg, resolve_gateway_base_url())
+    except Exception:
+        pass
     return cfg

--- a/modules/interactions/services/engine.py
+++ b/modules/interactions/services/engine.py
@@ -19,8 +19,15 @@ logger = logging.getLogger("interactions.engine")
 
 
 class InteractionEngine:
-    def __init__(self, cfg: Dict[str, Any], neo_client: Any | None = None, social_db: Any | None = None):
+    def __init__(
+        self,
+        cfg: Dict[str, Any],
+        neo_client: Any | None = None,
+        social_db: Any | None = None,
+        expression_arbiter: Any | None = None,
+    ):
         self.cfg = cfg
+        self._expression_arbiter = expression_arbiter
         if social_db is None:
             try:
                 from modules.social_db import get_default as _social_default  # type: ignore
@@ -34,8 +41,9 @@ class InteractionEngine:
         provided = neo_client
         if provided is not None:
             class _LocalNeoAdapter:
-                def __init__(self, runner):
+                def __init__(self, runner, engine_ref):
                     self._runner = runner
+                    self._engine = engine_ref
 
                 def clear(self) -> None:
                     try:
@@ -71,22 +79,25 @@ class InteractionEngine:
 
                 def play_effect(self, name: str, duration_ms: int = 800, color: Optional[str | tuple[int, int, int]] = None) -> None:
                     try:
-                        # Runner.animate is non-blocking; start it and let it run
                         self._runner.animate(name)
-                        # Optionally clear after duration
-                        import threading, time
+                        import threading
+                        import time
 
-                        def _clear_after():
+                        def _restore_idle():
                             try:
                                 time.sleep(max(0.0, duration_ms / 1000.0))
+                                idle = (self._engine.defaults or {}).get("idle", {}).get("base", {})
+                                base_name = str(idle.get("name", "BREATHE"))
+                                base_color = idle.get("color")
+                                self._engine.neo.set_base(name=base_name, color=base_color)
                             except Exception:
                                 pass
 
-                        threading.Thread(target=_clear_after, daemon=True).start()
+                        threading.Thread(target=_restore_idle, daemon=True).start()
                     except Exception:
                         pass
 
-            self.neo = _LocalNeoAdapter(provided)
+            self.neo = _LocalNeoAdapter(provided, self)
         else:
             base_url = str(cfg.get("adapter", {}).get("http_base_url", "http://localhost:8092/neopixel"))
             self.neo = NeoHttpClient(base_url) if base_url else NoOpNeoClient()
@@ -161,6 +172,12 @@ class InteractionEngine:
             self._ctx.update(kwargs)
 
     def trigger_effect(self, name: str, duration_ms: int = 800, force: bool = False) -> None:
+        if self._expression_arbiter is not None:
+            try:
+                if not self._expression_arbiter.claim_lights("interactions", force=bool(force)):
+                    return
+            except Exception:
+                pass
         with self._lock:
             self._manual_effect = {
                 "name": str(name),
@@ -245,10 +262,9 @@ class InteractionEngine:
                     name = str(eff.get("name", "COMET"))
                     duration_ms = int(eff.get("duration_ms", 800))
                     event_name = self._ctx.get("event")
-                    if self._effect_allowed(event_name):
+                    if self._effect_allowed(event_name) and self._claim_lights_for_event(event_name):
                         self._active_effect_until = now + duration_ms / 1000.0
                         chosen.stamp()
-                        # play effect asynchronously to avoid blocking
                         threading.Thread(target=self.neo.play_effect, args=(name, duration_ms), daemon=True).start()
                 elif "base" in act and now >= self._active_effect_until:
                     base = act["base"] or {}
@@ -273,6 +289,15 @@ class InteractionEngine:
 
             # one-shot event is consumed
             self._ctx.pop("event", None)
+
+    def _claim_lights_for_event(self, event_name: Any, *, force: bool = False) -> bool:
+        if self._expression_arbiter is None:
+            return True
+        try:
+            source = str(event_name or "interactions.rule")
+            return bool(self._expression_arbiter.claim_lights(source, force=force))
+        except Exception:
+            return True
 
     def _effect_allowed(self, event_name: Any) -> bool:
         if not bool(self.quiet_hours_cfg.get("enabled", False)):

--- a/modules/neopixel/services/runner.py
+++ b/modules/neopixel/services/runner.py
@@ -151,6 +151,14 @@ class NeoRunner:
         except queue.Empty:
             pass
 
+    def _wait_for_animations(self, timeout: float = 5.0) -> bool:
+        """Wait for all queued animations to complete. Returns True if completed, False on timeout."""
+        try:
+            self._animate_queue.join()
+            return True
+        except Exception:
+            return False
+
     # Exposed operations
     def clear(self) -> None:
         self._drain_animate_queue()

--- a/modules/neopixel/services/runner.py
+++ b/modules/neopixel/services/runner.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+import queue
+import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import yaml
 
@@ -53,6 +55,13 @@ class NeoRunner:
         self._preset_store_path = Path(preset_store_path).resolve() if preset_store_path else None
         self._preset_version = max(1, int(preset_version or 1))
         self._init_segments(segments or [])
+        self._animate_queue: queue.Queue = queue.Queue()
+        self._animate_worker = threading.Thread(
+            target=self._animate_worker_loop,
+            name="NeoRunnerAnimate",
+            daemon=True,
+        )
+        self._animate_worker.start()
 
     def _init_segments(self, segments: list[dict[str, Any]]) -> None:
         for item in segments:
@@ -134,11 +143,21 @@ class NeoRunner:
             return None
         return self._segments.get(str(name).strip().lower())
 
+    def _drain_animate_queue(self) -> None:
+        try:
+            while True:
+                self._animate_queue.get_nowait()
+                self._animate_queue.task_done()
+        except queue.Empty:
+            pass
+
     # Exposed operations
     def clear(self) -> None:
+        self._drain_animate_queue()
         self.driver.clear()
 
     def fill(self, r: int, g: int, b: int) -> None:
+        self._drain_animate_queue()
         self.driver.fill(r, g, b)
 
     def fill_segment(self, name: str, r: int, g: int, b: int) -> bool:
@@ -324,6 +343,16 @@ class NeoRunner:
             if c1:
                 self.fill(*c1)
 
+    def _animate_worker_loop(self) -> None:
+        while True:
+            item = self._animate_queue.get()
+            try:
+                self._animate_sync(*item)
+            except Exception:
+                pass
+            finally:
+                self._animate_queue.task_done()
+
     def animate(
         self,
         name: str,
@@ -331,20 +360,22 @@ class NeoRunner:
         iterations: int | None = None,
         color: tuple[int, int, int] | None = None,
         segment: str | None = None,
+        *,
+        coalesce: bool = True,
     ) -> None:
-        """Non-blocking animate: schedule synchronous animation in a daemon thread."""
-        import threading
-
-        try:
-            t = threading.Thread(
-                target=self._animate_sync,
-                args=(name, emotions, iterations, color, segment),
-                daemon=True,
-            )
-            t.start()
-        except Exception:
-            # Best-effort: fallback to synchronous if thread can't be started
+        """Queue animations so only one runs at a time; drop pending when coalesce=True."""
+        payload = (name, emotions, iterations, color, segment)
+        if coalesce:
             try:
-                self._animate_sync(name, emotions, iterations, color, segment)
+                while True:
+                    self._animate_queue.get_nowait()
+                    self._animate_queue.task_done()
+            except queue.Empty:
+                pass
+        try:
+            self._animate_queue.put_nowait(payload)
+        except Exception:
+            try:
+                self._animate_sync(*payload)
             except Exception:
                 pass

--- a/modules/neopixel/tests/test_segments.py
+++ b/modules/neopixel/tests/test_segments.py
@@ -46,6 +46,7 @@ def test_animate_segment_falls_back_to_segment_fill():
     runner = NeoRunner(NeoDriverConfig(num_leds=6), segments=[{"name": "jewel", "start": 0, "count": 2}])
     runner.driver = _FakeDriver(6)
     runner.animate("PULSE", color=(10, 20, 30), segment="jewel")
+    runner._wait_for_animations()
     assert runner.driver.buf[0] == (10, 20, 30)
     assert runner.driver.buf[1] == (10, 20, 30)
     assert runner.driver.buf[2:] == [(0, 0, 0)] * 4

--- a/modules/oled_faces/xOledFacesService.py
+++ b/modules/oled_faces/xOledFacesService.py
@@ -13,9 +13,15 @@ from .api.router import get_router
 
 
 class xOledFacesService:
-    def __init__(self, state_store: Any = None, config_overrides: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        state_store: Any = None,
+        config_overrides: Optional[Dict[str, Any]] = None,
+        expression_arbiter: Any = None,
+    ):
         self.cfg = load_config(overrides=config_overrides)
         self.state_store = state_store
+        self._expression_arbiter = expression_arbiter
         self.mapper = FaceMapper(self.cfg)
         self.display = PiSsd1306Driver(self.cfg.get("display") if isinstance(self.cfg.get("display"), dict) else {})
 
@@ -145,6 +151,12 @@ class xOledFacesService:
     def _apply(self, action: OledAction, priority: int = 50, force: bool = False) -> bool:
         if not bool(self.cfg.get("enabled", True)):
             return False
+        if self._expression_arbiter is not None:
+            try:
+                if not self._expression_arbiter.claim_oled("oled_faces", force=bool(force)):
+                    return False
+            except Exception:
+                pass
         now = time.time()
         mode = action.mode.strip().lower()
         name = action.name.strip().lower()

--- a/modules/ollama/api/router.py
+++ b/modules/ollama/api/router.py
@@ -108,11 +108,21 @@ def get_router(cfg: dict) -> APIRouter:
     def healthz():
         info: Dict[str, Any] = {"ok": True, "provider": provider_name, "model": model}
         if provider_name == "ollama":
-            info["base_url"] = str(cfg.get("ollama", {}).get("base_url", "http://127.0.0.1:11434"))
+            base = str(cfg.get("ollama", {}).get("base_url", "http://127.0.0.1:11434")).rstrip("/")
+            info["base_url"] = base
+            try:
+                resp = requests.get(f"{base}/api/tags", timeout=2.0)
+                info["daemon_ok"] = resp.status_code == 200
+                info["ok"] = bool(info["daemon_ok"])
+            except Exception as exc:
+                info["daemon_ok"] = False
+                info["ok"] = False
+                info["error"] = str(exc)
         elif provider_name == "google_ai_studio":
             gcfg = cfg.get("google_ai_studio", {}) if isinstance(cfg.get("google_ai_studio", {}), dict) else {}
             info["base_url"] = str(gcfg.get("base_url", "https://generativelanguage.googleapis.com"))
             info["api_key_configured"] = bool(str(gcfg.get("api_key", "")).strip() or os.getenv("GOOGLE_API_KEY"))
+            info["ok"] = bool(info["api_key_configured"])
         return info
 
     def _format_chat_payload(result: Dict[str, Any], translation: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/modules/ota/services/uploader.py
+++ b/modules/ota/services/uploader.py
@@ -169,13 +169,13 @@ class OTAService:
         res.update({"name": name, "sha": sha})
         return res
 
-    def upload_path(self, path: str) -> Dict[str, Any]:
+    def upload_path(self, path: str, signature: str | None = None) -> Dict[str, Any]:
         if not os.path.exists(path):
             return {"ok": False, "error": "file not found"}
         name, sha = self.uploader.compute_version(path)
         if self.uploader.already_uploaded(name, sha):
             return {"ok": True, "skipped": True, "name": name, "sha": sha}
-        res = self.uploader.upload(path)
+        res = self.uploader.upload(path, signature=signature)
         if res.get("ok"):
             self.uploader.mark_uploaded(name, sha)
         res.update({"name": name, "sha": sha})

--- a/modules/scheduler/services/runner.py
+++ b/modules/scheduler/services/runner.py
@@ -132,7 +132,7 @@ class Scheduler:
             except Exception:
                 body = resp.text[:500]
             return {
-                "ok": bool(resp.status_code < 500),
+                "ok": bool(200 <= resp.status_code < 300),
                 "status_code": int(resp.status_code),
                 "latency_ms": latency_ms,
                 "body": body,

--- a/modules/speak/api/router.py
+++ b/modules/speak/api/router.py
@@ -43,7 +43,7 @@ def get_router(service: SpeakService) -> APIRouter:
 
     @router.get("/speak/status")
     async def status():
-        return {"ready": True}
+        return {"ready": getattr(service, "tts", None) is not None}
 
     @router.post("/speak/stop")
     async def stop():
@@ -106,7 +106,14 @@ def get_router(service: SpeakService) -> APIRouter:
 
         async def _run():
             try:
+                from modules.speak.services.player import _play_stop
+
                 for idx, chunk in enumerate(chunks, start=1):
+                    if _play_stop.is_set():
+                        job = stream_jobs.get(job_id)
+                        if job is not None:
+                            job["status"] = "interrupted"
+                        return
                     await asyncio.to_thread(
                         service.speak,
                         chunk,

--- a/modules/speak/config/config.yml
+++ b/modules/speak/config/config.yml
@@ -52,7 +52,8 @@ tts:
 
 liveliness:
   enabled: true
-  interactions_base_url: http://localhost:8080/interactions
+  event_driven_effects: true
+  interactions_base_url: "@gateway/interactions"
   speech_effect:
     name: PULSE
     tone_effect_map:
@@ -64,7 +65,7 @@ liveliness:
       exclamation: COMET
       question: TWINKLE
     rhythm:
-      enabled: true
+      enabled: false
       mode: clauses           # words | clauses
       effect: PULSE
       words_per_beat: 3

--- a/modules/speak/services/tts.py
+++ b/modules/speak/services/tts.py
@@ -15,6 +15,16 @@ import requests
 
 logger = logging.getLogger("speak.tts")
 
+_synth_cancel = threading.Event()
+
+
+def cancel_synthesis() -> None:
+    _synth_cancel.set()
+
+
+def clear_synthesis_cancel() -> None:
+    _synth_cancel.clear()
+
 
 @dataclass
 class TTSConfig:
@@ -165,13 +175,28 @@ class _PiperModel:
 
             last_error = ""
             for cmd in cmd_variants:
-                proc = subprocess.run(
+                if _synth_cancel.is_set():
+                    raise RuntimeError("synthesis cancelled")
+                proc = subprocess.Popen(
                     cmd,
-                    input=(stdin_text + "\n").encode("utf-8"),
+                    stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                 )
-                stderr_txt = proc.stderr.decode("utf-8", "ignore").strip()
+                try:
+                    stdout_b, stderr_b = proc.communicate(
+                        input=(stdin_text + "\n").encode("utf-8"),
+                        timeout=120.0,
+                    )
+                except Exception:
+                    proc.kill()
+                    proc.communicate(timeout=1.0)
+                    if _synth_cancel.is_set():
+                        raise RuntimeError("synthesis cancelled")
+                    raise
+                if _synth_cancel.is_set():
+                    raise RuntimeError("synthesis cancelled")
+                stderr_txt = stderr_b.decode("utf-8", "ignore").strip()
 
                 if proc.returncode == 0:
                     try:
@@ -181,9 +206,9 @@ class _PiperModel:
                     except Exception as exc:
                         last_error = f"wav read failed: {exc}"
 
-                    if proc.stdout:
+                    if stdout_b:
                         try:
-                            return _wav_bytes_to_pcm(proc.stdout)
+                            return _wav_bytes_to_pcm(stdout_b)
                         except Exception as exc:
                             last_error = f"stdout wav parse failed: {exc}"
                     else:

--- a/modules/speak/tests/test_liveliness_sync.py
+++ b/modules/speak/tests/test_liveliness_sync.py
@@ -27,6 +27,7 @@ class _FakeSpeakService(SpeakService):
         self.player = _DummyPlayer()
         self._liveliness_cfg = {
             "enabled": True,
+            "event_driven_effects": False,
             "interactions_base_url": "http://localhost:8080/interactions",
             "speech_effect": {
                 "name": "PULSE",
@@ -58,6 +59,7 @@ class _FakeSpeakService(SpeakService):
                 "max_duration_ms": 7000,
                 "chars_per_second": 16,
                 "force": False,
+                "stack_emphasis_effects": True,
             },
         }
         self.calls = []

--- a/modules/speak/xSpeakService.py
+++ b/modules/speak/xSpeakService.py
@@ -133,21 +133,23 @@ class SpeakService:
             },
         )
         effect_cfg = self._liveliness_cfg.get("speech_effect", {}) or {}
-        effect_name = self._resolve_effect_name_for_tone(tone)
-        duration_ms = self._estimate_effect_duration_ms(text, tone)
         force = bool(effect_cfg.get("force", False))
-        self._post_interactions(
-            "/effect",
-            {"name": effect_name, "duration_ms": duration_ms, "force": force},
-        )
-        self._emit_speech_rhythm_beats(text, force=force)
-        emph_map = effect_cfg.get("emphasis_effect_map", {}) if isinstance(effect_cfg.get("emphasis_effect_map", {}), dict) else {}
-        if exclamations > 0:
-            name = str(emph_map.get("exclamation", "COMET"))
-            self._post_interactions("/effect", {"name": name, "duration_ms": 260, "force": force})
-        if questions > 0:
-            name = str(emph_map.get("question", "TWINKLE"))
-            self._post_interactions("/effect", {"name": name, "duration_ms": 240, "force": force})
+        if not bool(self._liveliness_cfg.get("event_driven_effects", False)):
+            effect_name = self._resolve_effect_name_for_tone(tone)
+            duration_ms = self._estimate_effect_duration_ms(text, tone)
+            self._post_interactions(
+                "/effect",
+                {"name": effect_name, "duration_ms": duration_ms, "force": force},
+            )
+        if bool(effect_cfg.get("stack_emphasis_effects", False)):
+            self._emit_speech_rhythm_beats(text, force=force)
+            emph_map = effect_cfg.get("emphasis_effect_map", {}) if isinstance(effect_cfg.get("emphasis_effect_map", {}), dict) else {}
+            if exclamations > 0:
+                name = str(emph_map.get("exclamation", "COMET"))
+                self._post_interactions("/effect", {"name": name, "duration_ms": 260, "force": force})
+            if questions > 0:
+                name = str(emph_map.get("question", "TWINKLE"))
+                self._post_interactions("/effect", {"name": name, "duration_ms": 240, "force": force})
 
     def _emit_speech_rhythm_beats(self, text: str, force: bool = False) -> None:
         effect_cfg = self._liveliness_cfg.get("speech_effect", {}) or {}
@@ -213,6 +215,12 @@ class SpeakService:
 
     def stop_speaking(self) -> dict:
         """Interrupt current TTS playback (wakeword barge-in)."""
+        try:
+            from modules.speak.services.tts import cancel_synthesis
+
+            cancel_synthesis()
+        except Exception:
+            pass
         self.player.stop_playback()
         return {"ok": True, "stopped": True}
 
@@ -238,6 +246,12 @@ class SpeakService:
         if language:
             overrides["language"] = language
         self._emit_speech_liveliness_start(text, tone_dict)
+        try:
+            from modules.speak.services.tts import clear_synthesis_cancel
+
+            clear_synthesis_cancel()
+        except Exception:
+            pass
         wav = self.tts.synthesize(text, overrides=overrides or None)
         dur = self.player.play_blocking(wav)
         self._emit_speech_liveliness_end(dur)

--- a/modules/speech/api/router.py
+++ b/modules/speech/api/router.py
@@ -14,22 +14,32 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("speech.api")
 
-_BARGE_IN_URLS = (
-    "http://localhost:8080/speak/stop",
-    "http://localhost:8080/agent/speech/interrupt",
-    "http://localhost:8080/speech/start",
-)
+_GATEWAY_BASE = "http://127.0.0.1:8080"
+
+
+def _gw(path: str) -> str:
+    return f"{_GATEWAY_BASE.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _barge_in_urls() -> tuple[str, ...]:
+    return (
+        _gw("/speak/stop"),
+        _gw("/agent/speech/interrupt"),
+        _gw("/speech/start"),
+    )
+
 
 def _notify_autonomy():
     try:
-        requests.post("http://localhost:8080/autonomy/interaction", timeout=0.1)
+        requests.post(_gw("/autonomy/interaction"), timeout=0.1)
     except Exception:
         pass
+
 
 def _push_interaction_event(event_type: str):
     try:
         requests.post(
-            "http://localhost:8080/interactions/event",
+            _gw("/interactions/event"),
             json={"type": event_type},
             timeout=0.1,
         )
@@ -41,7 +51,7 @@ def _emit_speech_event(name: str):
 
 
 def _barge_in_for_wakeword() -> None:
-    for url in _BARGE_IN_URLS:
+    for url in _barge_in_urls():
         try:
             requests.post(url, json={}, timeout=0.25)
         except Exception:
@@ -49,12 +59,19 @@ def _barge_in_for_wakeword() -> None:
     logger.info("Wakeword barge-in: stopped TTS and opened listening")
 
 
-def get_router(service: SpeechService) -> APIRouter:
+def get_router(service: SpeechService, gateway_base_url: str = "") -> APIRouter:
+    global _GATEWAY_BASE
+    if gateway_base_url:
+        _GATEWAY_BASE = str(gateway_base_url).rstrip("/")
     router = APIRouter()
 
     @router.get("/speech/status")
     async def status():
-        return {"listening": service.listening}
+        return {
+            "listening": service.listening,
+            "model_ready": getattr(service, "recognizer", None) is not None,
+            "stt_suppressed": bool(getattr(service, "is_stt_suppressed", lambda: False)()),
+        }
 
     last: dict | None = {"text": None, "language": getattr(service, "source_language", "tr"), "ts": 0.0}
     last_nonempty_text = ""
@@ -86,6 +103,8 @@ def get_router(service: SpeechService) -> APIRouter:
 
     def _cb(r):
         nonlocal last, last_partial_text, last_partial_ts, last_nonempty_text
+        if hasattr(service, "is_stt_suppressed") and service.is_stt_suppressed():
+            return
         text = (r.text or "").strip()
         language = getattr(service, "source_language", "tr")
         if r.is_final and hasattr(service, "finalize_stt"):
@@ -173,5 +192,12 @@ def get_router(service: SpeechService) -> APIRouter:
     @router.get("/speech/track/status")
     async def track_status():
         return service.track_status()
+
+    @router.post("/speech/stt/suppress")
+    async def stt_suppress(body: dict | None = None):
+        enabled = bool((body or {}).get("enabled", True))
+        if hasattr(service, "set_stt_suppressed"):
+            service.set_stt_suppressed(enabled)
+        return {"ok": True, "suppressed": enabled}
 
     return router

--- a/modules/speech/services/audio_capture.py
+++ b/modules/speech/services/audio_capture.py
@@ -22,11 +22,13 @@ _SINGLE_CAPTURE_INSTANCE: Optional["AudioCapture"] = None
 _INSTANCE_LOCK = threading.Lock()
 
 def get_shared_capture(cfg: Dict) -> "AudioCapture":
-    """Returns a globally shared AudioCapture instance regardless of config keys to ensure no contention."""
+    """Shared mic for wakeword + speech. Later callers may upgrade device/rate if unset."""
     global _SINGLE_CAPTURE_INSTANCE
     with _INSTANCE_LOCK:
         if _SINGLE_CAPTURE_INSTANCE is None:
             _SINGLE_CAPTURE_INSTANCE = AudioCapture(cfg)
+        else:
+            _SINGLE_CAPTURE_INSTANCE.merge_config(cfg)
         return _SINGLE_CAPTURE_INSTANCE
 
 def release_shared_capture(inst: "AudioCapture") -> None:
@@ -58,6 +60,21 @@ class AudioCapture:
         self._stopped = False
         self._alsa_thread = None
         self._pcm = None
+
+    def merge_config(self, cfg: Dict) -> None:
+        """Apply non-default audio fields from a later module (e.g. wakeword plughw)."""
+        if not isinstance(cfg, dict):
+            return
+        audio = cfg.get("audio", cfg)
+        if not isinstance(audio, dict):
+            return
+        dev = audio.get("device")
+        if dev is not None and str(dev).strip():
+            self.cfg.device = dev
+        if audio.get("samplerate") is not None:
+            self.cfg.samplerate = int(audio.get("samplerate", self.cfg.samplerate))
+        if audio.get("channels") is not None:
+            self.cfg.channels = int(audio.get("channels", self.cfg.channels))
 
     def _callback(self, indata, frames, time, status):
         if status:

--- a/modules/speech/xSpeechService.py
+++ b/modules/speech/xSpeechService.py
@@ -129,6 +129,16 @@ class SpeechService:
         pt_cfg = self.cfg.get("pan_tilt", {})
         self._pan = PanTiltController(pt_cfg, sender=self._send_pan)
         self._tracking = False
+        self._stt_suppressed = False
+        self._stt_suppress_lock = Lock()
+
+    def set_stt_suppressed(self, suppressed: bool) -> None:
+        with self._stt_suppress_lock:
+            self._stt_suppressed = bool(suppressed)
+
+    def is_stt_suppressed(self) -> bool:
+        with self._stt_suppress_lock:
+            return bool(self._stt_suppressed)
 
     def start(self, on_result: Optional[Callable[[RecognitionResult], None]] = None) -> None:
         """Start capturing and recognition in the same thread using a generator pipeline.
@@ -146,6 +156,8 @@ class SpeechService:
         try:
             stream: Iterable[bytes] = self.capture.stream()
             for result in self.recognizer.run(self._direction_wrapper(stream)):
+                if self.is_stt_suppressed():
+                    continue
                 cb = None
                 with self._result_lock:
                     cb = self._on_result_cb
@@ -271,22 +283,16 @@ class SpeechService:
 
     def start_background(self, on_result: Optional[Callable[[RecognitionResult], None]] = None) -> None:
         import threading
+
         if on_result is not None:
             with self._result_lock:
                 self._on_result_cb = on_result
         with self._listen_lock:
-            if self._listening:
-                self._stop_event.set()
-                thread = self._thread
-            else:
-                thread = None
-        if thread is not None and thread.is_alive():
-            thread.join(timeout=0.8)
-        self._stop_event = Event()
-        with self._listen_lock:
-            self._listening = False
+            if self._listening and self._thread is not None and self._thread.is_alive():
+                return
         t = threading.Thread(target=self.start, kwargs={"on_result": None}, daemon=True)
-        self._thread = t
+        with self._listen_lock:
+            self._thread = t
         t.start()
 
     def stop(self) -> None:
@@ -337,8 +343,9 @@ class SpeechService:
         # We use a simple requests call here, but in production consider async client or keeping a session
         try:
             import requests
-            # Use request endpoint to get ACK/error for motion commands.
-            url = "http://localhost:8080/arduino/request"
+            from modules.gateway.url import gateway_url, resolve_gateway_base_url
+
+            url = gateway_url(resolve_gateway_base_url(), "/arduino/request")
             payload = build_set_servo_cmd(SERVO_INDEX_PAN, int(angle_deg))
             requests.post(url, json=payload, params={"timeout": 0.1}, timeout=0.2)
         except Exception as e:

--- a/modules/vlm_bridge/api/router.py
+++ b/modules/vlm_bridge/api/router.py
@@ -5,15 +5,23 @@ import logging
 import requests
 from modules.arduino_serial.contract import build_track_cmd
 
+_GATEWAY_BASE = "http://127.0.0.1:8080"
+
+
+def _gw(path: str) -> str:
+    return f"{_GATEWAY_BASE.rstrip('/')}/{path.lstrip('/')}"
+
+
 def _notify_autonomy():
     try:
-        requests.post("http://localhost:8080/autonomy/interaction", timeout=0.1)
+        requests.post(_gw("/autonomy/interaction"), timeout=0.1)
     except Exception:
         pass
 
+
 def _request_arduino(payload: dict, timeout: float = 1.0) -> dict:
     resp = requests.post(
-        "http://127.0.0.1:8080/arduino/request",
+        _gw("/arduino/request"),
         json=payload,
         params={"timeout": float(timeout)},
         timeout=max(0.2, float(timeout) + 0.2),
@@ -26,7 +34,14 @@ def _request_arduino(payload: dict, timeout: float = 1.0) -> dict:
     return data
 
 
-def get_router(processor: Any, ardu: Optional[Any] = None) -> APIRouter:
+def get_router(
+    processor: Any,
+    ardu: Optional[Any] = None,
+    gateway_base_url: str = "",
+) -> APIRouter:
+    global _GATEWAY_BASE
+    if gateway_base_url:
+        _GATEWAY_BASE = str(gateway_base_url).rstrip("/")
     r = APIRouter(
         prefix="/vlm",
         tags=["vlm"],
@@ -316,6 +331,8 @@ def get_router(processor: Any, ardu: Optional[Any] = None) -> APIRouter:
         """Return the latest cached VisionFrameContext if available."""
         if not processor:
             raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if not processor.is_camera_input_available():
+            return {"available": False, "context": None, "reason": "camera_unavailable"}
         ctx = processor.get_latest_visual_context()
         if ctx is None:
             return {"available": False, "context": None, "reason": "No context cached yet"}
@@ -326,6 +343,8 @@ def get_router(processor: Any, ardu: Optional[Any] = None) -> APIRouter:
         """Trigger a fresh VLM analysis of the current camera frame."""
         if not processor:
             raise HTTPException(status_code=503, detail="Vision processor not initialized")
+        if not processor.is_camera_input_available():
+            return {"ok": False, "context_available": False, "context": None, "reason": "camera_unavailable"}
 
         if hasattr(processor, "refresh_visual_context"):
             ctx = processor.refresh_visual_context()
@@ -342,7 +361,9 @@ def get_router(processor: Any, ardu: Optional[Any] = None) -> APIRouter:
         question = body.get("question", "").strip()
         if not question:
             raise HTTPException(status_code=400, detail="question required")
-        
+        if not processor.is_camera_input_available():
+            return {"ok": False, "answer": "Kamera görüntüsü şu an kullanılamıyor.", "reason": "camera_unavailable"}
+
         # Try to get current frame first
         frame = None
         with processor._frame_lock:
@@ -363,11 +384,7 @@ def get_router(processor: Any, ardu: Optional[Any] = None) -> APIRouter:
                 pass
         
         if frame is None:
-            # Fallback to cached context
-            ctx = processor.get_latest_visual_context()
-            if ctx:
-                return {"ok": True, "answer": ctx.get("persona_interpretation", ctx.get("summary", "Görüntü işlenemedi."))}
-            return {"ok": False, "answer": "Kamera görüntüsü alınamadı."}
+            return {"ok": False, "answer": "Kamera görüntüsü alınamadı.", "reason": "no_frame"}
         
         # Call VLM if available
         if processor.vlm_client:
@@ -380,13 +397,7 @@ def get_router(processor: Any, ardu: Optional[Any] = None) -> APIRouter:
             except Exception:
                 pass
         
-        # Fallback: context interpretation
-        ctx = processor.get_latest_visual_context()
-        if ctx:
-            summary = ctx.get("persona_interpretation", ctx.get("summary", "Cevap alınamadı."))
-            return {"ok": True, "answer": f"Görüntü işleme gecikti; elimdeki son görüntüye göre {summary}"}
-        
-        return {"ok": False, "answer": "VLM sistemi şu an kullanılamıyor."}
+        return {"ok": False, "answer": "VLM sistemi şu an kullanılamıyor.", "reason": "vlm_unavailable"}
 
     @r.post("/person/remember", tags=["vision"], summary="Remember/store person with relationship")
     def remember_person(body: dict):

--- a/modules/vlm_bridge/config_loader.py
+++ b/modules/vlm_bridge/config_loader.py
@@ -267,4 +267,7 @@ def load_config(base_dir: Optional[str] = None, overrides: Optional[Dict[str, An
             root_google,
         )
 
-    return _enforce_policy(cfg, root_cfg)
+    cfg = _enforce_policy(cfg, root_cfg)
+    from modules.gateway.url import gateway_base_from_agent_cfg, rewrite_loopback_urls
+
+    return rewrite_loopback_urls(cfg, gateway_base_from_agent_cfg(root_cfg))

--- a/modules/vlm_bridge/services/llm_client.py
+++ b/modules/vlm_bridge/services/llm_client.py
@@ -12,7 +12,13 @@ except Exception:
 
 logger = logging.getLogger("vlm_bridge.llm")
 
-_DEFAULT_CHAT_ENDPOINT = "http://localhost:8080/ollama/chat"
+def _default_chat_endpoint() -> str:
+    try:
+        from modules.gateway.url import gateway_url, resolve_gateway_base_url
+
+        return gateway_url(resolve_gateway_base_url(), "/ollama/chat")
+    except Exception:
+        return "http://127.0.0.1:8080/ollama/chat"
 _DEFAULT_GENERATE_ENDPOINT = "http://127.0.0.1:11434/api/generate"
 _CHAT_COOLDOWN_UNTIL: Dict[str, float] = {}
 
@@ -34,7 +40,7 @@ def _derive_chat_endpoint_from_base_url(raw: str) -> str:
 def _resolve_default_chat_endpoint() -> str:
     env_chat = str(os.getenv("VLM_OLLAMA_CHAT_ENDPOINT", "")).strip()
     if env_chat:
-        return _derive_chat_endpoint_from_base_url(env_chat) or _DEFAULT_CHAT_ENDPOINT
+        return _derive_chat_endpoint_from_base_url(env_chat) or _default_chat_endpoint()
 
     env_base = str(
         os.getenv("AGENT_OLLAMA_BASE_URL")
@@ -43,7 +49,7 @@ def _resolve_default_chat_endpoint() -> str:
         or ""
     ).strip()
     if env_base:
-        return _derive_chat_endpoint_from_base_url(env_base) or _DEFAULT_CHAT_ENDPOINT
+        return _derive_chat_endpoint_from_base_url(env_base) or _default_chat_endpoint()
 
     try:
         from modules.vlm_bridge.config_loader import load_config as load_vlm_config  # type: ignore
@@ -52,11 +58,11 @@ def _resolve_default_chat_endpoint() -> str:
         ollama_cfg = cfg.get("ollama", {}) if isinstance(cfg, dict) else {}
         endpoint = str(ollama_cfg.get("endpoint", "")).strip()
         if endpoint:
-            return _derive_chat_endpoint_from_base_url(endpoint) or _DEFAULT_CHAT_ENDPOINT
+            return _derive_chat_endpoint_from_base_url(endpoint) or _default_chat_endpoint()
     except Exception:
         pass
 
-    return _DEFAULT_CHAT_ENDPOINT
+    return _default_chat_endpoint()
 
 
 def _normalize_endpoint(cfg: Dict[str, Any]) -> str:
@@ -213,7 +219,7 @@ def generate_text(
                 _CHAT_COOLDOWN_UNTIL.pop(endpoint, None)
                 return out or None
 
-            chat_url = endpoint or _DEFAULT_CHAT_ENDPOINT
+            chat_url = endpoint or _default_chat_endpoint()
             if _is_in_cooldown(chat_url):
                 return None
             # Ollama router's chat_post currently reads scalar args as query params.

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -130,6 +130,13 @@ class VisionProcessor:
     """
 
     def __init__(self, config: Dict[str, Any]):
+        try:
+            from modules.gateway.url import resolve_gateway_base_url, rewrite_loopback_urls
+
+            self._gateway_base = resolve_gateway_base_url(config)
+            config = rewrite_loopback_urls(config, self._gateway_base)
+        except Exception:
+            self._gateway_base = "http://127.0.0.1:8080"
         self.config = config
         vision_cfg = config.get("vision", {}) if isinstance(config, dict) else {}
 
@@ -137,6 +144,7 @@ class VisionProcessor:
         self.camera_source = vision_cfg.get("camera_source", 0)
         self._max_camera_wait_attempts = max(1, int(vision_cfg.get("max_camera_wait_attempts", 5)))
         self._camera_gave_up = False
+        self._context_max_age_s = max(5.0, float(vision_cfg.get("context_max_age_s", 45.0)))
         self.conf_threshold = float(vision_cfg.get("confidence_threshold", 0.5))
 
         raw_modes = vision_cfg.get("modes", {}) if isinstance(vision_cfg.get("modes", {}), dict) else {}
@@ -520,10 +528,28 @@ class VisionProcessor:
     # -----------------------------------------------------------------
     # Streaming lifecycle
     # -----------------------------------------------------------------
+    def is_camera_input_available(self) -> bool:
+        """True when local vision can read a live camera frame (not gave up / healthz dead)."""
+        if str(self.processing_mode).strip().lower() != "local":
+            return True
+        if self._is_http_camera_source():
+            ready = self._http_camera_ready()
+            if ready and self._camera_gave_up:
+                self._camera_gave_up = False
+            return ready and not self._camera_gave_up
+        if self._camera_gave_up:
+            return False
+        with self._frame_lock:
+            if self._latest_raw_frame is not None:
+                return True
+        thread = self._capture_thread
+        return thread is not None and thread.is_alive()
+
     def start_stream_processing(self) -> None:
         if self.processing_mode != "local":
             logger.debug("start_stream_processing() ignored in remote mode")
             return
+        self._camera_gave_up = False
         if self._capture_thread and self._capture_thread.is_alive():
             return
 
@@ -595,11 +621,16 @@ class VisionProcessor:
                         if not self._camera_gave_up:
                             self._camera_gave_up = True
                             logger.warning(
-                                "Camera source unavailable after %d attempts (%s); stopping capture retries",
+                                "Camera source unavailable after %d attempts (%s); pausing capture retries",
                                 self._max_camera_wait_attempts,
                                 self.camera_source,
                             )
-                        break
+                        time.sleep(3.0)
+                        if self._http_camera_ready():
+                            open_fail_count = 0
+                            self._camera_gave_up = False
+                            logger.info("Camera source recovered: %s", self.camera_source)
+                        continue
                     if open_fail_count == 1 or open_fail_count == self._max_camera_wait_attempts:
                         logger.info(
                             "Camera source not ready yet: %s (attempt=%d/%d), waiting...",
@@ -617,11 +648,13 @@ class VisionProcessor:
                         if not self._camera_gave_up:
                             self._camera_gave_up = True
                             logger.warning(
-                                "Could not open camera source after %d attempts: %s; stopping retries",
+                                "Could not open camera source after %d attempts: %s; pausing retries",
                                 self._max_camera_wait_attempts,
                                 self.camera_source,
                             )
-                        break
+                        time.sleep(3.0)
+                        open_fail_count = 0
+                        continue
                     if open_fail_count == 1 or open_fail_count == self._max_camera_wait_attempts:
                         logger.warning(
                             "Could not open camera source: %s (attempt=%d/%d), retrying...",
@@ -934,8 +967,10 @@ class VisionProcessor:
                 logger.debug("track callback failed: %s", exc)
 
         try:
+            from modules.gateway.url import gateway_url
+
             requests.post(
-                "http://localhost:8080/vlm/track",
+                gateway_url(self._gateway_base, "/vlm/track"),
                 params={"head_pan": float(pan), "head_tilt": float(tilt), "drive": int(drive)},
                 timeout=0.25,
             )
@@ -1290,6 +1325,8 @@ class VisionProcessor:
         """Return the latest cached visual context (if available)."""
         if self.visual_context_cache is None:
             return None
+        if self.visual_context_cache.age_s > self._context_max_age_s:
+            return None
         ctx = self.visual_context_cache.get_latest()
         if ctx is None:
             fallback = self._build_context_from_results(self.latest_results)
@@ -1506,8 +1543,10 @@ class VisionProcessor:
 
     def _emit_emotion(self, emotion: str) -> None:
         try:
+            from modules.gateway.url import gateway_url
+
             requests.post(
-                "http://localhost:8080/interactions/event",
+                gateway_url(self._gateway_base, "/interactions/event"),
                 json={"type": f"autonomy.{emotion}"},
                 timeout=0.5,
             )

--- a/modules/vlm_bridge/tests/conftest.py
+++ b/modules/vlm_bridge/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Pytest configuration for vlm_bridge tests.
+
+Mock cv2 and numpy to avoid Python 3.14 compatibility issues during import.
+These mocks are scoped to this test module only.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+
+class _SafeNumPyMock(MagicMock):
+    """Mock numpy that doesn't break isinstance() checks.
+    
+    Pytest and other libraries check for numpy bool types with isinstance(),
+    which requires the mock to provide a real type object, not a MagicMock.
+    """
+    
+    def __getattr__(self, name):
+        # Return None for type-like attributes so isinstance() doesn't fail
+        if name == 'bool_':
+            return type(None)  # Return a real type instead of MagicMock
+        return super().__getattr__(name)
+
+
+def pytest_configure(config):
+    """Configure pytest before test collection.
+    
+    Mock cv2 and numpy at the session level to prevent import errors
+    when VisionProcessor is imported during test collection.
+    """
+    if 'cv2' not in sys.modules:
+        sys.modules['cv2'] = MagicMock()
+    if 'numpy' not in sys.modules:
+        sys.modules['numpy'] = _SafeNumPyMock()
+
+
+def pytest_unconfigure(config):
+    """Clean up mocks after all tests complete.
+    
+    Remove the mocks so they don't interfere with other test modules.
+    """
+    # Remove mocks to allow other tests to import real libraries if needed
+    sys.modules.pop('cv2', None)
+    sys.modules.pop('numpy', None)
+

--- a/modules/vlm_bridge/tests/test_living_vision_context_fallback.py
+++ b/modules/vlm_bridge/tests/test_living_vision_context_fallback.py
@@ -1,4 +1,10 @@
 import threading
+from unittest.mock import MagicMock, patch
+
+# Mock cv2 and numpy before importing VisionProcessor
+import sys
+sys.modules['cv2'] = MagicMock()
+sys.modules['numpy'] = MagicMock()
 
 from modules.vlm_bridge.services.processor import VisionProcessor
 from modules.vlm_bridge.services.visual_context import VisualContextCache
@@ -11,6 +17,8 @@ def test_timeout_returns_cached_visual_context_fallback():
     proc._frame_lock = threading.Lock()
     proc._latest_raw_frame = None
     proc.vlm_client = None
+    proc._context_max_age_s = 45.0
+    proc.remote_mm_enabled = False
 
     # bind methods from class
     ctx = VisionProcessor.refresh_visual_context(proc, question="ne görüyorsun?")
@@ -26,6 +34,7 @@ def test_agent_core_get_visual_context_returns_latest_context():
     proc._frame_lock = threading.Lock()
     proc._latest_raw_frame = None
     proc.vlm_client = None
+    proc._context_max_age_s = 45.0
 
     VisionProcessor.update_visual_context(
         proc,

--- a/modules/vlm_bridge/tests/test_living_vision_context_fallback.py
+++ b/modules/vlm_bridge/tests/test_living_vision_context_fallback.py
@@ -1,10 +1,4 @@
 import threading
-from unittest.mock import MagicMock, patch
-
-# Mock cv2 and numpy before importing VisionProcessor
-import sys
-sys.modules['cv2'] = MagicMock()
-sys.modules['numpy'] = MagicMock()
 
 from modules.vlm_bridge.services.processor import VisionProcessor
 from modules.vlm_bridge.services.visual_context import VisualContextCache

--- a/modules/vlm_bridge/tests/test_smoke.py
+++ b/modules/vlm_bridge/tests/test_smoke.py
@@ -1,2 +1,32 @@
-def test_placeholder():
-    assert True
+from __future__ import annotations
+
+
+def test_gateway_url_helper_for_vlm_clients():
+    from modules.gateway.url import gateway_url, patch_service_endpoints
+
+    base = "http://127.0.0.1:9090"
+    assert gateway_url(base, "/vlm/ask") == "http://127.0.0.1:9090/vlm/ask"
+    patched = patch_service_endpoints({"vlm": "http://localhost:8080/vlm"}, base)
+    assert patched["vlm"] == "http://127.0.0.1:9090/vlm"
+
+
+def test_camera_gave_up_blocks_local_vision():
+    """Mirror VisionProcessor.is_camera_input_available local-path without importing cv2."""
+    processing_mode = "local"
+    is_http = False
+    camera_gave_up = True
+    latest_frame = None
+    capture_alive = False
+
+    available = True
+    if str(processing_mode).strip().lower() == "local":
+        if is_http:
+            available = False
+        elif camera_gave_up:
+            available = False
+        elif latest_frame is not None:
+            available = True
+        else:
+            available = capture_alive
+
+    assert available is False

--- a/modules/wakeword/config/config.yml
+++ b/modules/wakeword/config/config.yml
@@ -31,7 +31,7 @@ wakeword:
     - "sentry"
   trigger_on_partial: true
   min_confidence: 0.0
-  cooldown_sec: 3.0
+  cooldown_sec: 1.2
 
 openwakeword:
   # model_paths can be a list or a map: {label: path}
@@ -56,12 +56,12 @@ openwakeword:
   verifier_path: null  # optional path to verifier joblib trained with train_verifier.py
 
 actions:
-  speech_start_url: "http://localhost:8080/speech/start"
-  speech_stop_url: "http://localhost:8080/speech/stop"
-  speak_stop_url: "http://localhost:8080/speak/stop"
-  agent_interrupt_url: "http://localhost:8080/agent/speech/interrupt"
-  speech_last_url: "http://localhost:8080/speech/last"
-  interactions_event_url: "http://localhost:8080/interactions/event"
+  speech_start_url: "@gateway/speech/start"
+  speech_stop_url: "@gateway/speech/stop"
+  speak_stop_url: "@gateway/speak/stop"
+  agent_interrupt_url: "@gateway/agent/speech/interrupt"
+  speech_last_url: "@gateway/speech/last"
+  interactions_event_url: "@gateway/interactions/event"
   listen_window_sec: 8.0
   min_listen_before_final_sec: 1.5   # ignore early finals (often the wakeword itself)
   stop_on_final: true

--- a/modules/wakeword/xWakewordService.py
+++ b/modules/wakeword/xWakewordService.py
@@ -224,6 +224,9 @@ class WakewordService:
         except Exception as exc:
             self._degraded_reason = str(exc)
             logger.warning("wakeword listener stopped, running degraded: %s", exc)
+            if not self._stop_event.is_set():
+                time.sleep(1.0)
+                self._ensure_listener_restarted(retries=3, delay_sec=0.35)
         finally:
             with self._lock:
                 self._listening = False
@@ -245,7 +248,6 @@ class WakewordService:
 
     def stop(self) -> None:
         self._stop_event.set()
-        self.capture.stop()
         with self._lock:
             self._listening = False
             self._active_window = False
@@ -273,8 +275,6 @@ class WakewordService:
             self._last_trigger_ts = now
             self._active_window = True
         logger.info("wakeword candidate: %s at %f (barge-in)", wakeword, now)
-        # Briefly sleep the detection thread to let the audio buffer advance
-        time.sleep(0.5)
         threading.Thread(target=self._command_window, args=(wakeword,), daemon=True).start()
 
     def _command_window(self, wakeword: str) -> None:


### PR DESCRIPTION
## Summary

- Add a shared gateway URL resolver (`@gateway/` aliases, loopback rewrite) and enable API security with loopback trust so Pi modules keep working while remote writes can require `SENTRY_API_KEY`.
- Fix agent-core init order (`_gateway_base_url` before `ToolRegistry`) and gate vision/VLM on camera health.
- Harden the speech pipeline: STT echo suppression during TTS, Piper barge-in, wakeword shared mic lifecycle, speak LED via interactions.
- Coordinate expression output (LED queue, OLED/LED arbiter, interactions idle restore) and improve bootstrap wiring (mount order, piservo wakeword gesture, autonomy endpoints).

## Commits

1. `feat(gateway)` — URL resolver + loopback-safe security
2. `chore(config)` — `@gateway` aliases in agent/module YAML *(commit message on cbd3f24 says agent-core/vlm but diff is config-only)*
3. `fix(speech,wakeword)` — STT guard, barge-in, shared mic
4. `fix(speak)` — Piper cancel + event-driven LED
5. `fix(agent-core)` — gateway init order + STT suppress callback
6. `fix(vlm)` — camera-gated vision HTTP
7. `feat(bootstrap)` — expression arbiter + cross-module bridges
8. `fix(autonomy)` — operational gate + safe LED routing
9. `fix(ops)` — diagnostics/scheduler/ota/animate/ollama
10. `test` — gateway/autonomy/arduino smoke tests
11. `docs(cursor)` — rules + skills sync

## Test plan

- [ ] `python -m pytest modules/gateway/tests/ modules/agent_core/tests/test_tool_progress.py modules/vlm_bridge/tests/test_smoke.py -q`
- [ ] Pi: `python -u run_robot.py` — no `Agent Core init failed` / `agent_core mount skipped`
- [ ] `curl -s localhost:8080/camera/healthz` and `/agent/healthz`
- [ ] Wakeword during TTS → barge-in + ear gesture + LED TWINKLE
- [ ] Camera unplugged → `/vlm/ask` rejected, no stale vision tools
