### PR TITLE
feat(autonomy): Phase 1 - unified emotion model and expression director

### DIFF
--- a/.sentrybot/context/architecture-summary.md
+++ b/.sentrybot/context/architecture-summary.md
@@ -95,6 +95,18 @@ THINK → Duygu bozunması, sıkılma kontrolü, uyku saati kontrolü
 ACT   → LLM yanıtını parse et, donanım HTTP çağrıları yap
 ```
 
+### Duygusal Model (Affective Model)
+
+- **Mood eksenleri:** happiness, energy, curiosity, fear, **anger** (öfke ekseni
+  `anger>45 → anger`, `anger>75 → furious` baskın duygularını üretir).
+- **Affective appraisal** (`services/affective_appraisal.py` + `config/appraisal.yml`):
+  semantik olayları (`user_rude`, `owner_returned`, `command_failed`…) mood
+  deltalarına çevirir → duygular zamansal bozunmadan değil **nedenden** doğar.
+- **Tek duygu sözlüğü:** tüm görsel/işitsel çıktılar `modules/common` kanonik
+  duygu vocab'ından çözülür (eyes/LEDs/ears/tone aynı taksonomi).
+- **Expression Director** (`services/expression_director.py`): tek çağrıda
+  gözler + LED + kulaklar + kafa + ses tonunu eşgüdümlü tetikler (`brain.express`).
+
 ## Güvenlik ve Dayanıklılık
 
 - **Owner kontrolü:** VLM + RFID ile sahip doğrulaması

--- a/.sentrybot/context/module-registry.md
+++ b/.sentrybot/context/module-registry.md
@@ -35,6 +35,7 @@
 | 27 | `esp_link` | — | Etkileşim | ESP32 köprü iletişimi (mDNS web remote) | Dolaylı | — |
 | 28 | `social_db` | — | Veri | SQLite kişi hafızası, ilişki/tanıma seviyeleri | Hayır | — |
 | 29 | `admin_ui` | — | Etkileşim | Web yönetim paneli (statik dosyalar) | Hayır | gateway |
+| 30 | `common` | — | Paylaşılan | Kanonik duygu sözlüğü (eyes/LEDs/ears/tone tek taksonomi) | Hayır | — |
 
 ## Mimari Katmanlar
 

--- a/modules/autonomy/config/appraisal.yml
+++ b/modules/autonomy/config/appraisal.yml
@@ -1,0 +1,29 @@
+# Affective appraisal rules: map a semantic event to mood-axis deltas.
+#
+# Axes: happiness, energy, curiosity, fear, anger (0-100).
+# Deltas are scaled by an optional per-call intensity factor.
+#
+# This gives the robot *causal* emotion ("the user was rude -> anger") instead
+# of pure time-based decay, so its feelings react to what actually happens.
+
+rules:
+  owner_returned:   { happiness: 22, anger: -12, fear: -10 }
+  owner_left:       { happiness: -8, curiosity: 4 }
+  greeted:          { happiness: 7 }
+  user_praise:      { happiness: 18, anger: -10 }
+  user_thanks:      { happiness: 12 }
+  user_rude:        { anger: 32, happiness: -12 }
+  user_insult:      { anger: 45, happiness: -18, fear: 6 }
+  command_failed:   { anger: 12, fear: 6 }
+  command_ok:       { happiness: 6, anger: -4 }
+  owner_lockout:    { anger: 20, fear: 15, happiness: -10 }
+  petted:           { happiness: 16, anger: -16, fear: -8 }
+  loud_noise:       { fear: 22, anger: 5, energy: 6 }
+  new_person:       { curiosity: 12, energy: 4 }
+  scene_change:     { curiosity: 8 }
+  darkness:         { fear: 8, energy: -6 }
+  alone_too_long:   { happiness: -10, curiosity: 6 }
+  played_with:      { happiness: 20, energy: 8, anger: -10 }
+  rested:           { energy: 30, fear: -10 }
+
+# Decay multipliers are handled by MoodManager; this file only defines events.

--- a/modules/autonomy/services/affective_appraisal.py
+++ b/modules/autonomy/services/affective_appraisal.py
@@ -1,0 +1,95 @@
+"""Affective appraisal engine.
+
+Maps *semantic events* (e.g. ``user_rude``, ``owner_returned``) onto mood-axis
+deltas so the robot's feelings have causes rather than only time-based decay.
+
+Rules are config-driven (``config/appraisal.yml``) and can be overridden by the
+autonomy config under ``defaults.appraisal.rules``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+logger = logging.getLogger("autonomy.appraisal")
+
+_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "appraisal.yml"
+
+# Minimal built-in defaults so the engine works even without the YAML file.
+_DEFAULT_RULES: Dict[str, Dict[str, float]] = {
+    "owner_returned": {"happiness": 22, "anger": -12, "fear": -10},
+    "user_praise": {"happiness": 18, "anger": -10},
+    "user_rude": {"anger": 32, "happiness": -12},
+    "command_failed": {"anger": 12, "fear": 6},
+    "loud_noise": {"fear": 22, "anger": 5},
+    "new_person": {"curiosity": 12},
+    "petted": {"happiness": 16, "anger": -16},
+}
+
+
+class AffectiveAppraisal:
+    """Turns events into mood deltas and applies them to a mood manager."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        self.rules: Dict[str, Dict[str, float]] = dict(_DEFAULT_RULES)
+        self._load_yaml_rules()
+        # Allow an autonomy-config override to win over file/defaults.
+        override = ((config or {}).get("defaults", {}) or {}).get("appraisal", {}) or {}
+        file_rules = override.get("rules")
+        if isinstance(file_rules, dict):
+            self._merge_rules(file_rules)
+
+    def _load_yaml_rules(self) -> None:
+        try:
+            with open(_CONFIG_PATH, "r", encoding="utf-8") as handle:
+                data = yaml.safe_load(handle) or {}
+            rules = data.get("rules")
+            if isinstance(rules, dict):
+                self._merge_rules(rules)
+        except FileNotFoundError:
+            logger.debug("appraisal.yml not found, using built-in defaults")
+        except Exception as exc:
+            logger.warning("failed to load appraisal rules: %s", exc)
+
+    def _merge_rules(self, rules: Dict[str, Any]) -> None:
+        for event, deltas in rules.items():
+            if not isinstance(deltas, dict):
+                continue
+            clean = {}
+            for axis, value in deltas.items():
+                try:
+                    clean[str(axis)] = float(value)
+                except (TypeError, ValueError):
+                    continue
+            if clean:
+                self.rules[str(event).strip().lower()] = clean
+
+    def known_events(self):
+        return sorted(self.rules.keys())
+
+    def appraise(self, event: str, intensity: float = 1.0) -> Dict[str, float]:
+        """Return scaled mood deltas for an event (empty dict if unknown)."""
+        deltas = self.rules.get(str(event).strip().lower())
+        if not deltas:
+            return {}
+        factor = max(0.0, float(intensity))
+        return {axis: value * factor for axis, value in deltas.items()}
+
+    def apply(self, mood: Any, event: str, intensity: float = 1.0) -> Optional[str]:
+        """Apply an event's deltas to ``mood``; returns the event if it matched."""
+        deltas = self.appraise(event, intensity)
+        if not deltas:
+            return None
+        for axis, delta in deltas.items():
+            try:
+                mood.modify(axis, delta)
+            except Exception:
+                continue
+        return str(event).strip().lower()
+
+
+__all__ = ["AffectiveAppraisal"]

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -12,6 +12,7 @@ from .idle_behaviors import IdleBehaviorPlanner
 from .mood import MoodManager
 from .memory import ShortTermMemory
 from .affective_appraisal import AffectiveAppraisal
+from .expression_director import ExpressionDirector
 from .companion_rituals import CompanionRituals
 from .proactive_planner import ProactivePlanner
 from .relationship_memory import RelationshipMemory
@@ -58,6 +59,7 @@ class AutonomyBrain(
         self.mood = MoodManager(config)
         self.appraisal = AffectiveAppraisal(config)
         self.client = ServiceClient(config.get("endpoints", {}), config=config)
+        self.expression = ExpressionDirector(self.client)
         self.idle_planner = IdleBehaviorPlanner(config)
         self.memory = ShortTermMemory(max_items=20)
         companion_cfg = config.get("companion", {}) if isinstance(config.get("companion", {}), dict) else {}
@@ -283,6 +285,22 @@ class AutonomyBrain(
                     pass
         except Exception:
             logger.debug("Failed to run emotion scene %s", scene_name, exc_info=True)
+
+    def express(self, emotion: str, *, say: Optional[str] = None, language: Optional[str] = None) -> str:
+        """Deliberately express an emotion across all modalities at once.
+
+        Use for reactive, intentional expressions (greetings, reactions). Passive
+        mood-driven visuals continue to flow through ``_sync_emotion``.
+        """
+        head = None
+        try:
+            profile = self.mood.get_body_language_profile() or {}
+            pan = int(self.state.get("current_pan", 90)) + int(profile.get("pan_delta", 0))
+            tilt = int(self.state.get("current_tilt", 90))
+            head = (max(0, min(180, pan)), max(0, min(180, tilt)))
+        except Exception:
+            head = None
+        return self.expression.express(emotion, say=say, language=language, move_head=head)
 
     def appraise_event(self, event: str, intensity: float = 1.0, *, emit: bool = True) -> Optional[str]:
         """Apply a causal emotion event to mood and announce it.

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -5,12 +5,13 @@ import random
 import datetime
 import json
 import uuid
-from typing import List
+from typing import List, Optional
 
 from .client import ServiceClient
 from .idle_behaviors import IdleBehaviorPlanner
 from .mood import MoodManager
 from .memory import ShortTermMemory
+from .affective_appraisal import AffectiveAppraisal
 from .companion_rituals import CompanionRituals
 from .proactive_planner import ProactivePlanner
 from .relationship_memory import RelationshipMemory
@@ -55,6 +56,7 @@ class AutonomyBrain(
 
         # Components
         self.mood = MoodManager(config)
+        self.appraisal = AffectiveAppraisal(config)
         self.client = ServiceClient(config.get("endpoints", {}), config=config)
         self.idle_planner = IdleBehaviorPlanner(config)
         self.memory = ShortTermMemory(max_items=20)
@@ -281,6 +283,39 @@ class AutonomyBrain(
                     pass
         except Exception:
             logger.debug("Failed to run emotion scene %s", scene_name, exc_info=True)
+
+    def appraise_event(self, event: str, intensity: float = 1.0, *, emit: bool = True) -> Optional[str]:
+        """Apply a causal emotion event to mood and announce it.
+
+        Returns the matched event name (or ``None`` if the event is unknown).
+        """
+        matched = self.appraisal.apply(self.mood, event, intensity)
+        if not matched:
+            return None
+        try:
+            self.memory.add_event(f"Felt a reaction to: {matched}")
+        except Exception:
+            pass
+        if emit:
+            try:
+                self.client.push_interaction_event(f"appraisal:{matched}")
+            except Exception:
+                pass
+        return matched
+
+    @staticmethod
+    def _sentiment_event_for_text(text: str) -> Optional[str]:
+        """Very lightweight keyword sentiment -> appraisal event mapping."""
+        low = str(text or "").lower()
+        if not low:
+            return None
+        rude = ("aptal", "salak", "gerizekal", "kapa cen", "sus ", "stupid", "shut up", "idiot")
+        praise = ("aferin", "harikasin", "cok iyi", "tesekkur", "sevimlisin", "good job", "well done", "thank you", "i love you")
+        if any(tok in low for tok in rude):
+            return "user_rude"
+        if any(tok in low for tok in praise):
+            return "user_praise"
+        return None
 
     def _think(self):
         now = time.time()
@@ -650,6 +685,9 @@ class AutonomyBrain(
         logger.info("Heard: %s", text)
         self.state["last_interaction"] = time.time()
         self.mood.modify("happiness", 5)
+        sentiment_event = self._sentiment_event_for_text(text)
+        if sentiment_event:
+            self.appraise_event(sentiment_event)
         self.memory.add_event(f"User said: {text}")
         self._log_conversation(text)
         lang = str(source_lang or self.state.get("last_speech_language") or "tr")
@@ -769,7 +807,8 @@ class AutonomyBrain(
                     logger.info("LLM response only triggered physical actions.")
         except Exception as exc:
             logger.error("Failed to generate reply: %s", exc)
-            self.mood.modify("fear", 15)
+            # A failed reply both scares and frustrates the robot (causal appraisal).
+            self.appraise_event("command_failed", emit=False)
             self.client.push_interaction_event("error", {"source": "ollama", "reason": "chat_failed"})
             self._apply_emotion_visual_state("fear")
         finally:

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -617,26 +617,34 @@ class AutonomyBrain(
     def _visual_lock_active(self) -> bool:
         return time.time() < float(self._visual_lock_until)
 
+    # Emotions that warrant a longer visual hold (high-arousal states).
+    _STRONG_VISUAL_EMOTIONS = {"fear", "furious", "anger", "surprise"}
+
     def _apply_emotion_visual_state(self, emotion: str) -> None:
         e = str(emotion or "neutral").strip().lower()
-        mapping = {
-            "joy": {"effect": "RAINBOW_CYCLE", "oled": "happy", "color": [255, 190, 80], "strong": False},
-            "curiosity": {"effect": "COMET", "oled": "focused", "color": [60, 190, 255], "strong": False},
-            "sadness": {"effect": "PULSE", "oled": "sad", "color": [60, 90, 180], "strong": False},
-            "tired": {"effect": "BREATHE", "oled": "sleepy", "color": [80, 70, 120], "strong": False},
-            "fear": {"effect": "PULSE", "oled": "scared", "color": [255, 40, 40], "strong": True},
-            "neutral": {"effect": "BREATHE", "oled": "normal", "color": [120, 120, 140], "strong": False},
-        }
-        spec = mapping.get(e, mapping["neutral"])
-        lock_s = self._visual_lock_strong_s if spec.get("strong") else self._visual_lock_default_s
-        self._visual_lock_until = max(self._visual_lock_until, time.time() + max(0.2, float(lock_s)))
-        self._visual_lock_reason = f"emotion:{e}"
+        # Resolve eyes + LED effect + colour from the single canonical vocabulary
+        # so every emotion (incl. anger/furious/surprise) gets coherent visuals.
         try:
-            self.client.set_neopixel(str(spec.get("effect", "BREATHE")), emotions=[e], color=spec.get("color"))
+            from modules.common.emotion_vocab import emotion_render
+
+            render = emotion_render(e)
+            canon = render.canonical
+            effect = render.effect
+            oled = render.oled
+            color = list(render.rgb)
+        except Exception:
+            canon, effect, oled, color = "neutral", "BREATHE", "normal", [120, 120, 140]
+
+        strong = canon in self._STRONG_VISUAL_EMOTIONS
+        lock_s = self._visual_lock_strong_s if strong else self._visual_lock_default_s
+        self._visual_lock_until = max(self._visual_lock_until, time.time() + max(0.2, float(lock_s)))
+        self._visual_lock_reason = f"emotion:{canon}"
+        try:
+            self.client.set_neopixel(effect, emotions=[canon], color=color)
         except Exception:
             pass
         try:
-            self.client.oled_show(str(spec.get("oled", "normal")))
+            self.client.oled_show(oled)
         except Exception:
             pass
 

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -310,7 +310,7 @@ class AutonomyBrain(
         if not low:
             return None
         rude = ("aptal", "salak", "gerizekal", "kapa cen", "sus ", "stupid", "shut up", "idiot")
-        praise = ("aferin", "harikasin", "cok iyi", "tesekkur", "sevimlisin", "good job", "well done", "thank you", "i love you")
+        praise = ("aferin", "harikasin", "cok iyi", "tesekkur", "sevimlisin", "seviyorum", "good job", "well done", "thank you", "i love you")
         if any(tok in low for tok in rude):
             return "user_rude"
         if any(tok in low for tok in praise):

--- a/modules/autonomy/services/brain_parts/animations.py
+++ b/modules/autonomy/services/brain_parts/animations.py
@@ -29,6 +29,33 @@ class AnimationSupportMixin:
         if isinstance(evt, str) and evt and random.random() < 0.18:
             self.client.push_interaction_event(evt)
 
+        # Layer subtle eye + ear life on top of head motion for richer liveliness.
+        if random.random() < 0.25:
+            self._perform_eye_saccade()
+        if random.random() < 0.2:
+            self._perform_ear_micromovement()
+
+    def _perform_eye_saccade(self) -> None:
+        """Briefly dart the eyes to a random gaze direction."""
+        gaze = random.choice(["look_left", "look_right", "look_up", "look_down"])
+        try:
+            self.client.oled_show(gaze)
+        except Exception:
+            pass
+
+    def _perform_ear_micromovement(self) -> None:
+        """Nudge the ears toward the current mood pose for ambient liveliness."""
+        dominant = "neutral"
+        if hasattr(self, "mood") and hasattr(self.mood, "get_dominant_emotion"):
+            try:
+                dominant = self.mood.get_dominant_emotion() or "neutral"
+            except Exception:
+                dominant = "neutral"
+        try:
+            self.client.push_interaction_event(f"emotion:{dominant}")
+        except Exception:
+            pass
+
     def _trigger_animation(self, name: str, speed: float = 1.0, loop: bool = False) -> bool:
         resp = self.client.run_animation(name, speed=speed, loop=loop)
         return bool(resp and resp.get("ok"))

--- a/modules/autonomy/services/expression_director.py
+++ b/modules/autonomy/services/expression_director.py
@@ -1,0 +1,80 @@
+"""Multi-modal expression director.
+
+Fires a single, coherent emotional expression across every output modality at
+once — eyes (OLED), LEDs (NeoPixel), ears (PiServo, via interaction event),
+optional head pose and optional speech with a matching TTS tone.
+
+All modalities are resolved from the shared canonical emotion vocabulary so they
+stay in sync. Every call is best-effort: a failing modality never blocks the
+others, keeping the robot alive even if one subsystem is down.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger("autonomy.expression")
+
+try:
+    from modules.common.emotion_vocab import emotion_render as _emotion_render
+except Exception:  # pragma: no cover - optional dependency
+    _emotion_render = None
+
+
+def _safe(label: str, fn) -> bool:
+    try:
+        fn()
+        return True
+    except Exception:
+        logger.debug("expression modality failed: %s", label, exc_info=True)
+        return False
+
+
+class ExpressionDirector:
+    """Coordinates eyes + LEDs + ears + head + voice for one emotion."""
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    def express(
+        self,
+        emotion: str,
+        *,
+        say: Optional[str] = None,
+        language: Optional[str] = None,
+        move_head: Optional[Tuple[int, int]] = None,
+    ) -> str:
+        """Render ``emotion`` across all modalities; returns the canonical label."""
+        if _emotion_render is not None:
+            render = _emotion_render(emotion)
+            canon = render.canonical
+            effect = render.effect
+            oled = render.oled
+            color = list(render.rgb)
+            tone = render.tone
+        else:  # minimal fallback when shared vocab is unavailable
+            canon = str(emotion or "neutral").strip().lower()
+            effect, oled, color, tone = "BREATHE", "normal", [120, 120, 140], "neutral"
+
+        modalities = []
+        if _safe("leds", lambda: self.client.set_neopixel(effect, emotions=[canon], color=color)):
+            modalities.append("leds")
+        if _safe("eyes", lambda: self.client.oled_show(oled)):
+            modalities.append("eyes")
+        # interaction event drives ears (piservo bridge) + any other subscribers
+        if _safe("ears", lambda: self.client.push_interaction_event(f"emotion:{canon}")):
+            modalities.append("ears")
+        if move_head is not None:
+            pan, tilt = move_head
+            if _safe("head", lambda: self.client.move_head(int(pan), int(tilt))):
+                modalities.append("head")
+        if say:
+            if _safe("voice", lambda: self.client.speak(say, tone=tone, language=language)):
+                modalities.append("voice")
+
+        logger.debug("expressed %s via %s", canon, modalities)
+        return canon
+
+
+__all__ = ["ExpressionDirector"]

--- a/modules/autonomy/services/mood.py
+++ b/modules/autonomy/services/mood.py
@@ -13,7 +13,8 @@ class MoodManager:
             "happiness": defaults.get("initial_happiness", 50),
             "energy": defaults.get("initial_energy", 100),
             "curiosity": 50,
-            "fear": 0
+            "fear": 0,
+            "anger": 0,
         }
 
         self.last_update = time.time()
@@ -60,6 +61,7 @@ class MoodManager:
         self.state["energy"] = max(0, self.state["energy"] - (decay * 0.2))
         self.state["curiosity"] = min(100, self.state["curiosity"] + (decay * 0.5)) # Curiosity grows when idle
         self.state["fear"] = max(0, self.state["fear"] - (decay * 2.0)) # Fear recovers quickly
+        self.state["anger"] = max(0, self.state["anger"] - (decay * 1.5)) # Anger cools down over time
         self._maybe_snapshot()
 
     def modify(self, mood, delta):
@@ -68,9 +70,15 @@ class MoodManager:
             self._maybe_snapshot()
             
     def get_dominant_emotion(self):
-        # Simple logic to determine dominant emotion for LED/Expression
+        # Determine the dominant emotion for LEDs / eyes / body language.
+        # Order encodes priority: high-arousal negative states win first.
+        anger = self.state.get("anger", 0)
+        if anger > 75:
+            return "furious"
         if self.state["fear"] > 50:
             return "fear"
+        if anger > 45:
+            return "anger"
         if self.state["happiness"] > 70:
             return "joy"
         if self.state["happiness"] < 30:
@@ -95,6 +103,8 @@ class MoodManager:
             "joy": {"pan_delta": 6, "tilt_delta": 4, "event": "autonomy.joy"},
             "curiosity": {"pan_delta": 8, "tilt_delta": 3, "event": "autonomy.curious"},
             "fear": {"pan_delta": 10, "tilt_delta": 6, "event": "autonomy.alert"},
+            "anger": {"pan_delta": 9, "tilt_delta": 5, "event": "autonomy.angry"},
+            "furious": {"pan_delta": 12, "tilt_delta": 7, "event": "autonomy.angry"},
             "tired": {"pan_delta": 2, "tilt_delta": 2, "event": "autonomy.tired"},
             "sadness": {"pan_delta": 3, "tilt_delta": 5, "event": "autonomy.sad"},
             "neutral": {"pan_delta": 4, "tilt_delta": 3, "event": "autonomy.neutral"},

--- a/modules/autonomy/tests/test_affective_model.py
+++ b/modules/autonomy/tests/test_affective_model.py
@@ -1,0 +1,70 @@
+"""Tests for the anger axis and the affective appraisal engine."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.mood import MoodManager
+from modules.autonomy.services.affective_appraisal import AffectiveAppraisal
+
+
+def _mood():
+    return MoodManager({"defaults": {"mood": {"initial_happiness": 50, "initial_energy": 100}}})
+
+
+def test_anger_axis_exists_and_decays():
+    mood = _mood()
+    assert "anger" in mood.state
+    mood.state["anger"] = 50
+    mood.last_update -= 10  # simulate elapsed time
+    mood.update()
+    assert mood.state["anger"] < 50
+
+
+def test_dominant_emotion_includes_anger_and_furious():
+    mood = _mood()
+    mood.state["anger"] = 50
+    assert mood.get_dominant_emotion() == "anger"
+    mood.state["anger"] = 90
+    assert mood.get_dominant_emotion() == "furious"
+
+
+def test_body_language_profile_for_anger():
+    mood = _mood()
+    mood.state["anger"] = 90
+    profile = mood.get_body_language_profile()
+    assert profile["event"] == "autonomy.angry"
+    assert profile["pan_delta"] >= 9
+
+
+def test_appraisal_applies_mood_deltas():
+    mood = _mood()
+    appraisal = AffectiveAppraisal()
+    before = mood.state["anger"]
+    matched = appraisal.apply(mood, "user_rude")
+    assert matched == "user_rude"
+    assert mood.state["anger"] > before
+    assert mood.state["happiness"] < 50
+
+
+def test_appraisal_intensity_scales_and_clamps():
+    mood = _mood()
+    appraisal = AffectiveAppraisal()
+    appraisal.apply(mood, "user_insult", intensity=5.0)
+    # mood.modify clamps to [0, 100]
+    assert 0 <= mood.state["anger"] <= 100
+    assert mood.state["anger"] == 100
+
+
+def test_unknown_event_is_noop():
+    mood = _mood()
+    appraisal = AffectiveAppraisal()
+    snapshot = dict(mood.state)
+    assert appraisal.apply(mood, "not_a_real_event") is None
+    assert mood.state == snapshot
+
+
+def test_sentiment_keyword_mapping():
+    from modules.autonomy.services.brain import AutonomyBrain
+
+    assert AutonomyBrain._sentiment_event_for_text("seni cok seviyorum") == "user_praise"
+    assert AutonomyBrain._sentiment_event_for_text("aptal robot") == "user_rude"
+    assert AutonomyBrain._sentiment_event_for_text("bugun hava nasil") is None

--- a/modules/autonomy/tests/test_expression_director.py
+++ b/modules/autonomy/tests/test_expression_director.py
@@ -1,0 +1,98 @@
+"""Tests for the multi-modal expression director and idle micro-behaviors."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.expression_director import ExpressionDirector
+from modules.autonomy.services.brain_parts.animations import AnimationSupportMixin
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def set_neopixel(self, effect, emotions=None, color=None, duration=None):
+        self.calls.append(("leds", effect, tuple(emotions or []), tuple(color or ())))
+
+    def oled_show(self, name):
+        self.calls.append(("eyes", name))
+
+    def push_interaction_event(self, event_type, data=None):
+        self.calls.append(("event", event_type))
+
+    def move_head(self, pan, tilt, speed=0.8):
+        self.calls.append(("head", pan, tilt))
+
+    def speak(self, text, tone=None, engine=None, language=None):
+        self.calls.append(("voice", text, tone))
+
+    def kinds(self):
+        return [c[0] for c in self.calls]
+
+
+def test_express_fires_all_modalities_with_canonical_label():
+    client = _RecordingClient()
+    director = ExpressionDirector(client)
+    canon = director.express("happy", say="merhaba", move_head=(100, 90))
+    assert canon == "joy"
+    kinds = client.kinds()
+    assert {"leds", "eyes", "event", "head", "voice"} <= set(kinds)
+    # LEDs and the ear-driving interaction event both use the canonical label
+    leds = next(c for c in client.calls if c[0] == "leds")
+    assert leds[2] == ("joy",)
+    assert ("event", "emotion:joy") in client.calls
+    voice = next(c for c in client.calls if c[0] == "voice")
+    assert voice[2] == "joy"  # TTS tone resolved from vocab
+
+
+def test_express_without_speech_or_head_skips_those():
+    client = _RecordingClient()
+    director = ExpressionDirector(client)
+    director.express("anger")
+    kinds = set(client.kinds())
+    assert "voice" not in kinds
+    assert "head" not in kinds
+    assert {"leds", "eyes", "event"} <= kinds
+
+
+def test_failing_modality_does_not_block_others():
+    class _Flaky(_RecordingClient):
+        def oled_show(self, name):
+            raise RuntimeError("display offline")
+
+    client = _Flaky()
+    director = ExpressionDirector(client)
+    canon = director.express("surprise")
+    assert canon == "surprise"
+    # eyes failed, but LEDs + ears still fired
+    assert "leds" in client.kinds()
+    assert ("event", "emotion:surprise") in client.calls
+
+
+class _StubMood:
+    def get_body_language_profile(self):
+        return {"pan_delta": 4, "tilt_delta": 3, "event": "autonomy.neutral"}
+
+    def get_dominant_emotion(self):
+        return "joy"
+
+
+class _Mini(AnimationSupportMixin):
+    def __init__(self, client):
+        self.client = client
+        self.state = {"current_pan": 90, "current_tilt": 90}
+        self.mood = _StubMood()
+
+
+def test_eye_saccade_uses_gaze_bitmaps():
+    client = _RecordingClient()
+    mini = _Mini(client)
+    mini._perform_eye_saccade()
+    eyes = [c for c in client.calls if c[0] == "eyes"]
+    assert eyes and eyes[0][1] in {"look_left", "look_right", "look_up", "look_down"}
+
+
+def test_ear_micromovement_emits_emotion_event():
+    client = _RecordingClient()
+    mini = _Mini(client)
+    mini._perform_ear_micromovement()
+    assert ("event", "emotion:joy") in client.calls

--- a/modules/common/README.md
+++ b/modules/common/README.md
@@ -1,0 +1,45 @@
+# common — Shared Helpers
+
+Dependency-light helpers shared across SentryBOT modules. Importable from any
+service without pulling heavy module graphs.
+
+## Canonical Emotion Vocabulary
+
+`emotion_vocab.py` is the **single source of truth** that unifies the three
+historically divergent emotion vocabularies:
+
+| Subsystem        | Old vocabulary                         |
+|------------------|----------------------------------------|
+| autonomy (mood)  | ~6 labels (`joy`, `sadness`, `tired`…) |
+| oled_faces       | ~13 event labels (`happy`, `sad`…)     |
+| neopixel         | ~23 palette files                      |
+
+Every subsystem now resolves its incoming label to a **canonical** key and
+reads shared render hints, so eyes (OLED), LEDs (NeoPixel), ears (PiServo),
+head body-language and TTS tone all agree on one emotion.
+
+### Usage
+
+```python
+from modules.common.emotion_vocab import get_vocab
+
+vocab = get_vocab()
+vocab.canonical("happy")        # -> "joy"
+r = vocab.render("happy")       # -> EmotionRender(...)
+r.oled                          # -> "happy"   (face bitmap)
+r.palette                       # -> "joy"     (neopixel palette file)
+r.effect                        # -> "RAINBOW_CYCLE"
+r.ears                          # -> "joy"     (piservo pose key)
+r.tone                          # -> "joy"     (speak TTS tone)
+r.rgb                           # -> (0, 200, 60)
+```
+
+### Config
+
+`config/emotions.yml` defines:
+
+- `aliases` — canonical → alias labels
+- `render`  — per-canonical render hints (`oled`, `palette`, `effect`, `ears`, `tone`, `rgb`)
+- `default_canonical` — fallback when a label is unknown (`neutral`)
+
+To add or retune an emotion, edit the YAML only — no code changes required.

--- a/modules/common/__init__.py
+++ b/modules/common/__init__.py
@@ -1,0 +1,23 @@
+"""Shared, dependency-light helpers used across SentryBOT modules.
+
+Currently hosts the canonical emotion vocabulary so eyes, LEDs, ears, body
+language and TTS tone all agree on a single emotion taxonomy.
+"""
+
+from .emotion_vocab import (
+    EmotionRender,
+    EmotionVocab,
+    canonical_emotion,
+    emotion_render,
+    get_vocab,
+    load_vocab,
+)
+
+__all__ = [
+    "EmotionRender",
+    "EmotionVocab",
+    "canonical_emotion",
+    "emotion_render",
+    "get_vocab",
+    "load_vocab",
+]

--- a/modules/common/config/emotions.yml
+++ b/modules/common/config/emotions.yml
@@ -38,9 +38,9 @@ render:
   sadness:    { oled: sad,        palette: sadness,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [40, 80, 160] }
   curiosity:  { oled: focused,    palette: curiosity,    effect: COMET,          ears: curiosity, tone: neutral,  rgb: [0, 180, 200] }
   tired:      { oled: sleepy,     palette: neutral,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [80, 40, 120] }
-  fear:       { oled: scared,     palette: nervousness,  effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 0, 120] }
-  anger:      { oled: angry,      palette: annoyance,    effect: PULSE,          ears: anger,     tone: excited,  rgb: [220, 40, 0] }
-  furious:    { oled: furious,    palette: annoyance,    effect: METEOR,         ears: anger,     tone: excited,  rgb: [255, 0, 0] }
+  fear:       { oled: scared,     palette: fear,         effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 0, 120] }
+  anger:      { oled: angry,      palette: anger,        effect: PULSE,          ears: anger,     tone: excited,  rgb: [220, 40, 0] }
+  furious:    { oled: furious,    palette: anger,        effect: METEOR,         ears: anger,     tone: excited,  rgb: [255, 0, 0] }
   surprise:   { oled: surprised,  palette: surprise,     effect: TWINKLE,        ears: surprise,  tone: excited,  rgb: [255, 200, 0] }
   excitement: { oled: excited,    palette: excitement,   effect: RAINBOW_CYCLE,  ears: surprise,  tone: excited,  rgb: [255, 120, 0] }
   love:       { oled: happy,      palette: love,         effect: PULSE,          ears: joy,       tone: joy,      rgb: [255, 40, 100] }

--- a/modules/common/config/emotions.yml
+++ b/modules/common/config/emotions.yml
@@ -1,0 +1,52 @@
+# SentryBOT — Canonical Emotion Vocabulary
+#
+# Single source of truth that unifies the three historical emotion vocabularies
+# (autonomy mood ~6, oled_faces events ~13, neopixel palettes ~23).
+#
+# Every subsystem resolves its incoming label to a canonical key, then reads the
+# render hints below. This keeps eyes (OLED), LEDs (NeoPixel), ears (PiServo),
+# head body-language and TTS tone aligned for one emotion.
+
+# canonical -> alias labels that should map onto it
+aliases:
+  neutral:    [calm, idle, default, normal]
+  joy:        [happy, happiness, glad, cheerful, amusement, optimism]
+  sadness:    [sad, unhappy, down, grief, disappointment, remorse]
+  curiosity:  [curious, interested, intrigued, realization]
+  tired:      [sleepy, drowsy, fatigued, exhausted]
+  fear:       [scared, afraid, frightened, nervousness, nervous]
+  anger:      [angry, mad, annoyance, annoyed]
+  furious:    [rage, enraged, livid]
+  surprise:   [surprised, shocked, astonished]
+  excitement: [excited, thrilled, energetic]
+  love:       [affection, adoration, admiration, desire, gratitude]
+  disgust:    [disgusted, repulsed, disapproval]
+  confusion:  [confused, disoriented, puzzled, uncertain]
+  worried:    [worry, anxious, concerned]
+  bored:      [boredom, dull, listless]
+
+# Per-canonical render hints consumed across modules.
+#   oled    -> bitmap/animation name in oled_faces catalog
+#   palette -> neopixel emotion palette file (modules/neopixel/emotions/<palette>.yml)
+#   effect  -> neopixel animation effect
+#   ears    -> piservo emotion pose key
+#   tone    -> speak TTS tone preset
+#   rgb     -> direct fallback color when a palette is unavailable
+render:
+  neutral:    { oled: normal,     palette: neutral,      effect: BREATHE,        ears: neutral,   tone: neutral,  rgb: [40, 60, 80] }
+  joy:        { oled: happy,      palette: joy,          effect: RAINBOW_CYCLE,  ears: joy,       tone: joy,      rgb: [0, 200, 60] }
+  sadness:    { oled: sad,        palette: sadness,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [40, 80, 160] }
+  curiosity:  { oled: focused,    palette: curiosity,    effect: COMET,          ears: curiosity, tone: neutral,  rgb: [0, 180, 200] }
+  tired:      { oled: sleepy,     palette: neutral,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [80, 40, 120] }
+  fear:       { oled: scared,     palette: nervousness,  effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 0, 120] }
+  anger:      { oled: angry,      palette: annoyance,    effect: PULSE,          ears: anger,     tone: excited,  rgb: [220, 40, 0] }
+  furious:    { oled: furious,    palette: annoyance,    effect: METEOR,         ears: anger,     tone: excited,  rgb: [255, 0, 0] }
+  surprise:   { oled: surprised,  palette: surprise,     effect: TWINKLE,        ears: surprise,  tone: excited,  rgb: [255, 200, 0] }
+  excitement: { oled: excited,    palette: excitement,   effect: RAINBOW_CYCLE,  ears: surprise,  tone: excited,  rgb: [255, 120, 0] }
+  love:       { oled: happy,      palette: love,         effect: PULSE,          ears: joy,       tone: joy,      rgb: [255, 40, 100] }
+  disgust:    { oled: worried,    palette: disgust,      effect: BREATHE,        ears: sadness,   tone: neutral,  rgb: [120, 160, 0] }
+  confusion:  { oled: disoriented,palette: confusion,    effect: TWINKLE,        ears: curiosity, tone: neutral,  rgb: [160, 0, 200] }
+  worried:    { oled: worried,    palette: nervousness,  effect: BREATHE,        ears: fear,      tone: sadness,  rgb: [180, 100, 0] }
+  bored:      { oled: bored,      palette: neutral,      effect: BREATHE,        ears: sadness,   tone: neutral,  rgb: [60, 60, 60] }
+
+default_canonical: neutral

--- a/modules/common/emotion_vocab.py
+++ b/modules/common/emotion_vocab.py
@@ -1,0 +1,162 @@
+"""Canonical emotion vocabulary resolver.
+
+Unifies the historically divergent emotion labels used by autonomy (mood),
+oled_faces (events) and neopixel (palettes) into one canonical set with shared
+render hints (eyes / LEDs / ears / TTS tone).
+
+Usage::
+
+    from modules.common.emotion_vocab import get_vocab
+
+    vocab = get_vocab()
+    vocab.canonical("happy")            # -> "joy"
+    vocab.render("happy")               # -> EmotionRender(oled="happy", ...)
+    vocab.render("happy").palette       # -> "joy"
+
+The module is intentionally dependency-light (PyYAML only) so any service can
+import it without pulling heavy module graphs.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+logger = logging.getLogger("common.emotion_vocab")
+
+_CONFIG_PATH = Path(__file__).parent / "config" / "emotions.yml"
+
+
+@dataclass(frozen=True)
+class EmotionRender:
+    """Resolved render hints for a canonical emotion."""
+
+    canonical: str
+    oled: str = "normal"
+    palette: str = "neutral"
+    effect: str = "BREATHE"
+    ears: str = "neutral"
+    tone: str = "neutral"
+    rgb: tuple = (40, 60, 80)
+
+
+@dataclass
+class EmotionVocab:
+    """Resolver around the canonical emotion config."""
+
+    default_canonical: str = "neutral"
+    _alias_to_canonical: Dict[str, str] = field(default_factory=dict)
+    _render: Dict[str, EmotionRender] = field(default_factory=dict)
+
+    def canonical(self, label: Optional[str]) -> str:
+        """Map any incoming label to its canonical key."""
+        key = str(label or "").strip().lower()
+        if not key:
+            return self.default_canonical
+        if key in self._render:
+            return key
+        return self._alias_to_canonical.get(key, self.default_canonical)
+
+    def render(self, label: Optional[str]) -> EmotionRender:
+        """Resolve an incoming label to its render hints."""
+        canon = self.canonical(label)
+        return self._render.get(canon) or self._render.get(self.default_canonical) or EmotionRender(canon)
+
+    def is_known(self, label: Optional[str]) -> bool:
+        key = str(label or "").strip().lower()
+        return bool(key) and (key in self._render or key in self._alias_to_canonical)
+
+    def canonical_keys(self) -> List[str]:
+        return list(self._render.keys())
+
+
+def _coerce_rgb(value: Any, fallback: tuple = (40, 60, 80)) -> tuple:
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        try:
+            return (int(value[0]), int(value[1]), int(value[2]))
+        except (TypeError, ValueError):
+            return fallback
+    return fallback
+
+
+def load_vocab(path: Optional[Path] = None) -> EmotionVocab:
+    """Build an :class:`EmotionVocab` from the YAML config (falls back to defaults)."""
+    cfg_path = Path(path) if path else _CONFIG_PATH
+    data: Dict[str, Any] = {}
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except FileNotFoundError:
+        logger.warning("emotion config not found at %s, using minimal defaults", cfg_path)
+    except Exception as exc:  # malformed yaml should not crash a service
+        logger.warning("failed to load emotion config: %s", exc)
+
+    default_canon = str(data.get("default_canonical", "neutral")).lower()
+
+    render: Dict[str, EmotionRender] = {}
+    for canon, hints in (data.get("render") or {}).items():
+        canon_key = str(canon).strip().lower()
+        hints = hints if isinstance(hints, dict) else {}
+        render[canon_key] = EmotionRender(
+            canonical=canon_key,
+            oled=str(hints.get("oled", "normal")),
+            palette=str(hints.get("palette", "neutral")),
+            effect=str(hints.get("effect", "BREATHE")),
+            ears=str(hints.get("ears", "neutral")),
+            tone=str(hints.get("tone", "neutral")),
+            rgb=_coerce_rgb(hints.get("rgb")),
+        )
+
+    alias_to_canonical: Dict[str, str] = {}
+    for canon, aliases in (data.get("aliases") or {}).items():
+        canon_key = str(canon).strip().lower()
+        alias_to_canonical[canon_key] = canon_key
+        if isinstance(aliases, (list, tuple)):
+            for alias in aliases:
+                alias_to_canonical[str(alias).strip().lower()] = canon_key
+
+    if default_canon not in render:
+        render[default_canon] = EmotionRender(default_canon)
+
+    return EmotionVocab(
+        default_canonical=default_canon,
+        _alias_to_canonical=alias_to_canonical,
+        _render=render,
+    )
+
+
+_vocab_lock = threading.Lock()
+_vocab_singleton: Optional[EmotionVocab] = None
+
+
+def get_vocab() -> EmotionVocab:
+    """Process-wide cached vocabulary."""
+    global _vocab_singleton
+    if _vocab_singleton is None:
+        with _vocab_lock:
+            if _vocab_singleton is None:
+                _vocab_singleton = load_vocab()
+    return _vocab_singleton
+
+
+def canonical_emotion(label: Optional[str]) -> str:
+    return get_vocab().canonical(label)
+
+
+def emotion_render(label: Optional[str]) -> EmotionRender:
+    return get_vocab().render(label)
+
+
+__all__ = [
+    "EmotionRender",
+    "EmotionVocab",
+    "load_vocab",
+    "get_vocab",
+    "canonical_emotion",
+    "emotion_render",
+]

--- a/modules/common/tests/test_smoke.py
+++ b/modules/common/tests/test_smoke.py
@@ -1,0 +1,58 @@
+"""Smoke + behaviour tests for the canonical emotion vocabulary."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_import():
+    module = importlib.import_module("modules.common.emotion_vocab")
+    assert hasattr(module, "get_vocab")
+
+
+def test_config_loader():
+    from modules.common.emotion_vocab import load_vocab
+
+    vocab = load_vocab()
+    assert vocab.canonical_keys(), "expected at least one canonical emotion"
+    assert "neutral" in vocab.canonical_keys()
+
+
+def test_alias_resolution():
+    from modules.common.emotion_vocab import get_vocab
+
+    vocab = get_vocab()
+    assert vocab.canonical("happy") == "joy"
+    assert vocab.canonical("sad") == "sadness"
+    assert vocab.canonical("sleepy") == "tired"
+    assert vocab.canonical("angry") == "anger"
+    assert vocab.canonical("scared") == "fear"
+    # canonical labels resolve to themselves
+    assert vocab.canonical("joy") == "joy"
+
+
+def test_unknown_falls_back_to_default():
+    from modules.common.emotion_vocab import get_vocab
+
+    vocab = get_vocab()
+    assert vocab.canonical(None) == "neutral"
+    assert vocab.canonical("") == "neutral"
+    assert vocab.canonical("definitely-not-an-emotion") == "neutral"
+
+
+def test_render_hints_are_consistent():
+    from modules.common.emotion_vocab import emotion_render
+
+    render = emotion_render("happy")
+    assert render.canonical == "joy"
+    # the alias and the canonical must yield identical render hints
+    assert emotion_render("joy") == render
+    assert isinstance(render.rgb, tuple) and len(render.rgb) == 3
+    assert render.oled and render.palette and render.effect and render.ears and render.tone
+
+
+def test_service_init():
+    # The vocab acts as the module's "service": construct it from defaults.
+    from modules.common.emotion_vocab import EmotionVocab, load_vocab
+
+    assert isinstance(load_vocab(), EmotionVocab)

--- a/modules/gateway/services/bootstrap.py
+++ b/modules/gateway/services/bootstrap.py
@@ -1038,18 +1038,31 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
     interactions = started.get("interactions")
     piservo = started.get("piservo")
     if interactions is not None and piservo is not None and hasattr(interactions, "register_event_handler"):
+        # Map interaction events onto expressive ear motion. Emotion events keep
+        # the ears in sync with eyes/LEDs; sound/vision events add reactive
+        # gestures; wakeword keeps its dedicated perk-up gesture.
+        _ear_gesture_events = {
+            "wakeword.detected": "wakeword",
+            "sound.detected": "sound",
+            "vision.focus": "sound",
+            "vision.person": "sound",
+        }
+
         def _piservo_on_interaction(evt: str, data: Dict[str, Any]) -> None:
-            if evt != "wakeword.detected":
-                return
+            key = str(evt or "").strip().lower()
             try:
-                if hasattr(piservo, "gesture"):
-                    piservo.gesture("wakeword")
+                if key.startswith("emotion:") and hasattr(piservo, "emotion"):
+                    piservo.emotion(key.split(":", 1)[1])
+                    return
+                gesture = _ear_gesture_events.get(key)
+                if gesture and hasattr(piservo, "gesture"):
+                    piservo.gesture(gesture)
             except Exception:
                 pass
 
         try:
             interactions.register_event_handler(_piservo_on_interaction)
-            logger.info("interactions wakeword -> piservo gesture bridge mounted")
+            logger.info("interactions -> piservo ear expression bridge mounted")
         except Exception as exc:
             logger.warning("piservo interactions bridge mount failed: %s", exc)
 

--- a/modules/neopixel/emotions/anger.yml
+++ b/modules/neopixel/emotions/anger.yml
@@ -1,0 +1,21 @@
+colors:
+- name: COLOR_CRIMSON
+  r: 220
+  g: 20
+  b: 30
+- name: COLOR_FLAME
+  r: 255
+  g: 60
+  b: 0
+- name: COLOR_BLOOD_RED
+  r: 180
+  g: 0
+  b: 0
+- name: COLOR_EMBER
+  r: 255
+  g: 90
+  b: 20
+- name: COLOR_DARK_RED
+  r: 120
+  g: 0
+  b: 0

--- a/modules/neopixel/emotions/fear.yml
+++ b/modules/neopixel/emotions/fear.yml
@@ -1,0 +1,21 @@
+colors:
+- name: COLOR_MAGENTA_ALERT
+  r: 200
+  g: 0
+  b: 120
+- name: COLOR_VIOLET
+  r: 138
+  g: 43
+  b: 226
+- name: COLOR_PALE_GHOST
+  r: 180
+  g: 180
+  b: 255
+- name: COLOR_DEEP_INDIGO
+  r: 75
+  g: 0
+  b: 130
+- name: COLOR_COLD_CYAN
+  r: 0
+  g: 150
+  b: 200

--- a/modules/neopixel/emotions/joy.yml
+++ b/modules/neopixel/emotions/joy.yml
@@ -1,0 +1,21 @@
+colors:
+- name: COLOR_SPRING_GREEN
+  r: 0
+  g: 230
+  b: 118
+- name: COLOR_GOLDEN
+  r: 255
+  g: 214
+  b: 10
+- name: COLOR_SUNNY
+  r: 255
+  g: 179
+  b: 0
+- name: COLOR_LIME
+  r: 156
+  g: 255
+  b: 86
+- name: COLOR_AQUA_JOY
+  r: 64
+  g: 224
+  b: 208

--- a/modules/neopixel/emotions/loader.py
+++ b/modules/neopixel/emotions/loader.py
@@ -40,9 +40,33 @@ def _parse_color(value) -> ColorEntry:
     raise ValueError(f"Unsupported color format: {value!r}")
 
 
+def _resolve_palette_name(emotion: str) -> Optional[str]:
+    """Map an arbitrary emotion label onto a palette file name via the shared vocab.
+
+    Lets callers pass canonical autonomy moods (``joy``/``tired``) or any alias
+    (``happy``/``sleepy``) and still land on a real palette file.
+    """
+    try:
+        from modules.common.emotion_vocab import get_vocab  # lazy: optional dep
+
+        return get_vocab().render(emotion).palette
+    except Exception:
+        return None
+
+
 @dataclass
 class EmotionPalette:
     entries_by_emotion: Dict[str, List[ColorEntry]]
+
+    def _lookup(self, emotion: str) -> Optional[List[ColorEntry]]:
+        key = (emotion or "").lower()
+        lst = self.entries_by_emotion.get(key)
+        if lst:
+            return lst
+        palette_name = _resolve_palette_name(key)
+        if palette_name and palette_name != key:
+            return self.entries_by_emotion.get(palette_name)
+        return None
 
     def random_color(self, emotion: str) -> Color:
         # Backward compatible simple color picker
@@ -50,13 +74,13 @@ class EmotionPalette:
         return ent.color
 
     def random_entry(self, emotion: str) -> ColorEntry:
-        lst = self.entries_by_emotion.get(emotion.lower())
+        lst = self._lookup(emotion)
         if lst:
             return random.choice(lst)
         return ColorEntry("fallback", (255, 255, 255))
 
     def get_by_name(self, emotion: str, name: str) -> Optional[ColorEntry]:
-        lst = self.entries_by_emotion.get(emotion.lower())
+        lst = self._lookup(emotion)
         if not lst:
             return None
         name = name.lower()

--- a/modules/neopixel/services/runner.py
+++ b/modules/neopixel/services/runner.py
@@ -38,6 +38,38 @@ except Exception:
     from effects import wheel  # type: ignore
 
 
+class _SegmentView:
+    """Adapter that exposes a driver sub-range as if it were a full strip.
+
+    Lets the existing whole-strip animation functions run on a single
+    segment without modifying them: index ``i`` is remapped to
+    ``start + i`` and out-of-range writes are ignored.
+    """
+
+    def __init__(self, driver: Any, start: int, end: int) -> None:
+        self._driver = driver
+        self._start = start
+        self._end = end
+        self.num_leds = max(0, end - start)
+
+    def set(self, idx: int, r: int, g: int, b: int) -> None:
+        if 0 <= idx < self.num_leds:
+            self._driver.set(self._start + idx, r, g, b)
+
+    def show(self) -> None:
+        self._driver.show()
+
+    def clear(self) -> None:
+        for i in range(self._start, self._end):
+            self._driver.set(i, 0, 0, 0)
+        self._driver.show()
+
+    def fill(self, r: int, g: int, b: int) -> None:
+        for i in range(self._start, self._end):
+            self._driver.set(i, r, g, b)
+        self._driver.show()
+
+
 class NeoRunner:
     def __init__(
         self,
@@ -288,61 +320,20 @@ class NeoRunner:
         cols = self._colors_from_emotions(emotions)
         c1 = color if color is not None else (cols[0] if cols else None)
 
-        # Segment target currently supports deterministic color output.
+        # Segment target: run the *actual* animation scoped to the segment's
+        # LED range (falling back to a solid fill for that segment only).
         if segment:
-            if c1 is None:
-                c1 = (255, 255, 255)
-            if self.fill_segment(segment, *c1):
+            bounds = self._segment_bounds(segment)
+            if bounds is not None:
+                start, end = bounds
+                view = _SegmentView(self.driver, start, end)
+                if not self._run_named_animation(name, view, cols, c1, iterations):
+                    fill = c1 if c1 is not None else (255, 255, 255)
+                    view.fill(*fill)
                 return
+            # Unknown segment name: degrade to whole-strip behaviour below.
 
-        name = name.upper()
-        c2 = cols[1] if len(cols) > 1 else None
-        # Map names to functions
-        if name == "RAINBOW":
-            anim_rainbow(self.driver, c1, iterations or 1)
-        elif name == "RAINBOW_CYCLE":
-            rainbow_cycle(self.driver, c1, iterations or 1)
-        elif name == "SPINNER":
-            anim_spinner(self.driver, c1 or (255, 0, 0), iterations or 1)
-        elif name == "BREATHE":
-            anim_breathe(self.driver, c1 or (255, 0, 0), iterations or 1)
-        elif name == "METEOR":
-            meteor_rain(self.driver, c1 or (255, 255, 255))
-        elif name == "FIRE":
-            fire_flicker(self.driver, c1 or (255, 165, 0))
-        elif name == "COMET":
-            anim_comet(self.driver, c1 or (0, 255, 255))
-        elif name == "WAVE":
-            anim_wave(self.driver, c1)
-        elif name == "PULSE":
-            anim_pulse(self.driver, c1 or (255, 0, 127))
-        elif name == "TWINKLE":
-            anim_twinkle(self.driver, c1 or (255, 255, 255))
-        elif name == "COLOR_WIPE":
-            color_wipe(self.driver, c1 or (255, 0, 0))
-        elif name == "RANDOM_BLINK":
-            random_blink(self.driver, c1)
-        elif name == "THEATER_CHASE":
-            anim_theater_chase(self.driver, c1 or (127, 127, 127))
-        elif name == "SNOW":
-            anim_snow(self.driver, c1 or (255, 255, 255))
-        elif name == "ALTERNATING":
-            alternating_colors(self.driver, c1 or (255, 0, 0), c2 or (0, 0, 255))
-        elif name == "GRADIENT":
-            gradient_fade(self.driver, 5, c1)
-        elif name == "BOUNCING_BALL":
-            bouncing_ball(self.driver, c1 or (255, 0, 0))
-        elif name == "RUNNING_LIGHTS":
-            running_lights(self.driver, c1 or (255, 0, 0))
-        elif name == "STACKED_BARS":
-            stacked_bars(self.driver, 50, c1)
-        elif name == "MULTI_GRADIENT":
-            if cols:
-                multi_color_gradient(self.driver, cols, iterations or 5)
-        elif name == "MULTI_WAVE":
-            if cols:
-                multi_color_wave(self.driver, cols, iterations or 5)
-        else:
+        if not self._run_named_animation(name, self.driver, cols, c1, iterations):
             # Unknown animation name: try backend-native animation first.
             r, g, b = c1 if c1 else (255, 255, 255)
             if self.driver.animate(name_lower, r, g, b, iterations or 0, 50):
@@ -350,6 +341,69 @@ class NeoRunner:
             # last-resort fallback simple fill
             if c1:
                 self.fill(*c1)
+
+    def _run_named_animation(
+        self,
+        name: str,
+        driver: Any,
+        cols: list[tuple[int, int, int]],
+        c1: tuple[int, int, int] | None,
+        iterations: int | None,
+    ) -> bool:
+        """Dispatch a named animation onto ``driver`` (full strip or segment view).
+
+        Returns ``False`` when the name is not a known software animation.
+        """
+        name = name.upper()
+        c2 = cols[1] if len(cols) > 1 else None
+        # Map names to functions
+        if name == "RAINBOW":
+            anim_rainbow(driver, c1, iterations or 1)
+        elif name == "RAINBOW_CYCLE":
+            rainbow_cycle(driver, c1, iterations or 1)
+        elif name == "SPINNER":
+            anim_spinner(driver, c1 or (255, 0, 0), iterations or 1)
+        elif name == "BREATHE":
+            anim_breathe(driver, c1 or (255, 0, 0), iterations or 1)
+        elif name == "METEOR":
+            meteor_rain(driver, c1 or (255, 255, 255))
+        elif name == "FIRE":
+            fire_flicker(driver, c1 or (255, 165, 0))
+        elif name == "COMET":
+            anim_comet(driver, c1 or (0, 255, 255))
+        elif name == "WAVE":
+            anim_wave(driver, c1)
+        elif name == "PULSE":
+            anim_pulse(driver, c1 or (255, 0, 127))
+        elif name == "TWINKLE":
+            anim_twinkle(driver, c1 or (255, 255, 255))
+        elif name == "COLOR_WIPE":
+            color_wipe(driver, c1 or (255, 0, 0))
+        elif name == "RANDOM_BLINK":
+            random_blink(driver, c1)
+        elif name == "THEATER_CHASE":
+            anim_theater_chase(driver, c1 or (127, 127, 127))
+        elif name == "SNOW":
+            anim_snow(driver, c1 or (255, 255, 255))
+        elif name == "ALTERNATING":
+            alternating_colors(driver, c1 or (255, 0, 0), c2 or (0, 0, 255))
+        elif name == "GRADIENT":
+            gradient_fade(driver, 5, c1)
+        elif name == "BOUNCING_BALL":
+            bouncing_ball(driver, c1 or (255, 0, 0))
+        elif name == "RUNNING_LIGHTS":
+            running_lights(driver, c1 or (255, 0, 0))
+        elif name == "STACKED_BARS":
+            stacked_bars(driver, 50, c1)
+        elif name == "MULTI_GRADIENT":
+            if cols:
+                multi_color_gradient(driver, cols, iterations or 5)
+        elif name == "MULTI_WAVE":
+            if cols:
+                multi_color_wave(driver, cols, iterations or 5)
+        else:
+            return False
+        return True
 
     def _animate_worker_loop(self) -> None:
         while True:

--- a/modules/neopixel/tests/test_segments.py
+++ b/modules/neopixel/tests/test_segments.py
@@ -42,14 +42,27 @@ def test_fill_segment_applies_only_target_range():
     assert runner.driver.buf[3:] == [(0, 0, 0)] * 7
 
 
-def test_animate_segment_falls_back_to_segment_fill():
+def test_animate_unknown_effect_on_segment_falls_back_to_segment_fill():
     runner = NeoRunner(NeoDriverConfig(num_leds=6), segments=[{"name": "jewel", "start": 0, "count": 2}])
     runner.driver = _FakeDriver(6)
-    runner.animate("PULSE", color=(10, 20, 30), segment="jewel")
+    runner.animate("NO_SUCH_EFFECT", color=(10, 20, 30), segment="jewel")
     runner._wait_for_animations()
     assert runner.driver.buf[0] == (10, 20, 30)
     assert runner.driver.buf[1] == (10, 20, 30)
     assert runner.driver.buf[2:] == [(0, 0, 0)] * 4
+
+
+def test_animate_known_effect_runs_scoped_to_segment():
+    # A real animation must run on the segment range only, leaving the rest dark.
+    runner = NeoRunner(NeoDriverConfig(num_leds=6), segments=[{"name": "jewel", "start": 0, "count": 2}])
+    runner.driver = _FakeDriver(6)
+    runner.animate("PULSE", color=(200, 100, 50), segment="jewel")
+    runner._wait_for_animations()
+    # Segment LEDs were driven by the effect (non-zero), neighbours untouched.
+    assert runner.driver.buf[0] != (0, 0, 0)
+    assert runner.driver.buf[1] != (0, 0, 0)
+    assert runner.driver.buf[2:] == [(0, 0, 0)] * 4
+    assert runner.driver.shows > 0
 
 
 def test_apply_preset_sets_segment_colors():

--- a/modules/neopixel/tests/test_smoke.py
+++ b/modules/neopixel/tests/test_smoke.py
@@ -16,3 +16,15 @@ def test_basic_effects_smoke():
     col = store.random_color("joy")
     assert isinstance(col, tuple) and len(col) == 3
     r.emote_sequence(["joy", "fear"], duration=0)
+
+
+def test_emotion_palette_alias_resolution():
+    # Canonical labels and aliases must resolve to a real palette colour
+    # instead of the white (255,255,255) fallback.
+    store = EmotionStore()
+    palette = store.load()
+    assert "joy" in palette.entries_by_emotion
+    assert "anger" in palette.entries_by_emotion
+    # alias 'happy' resolves through the shared vocab to the 'joy' palette
+    assert store.random_color("happy") != (255, 255, 255)
+    assert store.random_color("scared") != (255, 255, 255)

--- a/modules/oled_faces/services/mapper.py
+++ b/modules/oled_faces/services/mapper.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+try:  # keep oled_faces importable even if the shared helper is unavailable
+    from modules.common.emotion_vocab import get_vocab as _get_emotion_vocab
+except Exception:  # pragma: no cover - defensive fallback
+    _get_emotion_vocab = None
+
 
 @dataclass(frozen=True)
 class OledAction:
@@ -43,9 +48,25 @@ class FaceMapper:
         if not emotions:
             return OledAction(mode="bitmap", name=self.idle_bitmap)
         key = str(emotions[0]).strip().lower()
+        # 1) Honour an explicit event_map override if present for this label.
         mapped = self.event_map.get(f"emotion:{key}")
         if isinstance(mapped, dict):
             return OledAction(mode=str(mapped.get("mode", "bitmap")), name=str(mapped.get("name", self.fallback_unknown)))
+        # 2) Resolve through the canonical vocabulary so divergent labels
+        #    (joy/happy, tired/sleepy, anger/angry) land on a real bitmap.
+        if _get_emotion_vocab is not None:
+            try:
+                render = _get_emotion_vocab().render(key)
+                canon_override = self.event_map.get(f"emotion:{render.canonical}")
+                if isinstance(canon_override, dict):
+                    return OledAction(
+                        mode=str(canon_override.get("mode", "bitmap")),
+                        name=str(canon_override.get("name", render.oled)),
+                    )
+                if render.oled in self.catalog_bitmaps:
+                    return OledAction(mode="bitmap", name=render.oled)
+            except Exception:
+                pass
         return OledAction(mode="bitmap", name=self.fallback_unknown)
 
     def from_interaction_event(self, event_type: str) -> OledAction:

--- a/modules/oled_faces/services/pi_ssd1306_driver.py
+++ b/modules/oled_faces/services/pi_ssd1306_driver.py
@@ -106,9 +106,22 @@ class PiSsd1306Driver:
         if bmp is None and key != "normal":
             bmp = self._load_bitmap("normal")
         if bmp is None:
-            return False
+            # No committed bitmap asset: keep the eyes expressive by drawing a
+            # procedural face for this expression directly into the buffer.
+            return self._render_procedural_face(key)
         with self._lock:
             self._buffer[:] = bmp
+            self.flush()
+        return True
+
+    def _render_procedural_face(self, name: str) -> bool:
+        try:
+            from .procedural_face import draw_face
+        except Exception:
+            from procedural_face import draw_face  # type: ignore
+        with self._lock:
+            self.clear()
+            draw_face(name, self.width, self.height, lambda x, y: self.set_pixel(x, y, 1))
             self.flush()
         return True
 

--- a/modules/oled_faces/services/procedural_face.py
+++ b/modules/oled_faces/services/procedural_face.py
@@ -1,0 +1,176 @@
+"""Procedural 1-bit face rasteriser.
+
+Fallback used when a pre-baked OLED bitmap asset is missing from disk. Draws a
+simple, recognisable face (eyes + brows + mouth) for a given emotion so the
+robot's eyes stay expressive even on a fresh checkout without committed binary
+bitmaps.
+
+The renderer is hardware-agnostic: it draws through a ``plot(x, y)`` callback so
+it can target the SSD1306 page buffer on a Pi or a plain grid in tests.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+try:
+    from modules.common.emotion_vocab import get_vocab as _get_emotion_vocab
+except Exception:  # pragma: no cover - optional dependency
+    _get_emotion_vocab = None
+
+Plot = Callable[[int, int], None]
+
+
+# Per-style eye/mouth/brow descriptors. Keyed by canonical emotion plus a few
+# direct gaze/blink poses that are not emotions.
+_EYE_OPEN = "open"
+_EYE_HAPPY = "happy"      # upward arc ^ ^
+_EYE_NARROW = "narrow"    # half-closed line
+_EYE_WIDE = "wide"        # big round
+_EYE_CLOSED = "closed"    # flat line (blink)
+
+_MOUTH_SMILE = "smile"
+_MOUTH_FROWN = "frown"
+_MOUTH_FLAT = "flat"
+_MOUTH_OPEN = "open"      # small "o"
+
+_STYLES: Dict[str, Dict[str, object]] = {
+    "neutral":    {"eye": _EYE_OPEN,   "mouth": _MOUTH_FLAT,  "brow": 0},
+    "joy":        {"eye": _EYE_HAPPY,  "mouth": _MOUTH_SMILE, "brow": 0},
+    "excitement": {"eye": _EYE_WIDE,   "mouth": _MOUTH_SMILE, "brow": 0},
+    "love":       {"eye": _EYE_HAPPY,  "mouth": _MOUTH_SMILE, "brow": 0},
+    "sadness":    {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": 1},
+    "tired":      {"eye": _EYE_NARROW, "mouth": _MOUTH_FLAT,  "brow": 0},
+    "bored":      {"eye": _EYE_NARROW, "mouth": _MOUTH_FLAT,  "brow": 0},
+    "fear":       {"eye": _EYE_WIDE,   "mouth": _MOUTH_OPEN,  "brow": 1},
+    "worried":    {"eye": _EYE_OPEN,   "mouth": _MOUTH_FROWN, "brow": 1},
+    "anger":      {"eye": _EYE_OPEN,   "mouth": _MOUTH_FROWN, "brow": -1},
+    "furious":    {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": -1},
+    "surprise":   {"eye": _EYE_WIDE,   "mouth": _MOUTH_OPEN,  "brow": 0},
+    "curiosity":  {"eye": _EYE_OPEN,   "mouth": _MOUTH_FLAT,  "brow": 0},
+    "disgust":    {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": -1},
+    "confusion":  {"eye": _EYE_OPEN,   "mouth": _MOUTH_FLAT,  "brow": 1},
+}
+
+# Direct (non-emotion) poses handled before vocab resolution.
+_DIRECT: Dict[str, Dict[str, object]] = {
+    "normal":  {"eye": _EYE_OPEN,   "mouth": _MOUTH_FLAT,  "brow": 0},
+    "blink":   {"eye": _EYE_CLOSED, "mouth": _MOUTH_FLAT,  "brow": 0},
+    "happy":   {"eye": _EYE_HAPPY,  "mouth": _MOUTH_SMILE, "brow": 0},
+    "sad":     {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": 1},
+    "angry":   {"eye": _EYE_OPEN,   "mouth": _MOUTH_FROWN, "brow": -1},
+    "furious": {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": -1},
+    "sleepy":  {"eye": _EYE_NARROW, "mouth": _MOUTH_FLAT,  "brow": 0},
+    "surprised": {"eye": _EYE_WIDE, "mouth": _MOUTH_OPEN,  "brow": 0},
+    "focused": {"eye": _EYE_NARROW, "mouth": _MOUTH_FLAT,  "brow": 0},
+}
+
+
+def _style_for(name: str) -> Dict[str, object]:
+    key = str(name or "").strip().lower()
+    if key in _DIRECT:
+        return _DIRECT[key]
+    canon = key
+    if _get_emotion_vocab is not None:
+        try:
+            canon = _get_emotion_vocab().canonical(key)
+        except Exception:
+            canon = key
+    return _STYLES.get(canon, _STYLES["neutral"])
+
+
+def _hline(plot: Plot, x0: int, x1: int, y: int) -> None:
+    if x1 < x0:
+        x0, x1 = x1, x0
+    for x in range(x0, x1 + 1):
+        plot(x, y)
+
+
+def _vline(plot: Plot, x: int, y0: int, y1: int) -> None:
+    if y1 < y0:
+        y0, y1 = y1, y0
+    for y in range(y0, y1 + 1):
+        plot(x, y)
+
+
+def _rect(plot: Plot, x0: int, y0: int, x1: int, y1: int, fill: bool) -> None:
+    if fill:
+        for y in range(y0, y1 + 1):
+            _hline(plot, x0, x1, y)
+    else:
+        _hline(plot, x0, x1, y0)
+        _hline(plot, x0, x1, y1)
+        _vline(plot, x0, y0, y1)
+        _vline(plot, x1, y0, y1)
+
+
+def _arc_up(plot: Plot, cx: int, y: int, half: int) -> None:
+    # simple upward chevron ^ for happy eyes / smile
+    for dx in range(-half, half + 1):
+        plot(cx + dx, y + abs(dx) // 2)
+
+
+def _arc_down(plot: Plot, cx: int, y: int, half: int) -> None:
+    for dx in range(-half, half + 1):
+        plot(cx + dx, y - abs(dx) // 2)
+
+
+def _draw_eye(plot: Plot, cx: int, cy: int, shape: str) -> None:
+    if shape == _EYE_CLOSED:
+        _hline(plot, cx - 7, cx + 7, cy)
+    elif shape == _EYE_NARROW:
+        _rect(plot, cx - 7, cy - 1, cx + 7, cy + 2, fill=True)
+    elif shape == _EYE_WIDE:
+        _rect(plot, cx - 8, cy - 8, cx + 8, cy + 8, fill=False)
+        _rect(plot, cx - 6, cy - 6, cx + 6, cy + 6, fill=True)
+    elif shape == _EYE_HAPPY:
+        _arc_up(plot, cx, cy - 2, 7)
+        _arc_up(plot, cx, cy - 1, 7)
+    else:  # open
+        _rect(plot, cx - 6, cy - 6, cx + 6, cy + 6, fill=True)
+
+
+def _draw_brow(plot: Plot, cx: int, cy: int, direction: int) -> None:
+    if direction == 0:
+        return
+    if direction < 0:  # angry: inner-down
+        _arc_down(plot, cx, cy, 7)
+    else:  # worried/sad: inner-up
+        _arc_up(plot, cx, cy, 7)
+
+
+def _draw_mouth(plot: Plot, cx: int, cy: int, shape: str) -> None:
+    if shape == _MOUTH_SMILE:
+        _arc_up(plot, cx, cy - 3, 10)
+    elif shape == _MOUTH_FROWN:
+        _arc_down(plot, cx, cy + 3, 10)
+    elif shape == _MOUTH_OPEN:
+        _rect(plot, cx - 4, cy - 4, cx + 4, cy + 4, fill=False)
+    else:  # flat
+        _hline(plot, cx - 8, cx + 8, cy)
+
+
+def draw_face(name: str, width: int, height: int, plot: Plot) -> str:
+    """Rasterise a face for ``name`` via ``plot``; returns the resolved style id."""
+    style = _style_for(name)
+    cx = width // 2
+    eye_y = height // 3
+    eye_dx = width // 4
+    left_x = cx - eye_dx
+    right_x = cx + eye_dx
+    mouth_y = (height * 3) // 4
+
+    brow = int(style.get("brow", 0))
+    eye_shape = str(style.get("eye", _EYE_OPEN))
+    mouth_shape = str(style.get("mouth", _MOUTH_FLAT))
+
+    if brow != 0:
+        _draw_brow(plot, left_x, eye_y - 10, brow)
+        _draw_brow(plot, right_x, eye_y - 10, brow)
+    _draw_eye(plot, left_x, eye_y, eye_shape)
+    _draw_eye(plot, right_x, eye_y, eye_shape)
+    _draw_mouth(plot, cx, mouth_y, mouth_shape)
+    return f"{eye_shape}/{mouth_shape}/{brow}"
+
+
+__all__ = ["draw_face"]

--- a/modules/oled_faces/tests/test_procedural_face.py
+++ b/modules/oled_faces/tests/test_procedural_face.py
@@ -1,0 +1,48 @@
+"""Tests for the procedural face fallback rasteriser."""
+
+from __future__ import annotations
+
+from modules.oled_faces.services.procedural_face import draw_face
+
+
+def _render(name: str, w: int = 128, h: int = 64):
+    pixels = set()
+
+    def plot(x: int, y: int) -> None:
+        if 0 <= x < w and 0 <= y < h:
+            pixels.add((x, y))
+
+    style = draw_face(name, w, h, plot)
+    return pixels, style
+
+
+def test_draws_within_bounds_and_non_empty():
+    pixels, _ = _render("normal")
+    assert pixels, "expected the face to draw at least some pixels"
+    for x, y in pixels:
+        assert 0 <= x < 128 and 0 <= y < 64
+
+
+def test_emotions_produce_distinct_faces():
+    happy, _ = _render("happy")
+    sad, _ = _render("sad")
+    angry, _ = _render("angry")
+    surprised, _ = _render("surprised")
+    # different expressions must not be pixel-identical
+    assert happy != sad
+    assert happy != angry
+    assert sad != surprised
+
+
+def test_aliases_match_canonical_via_vocab():
+    # 'happy' is a direct pose; 'joy' resolves through the vocab to the same look
+    happy, _ = _render("happy")
+    joy, _ = _render("joy")
+    assert happy == joy
+
+
+def test_blink_is_minimal():
+    blink, style = _render("blink")
+    normal, _ = _render("normal")
+    # closed eyes should draw fewer pixels than open eyes
+    assert len(blink) < len(normal)

--- a/modules/oled_faces/tests/test_smoke.py
+++ b/modules/oled_faces/tests/test_smoke.py
@@ -6,3 +6,17 @@ def test_mapper_has_full_catalog():
     assert len(mapper.catalog_bitmaps) >= 32
     assert "normal" in mapper.catalog_bitmaps
     assert "all" in mapper.catalog_animations
+
+
+def test_canonical_emotion_resolves_to_face():
+    # autonomy emits canonical labels (joy/tired/anger) that have no direct
+    # `emotion:<label>` entry; they must still land on a real bitmap.
+    mapper = FaceMapper({})
+    assert mapper.from_emotions(["joy"]).name == "happy"
+    assert mapper.from_emotions(["tired"]).name == "sleepy"
+    assert mapper.from_emotions(["anger"]).name == "angry"
+
+
+def test_explicit_event_map_override_wins():
+    mapper = FaceMapper({"event_map": {"emotion:happy": {"mode": "bitmap", "name": "excited"}}})
+    assert mapper.from_emotions(["happy"]).name == "excited"

--- a/modules/piservo/services/ears.py
+++ b/modules/piservo/services/ears.py
@@ -21,6 +21,27 @@ EMOTION_POSES: Dict[str, EarPose] = {
 }
 
 
+def pose_for_emotion(name: str) -> EarPose:
+    """Resolve an arbitrary emotion label to an ear pose.
+
+    Accepts canonical autonomy moods or any alias (happy/sleepy/angry) by
+    routing through the shared emotion vocabulary, then falling back to a
+    direct table lookup and finally to the neutral pose.
+    """
+    key = str(name or "").strip().lower()
+    if key in EMOTION_POSES:
+        return EMOTION_POSES[key]
+    try:
+        from modules.common.emotion_vocab import get_vocab  # lazy optional dep
+
+        ears_key = get_vocab().render(key).ears
+        if ears_key in EMOTION_POSES:
+            return EMOTION_POSES[ears_key]
+    except Exception:
+        pass
+    return EMOTION_POSES["neutral"]
+
+
 def gesture_wakeword() -> Tuple[float, float]:
     # quick raise both then relax
     return (60, 60)

--- a/modules/piservo/services/runner.py
+++ b/modules/piservo/services/runner.py
@@ -3,10 +3,10 @@ import time
 
 try:
     from .driver import Servo, ServoConfig
-    from .ears import EMOTION_POSES, gesture_sound, gesture_wakeword
+    from .ears import EMOTION_POSES, gesture_sound, gesture_wakeword, pose_for_emotion
 except Exception:
     from driver import Servo, ServoConfig  # type: ignore
-    from ears import EMOTION_POSES, gesture_sound, gesture_wakeword  # type: ignore
+    from ears import EMOTION_POSES, gesture_sound, gesture_wakeword, pose_for_emotion  # type: ignore
 
 
 class EarRunner:
@@ -21,7 +21,7 @@ class EarRunner:
         self.right.set_angle(right)
 
     def emotion(self, name: str) -> None:
-        pose = EMOTION_POSES.get(name.lower(), EMOTION_POSES.get("neutral", None))
+        pose = pose_for_emotion(name)
         if not pose:
             return
         self.set_angles(pose.left, pose.right)

--- a/modules/piservo/tests/test_smoke.py
+++ b/modules/piservo/tests/test_smoke.py
@@ -17,3 +17,18 @@ def test_set_angles():
     r = client.post("/piservo/set", params={"left": 90, "right": 90})
     assert r.status_code == 200
     assert r.json().get("ok") is True
+
+
+def test_ear_pose_resolves_emotion_aliases():
+    from modules.piservo.services.ears import EMOTION_POSES, pose_for_emotion
+
+    # canonical labels map straight through
+    assert pose_for_emotion("joy") == EMOTION_POSES["joy"]
+    # aliases resolve via the shared vocabulary
+    assert pose_for_emotion("happy") == EMOTION_POSES["joy"]
+    assert pose_for_emotion("scared") == EMOTION_POSES["fear"]
+    assert pose_for_emotion("angry") == EMOTION_POSES["anger"]
+    # tired has no dedicated pose -> mapped onto sadness ears
+    assert pose_for_emotion("tired") == EMOTION_POSES["sadness"]
+    # unknown -> neutral
+    assert pose_for_emotion("???") == EMOTION_POSES["neutral"]

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -75,12 +75,21 @@ except Exception:
     VisionSampler = None  # type: ignore
 
 try:
-    from .vision_event_bus import VisionEventBus, EVENT_HAZARD_DETECTED, EVENT_NEW_PERSON, EVENT_OWNER_SEEN
+    from .vision_event_bus import (
+        VisionEventBus,
+        EVENT_HAZARD_DETECTED,
+        EVENT_NEW_PERSON,
+        EVENT_OWNER_SEEN,
+        EVENT_SCENE_CHANGED,
+        EVENT_VLM_RESULT_READY,
+    )
 except Exception:
     VisionEventBus = None  # type: ignore
     EVENT_HAZARD_DETECTED = "hazard_detected"
     EVENT_NEW_PERSON = "new_person"
     EVENT_OWNER_SEEN = "owner_seen"
+    EVENT_SCENE_CHANGED = "scene_changed"
+    EVENT_VLM_RESULT_READY = "vlm_result_ready"
 
 try:
     from .head_control_arbiter import HeadControlArbiter, HeadCommand
@@ -708,6 +717,10 @@ class VisionProcessor:
                     parsed_results = list(parsed_results) + extras
             self.latest_results = parsed_results
 
+            # Continuous "living vision": let the sampler decide when to refresh
+            # the richer VLM scene context (idle cadence + scene-change driven).
+            self._maybe_sample_vlm(parsed_results)
+
             # Follow aktifken VLM sahne aksiyonu / tehlike anonsu bastirilir,
             # odak yuz kilidi ve takip akisinda kalir.
             self._handle_person_interactions(parsed_results)
@@ -724,6 +737,60 @@ class VisionProcessor:
                     self._latest_annotated_frame = buf.tobytes()
 
             time.sleep(0.05)
+
+    # -----------------------------------------------------------------
+    # Living-vision sampling
+    # -----------------------------------------------------------------
+    @staticmethod
+    def _scene_signature(parsed_results: List[Dict[str, Any]]) -> frozenset:
+        sig = set()
+        for r in parsed_results or []:
+            if isinstance(r, dict):
+                sig.add((str(r.get("label", "")), str(r.get("name", ""))))
+        return frozenset(sig)
+
+    def _scene_change_score(self, parsed_results: List[Dict[str, Any]]) -> float:
+        sig = self._scene_signature(parsed_results)
+        prev = getattr(self, "_last_scene_signature", None)
+        self._last_scene_signature = sig
+        if prev is None:
+            return 0.0
+        union = prev | sig
+        if not union:
+            return 0.0
+        churn = prev ^ sig
+        return len(churn) / len(union)
+
+    def _maybe_sample_vlm(self, parsed_results: List[Dict[str, Any]]) -> None:
+        sampler = getattr(self, "vision_sampler", None)
+        if sampler is None:
+            return
+        if getattr(self, "_vlm_refresh_inflight", False):
+            return
+        score = self._scene_change_score(parsed_results)
+        try:
+            should = sampler.should_call_vlm(
+                scene_change_score=score,
+                follow_mode_active=bool(getattr(self, "_follow_active", False)),
+            )
+        except Exception:
+            return
+        if not should:
+            return
+        sampler.record_call()
+        self._vlm_refresh_inflight = True
+        threading.Thread(target=self._background_context_refresh, daemon=True).start()
+
+    def _background_context_refresh(self) -> None:
+        try:
+            context = self.refresh_visual_context()
+            if context is not None and self.event_bus is not None:
+                self.event_bus.publish(EVENT_SCENE_CHANGED, {"context": context})
+                self.event_bus.publish(EVENT_VLM_RESULT_READY, {"context": context})
+        except Exception:
+            pass
+        finally:
+            self._vlm_refresh_inflight = False
 
     # -----------------------------------------------------------------
     # Core analysis

--- a/modules/vlm_bridge/tests/test_vision_sampler_wiring.py
+++ b/modules/vlm_bridge/tests/test_vision_sampler_wiring.py
@@ -1,0 +1,73 @@
+"""Verifies the VisionSampler is wired into the processor's living-vision loop."""
+
+from __future__ import annotations
+
+import time
+
+from modules.vlm_bridge.services.processor import VisionProcessor
+from modules.vlm_bridge.services.vision_sampler import VisionSampler
+
+
+class _FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def publish(self, event_type, data=None):
+        self.events.append((event_type, data))
+
+
+def _bare_processor():
+    proc = VisionProcessor.__new__(VisionProcessor)
+    proc.vision_sampler = VisionSampler({"min_interval_s": 0.0, "scene_change_threshold": 0.3})
+    proc.event_bus = _FakeBus()
+    proc._follow_active = False
+    proc._vlm_refresh_inflight = False
+    proc._last_scene_signature = None
+    return proc
+
+
+def test_scene_change_score_detects_churn():
+    proc = _bare_processor()
+    # first observation establishes a baseline -> no change
+    assert proc._scene_change_score([{"label": "person", "name": "A"}]) == 0.0
+    # same scene -> no churn
+    assert proc._scene_change_score([{"label": "person", "name": "A"}]) == 0.0
+    # a new object appears -> non-zero churn
+    score = proc._scene_change_score([{"label": "person", "name": "A"}, {"label": "cup", "name": ""}])
+    assert score > 0.0
+
+
+def test_sampler_triggers_background_refresh_and_publishes():
+    proc = _bare_processor()
+    calls = {"n": 0}
+
+    def _fake_refresh(question: str = ""):
+        calls["n"] += 1
+        return {"summary": "a room"}
+
+    proc.refresh_visual_context = _fake_refresh  # type: ignore[assignment]
+
+    # establish baseline then introduce a strong scene change
+    proc._maybe_sample_vlm([])
+    proc._maybe_sample_vlm([{"label": "person", "name": "X"}, {"label": "dog", "name": ""}])
+
+    # background refresh runs on a daemon thread
+    for _ in range(50):
+        if calls["n"] > 0 and not proc._vlm_refresh_inflight:
+            break
+        time.sleep(0.02)
+
+    assert calls["n"] >= 1
+    published = {evt for evt, _ in proc.event_bus.events}
+    assert "scene_changed" in published
+    assert "vlm_result_ready" in published
+
+
+def test_follow_mode_suppresses_sampling():
+    proc = _bare_processor()
+    proc._follow_active = True
+    proc.refresh_visual_context = lambda question="": {"summary": "x"}  # type: ignore[assignment]
+    proc._maybe_sample_vlm([])
+    proc._maybe_sample_vlm([{"label": "person", "name": "Y"}])
+    time.sleep(0.1)
+    assert proc.event_bus.events == []


### PR DESCRIPTION
## Özet
Tek kanonik duygu sözlüğü, anger ekseni, affective appraisal ve çok modlu Expression Director eklendi. Gözler, LED, kulaklar, kafa ve ses tonu tek duygu kaynağından eşgüdümlü tetiklenir.

## Değişiklik tipi
- [ ] Hata düzeltmesi
- [x] Yeni özellik
- [x] Refactor
- [x] Dokümantasyon güncellemesi
- [x] Test güncellemesi

## Etkilenen modüller
`modules/common`, `modules/autonomy`, `modules/neopixel`, `modules/oled_faces`, `modules/piservo`, `modules/gateway`

## Doğrulama
- [x] Lokal çalıştırma tamamlandı (PC mock/sim)
- [x] İlgili testler geçiyor
- [x] Gerekli doküman/konfig güncellemeleri yapıldı

## Arduino Kontrat Kontrolü (uygunsa)
- [x] `contract.py` dışında elle Arduino payload yazılmadı
- [x] Kritik komutlar gerektiğinde `/arduino/request` kullanıyor
- [ ] Yeni komut ailesi builder + validator + test içeriyor (bu PR'da yok)

## Risk ve geri alma
Orta-düşük risk; duygu etiketleri kanonik vocab'a taşındı. Geri alma: branch revert.

## İlgili issue
N/A
