### PR TITLE
release: companion liveliness roadmap (Phases 0-6)

### DIFF
--- a/.sentrybot/context/architecture-summary.md
+++ b/.sentrybot/context/architecture-summary.md
@@ -133,6 +133,18 @@ ACT   → LLM yanıtını parse et, donanım HTTP çağrıları yap
 - **Doğal barge-in:** `BargeInController` robot konuşurken kullanıcının anlamlı
   konuşmasıyla (sadece wakeword değil) sözü kesmesine izin verir.
 
+### Firmware Canlılık Köprüsü (Firmware Liveliness Bridge)
+
+- **Kontrat komutu:** `arduino_serial/contract.py` `build_liveliness_cmd` +
+  `validate_liveliness_cmd` (elle payload YOK) → `/arduino/request` ile gönderilir.
+- **Firmware-native hareket:** Mega `xCommands.h` `liveliness` komutunu işler,
+  `livelinessTick()` ana döngüde kafa servolarında yumuşak sinüs nefes/mikro-
+  hareket üretir (Pi köprüsü kısa süre dursa bile canlı kalır).
+- **Mood→hareket:** autonomy `LivelinessScheduler` baskın duygu+enerjiden
+  genlik/tempo/mod üretir (excited=büyük/hızlı, tired=küçük/yavaş, anger=micro).
+- **Akıllı gönderim:** brain `_liveliness_tick` yalnızca parametre değişince ya da
+  `refresh_interval_s` geçince yollar; konuşma/takip/uyku sırasında bastırılır.
+
 ## Güvenlik ve Dayanıklılık
 
 - **Owner kontrolü:** VLM + RFID ile sahip doğrulaması

--- a/.sentrybot/context/architecture-summary.md
+++ b/.sentrybot/context/architecture-summary.md
@@ -95,6 +95,18 @@ THINK → Duygu bozunması, sıkılma kontrolü, uyku saati kontrolü
 ACT   → LLM yanıtını parse et, donanım HTTP çağrıları yap
 ```
 
+### Duygusal Model (Affective Model)
+
+- **Mood eksenleri:** happiness, energy, curiosity, fear, **anger** (öfke ekseni
+  `anger>45 → anger`, `anger>75 → furious` baskın duygularını üretir).
+- **Affective appraisal** (`services/affective_appraisal.py` + `config/appraisal.yml`):
+  semantik olayları (`user_rude`, `owner_returned`, `command_failed`…) mood
+  deltalarına çevirir → duygular zamansal bozunmadan değil **nedenden** doğar.
+- **Tek duygu sözlüğü:** tüm görsel/işitsel çıktılar `modules/common` kanonik
+  duygu vocab'ından çözülür (eyes/LEDs/ears/tone aynı taksonomi).
+- **Expression Director** (`services/expression_director.py`): tek çağrıda
+  gözler + LED + kulaklar + kafa + ses tonunu eşgüdümlü tetikler (`brain.express`).
+
 ## Güvenlik ve Dayanıklılık
 
 - **Owner kontrolü:** VLM + RFID ile sahip doğrulaması

--- a/.sentrybot/context/architecture-summary.md
+++ b/.sentrybot/context/architecture-summary.md
@@ -121,6 +121,18 @@ ACT   → LLM yanıtını parse et, donanım HTTP çağrıları yap
 - **Proaktif betimleme:** `ProactivePlanner` boştayken yeni/önemli sahneyi
   doğal dille anlatır (`companion.scene_comment`).
 
+### Doğal Konuşma (Natural Speech)
+
+- **Duygulu prosodi:** `speak` tonu artık Piper sesini de şekillendirir
+  (`_tone_to_piper` → `length_scale`/`noise_w`); ton `agent_core` kuyruğundan
+  TTS'e kadar korunur (`_handle_speak` tone forward).
+- **Tek ton kaynağı:** autonomy `_tone_profile` kanonik duygu vocab'ından
+  çözülür → ses/göz/LED/kulak aynı duygu taksonomisini paylaşır.
+- **Disfluency/filler:** `SpeakService._enrich_text_for_speech` olasılıkla ve
+  duygu-havuzuna göre doğal dolgu ekler ("Şey,", "Hmm,", "Aa,").
+- **Doğal barge-in:** `BargeInController` robot konuşurken kullanıcının anlamlı
+  konuşmasıyla (sadece wakeword değil) sözü kesmesine izin verir.
+
 ## Güvenlik ve Dayanıklılık
 
 - **Owner kontrolü:** VLM + RFID ile sahip doğrulaması

--- a/.sentrybot/context/architecture-summary.md
+++ b/.sentrybot/context/architecture-summary.md
@@ -107,6 +107,20 @@ ACT   → LLM yanıtını parse et, donanım HTTP çağrıları yap
 - **Expression Director** (`services/expression_director.py`): tek çağrıda
   gözler + LED + kulaklar + kafa + ses tonunu eşgüdümlü tetikler (`brain.express`).
 
+### Sürekli Çevre Algısı (Continuous Perception)
+
+- **Living-vision sampling:** `vlm_bridge` inference döngüsü ve uzak ingest yolu
+  `VisionSampler`'a owner/yeni-kişi/tehlike/ani-hareket/sıkılma sinyallerini
+  besler → sahne bağlamı koşullu olarak arkaplanda yenilenir.
+- **İçerik-temelli önem:** `compute_importance` cache'e bağlı; tehlike/owner/
+  yenilik gerçek `importance_score` üretir (hardcode değil).
+- **WorldState environment:** sahne özeti/nesneler/tehlikeler/kişiler agent_core
+  `WorldState`'e işlenir ve LLM bağlamına enjekte edilir (`inject_world_state`).
+- **Sahne yeniliği:** autonomy `_track_scene_context` token-farkıyla yeniliği
+  ölçer, `environment.scene_changed` etkileşim olayı yayar (kulak/LED tepkisi).
+- **Proaktif betimleme:** `ProactivePlanner` boştayken yeni/önemli sahneyi
+  doğal dille anlatır (`companion.scene_comment`).
+
 ## Güvenlik ve Dayanıklılık
 
 - **Owner kontrolü:** VLM + RFID ile sahip doğrulaması

--- a/.sentrybot/context/architecture-summary.md
+++ b/.sentrybot/context/architecture-summary.md
@@ -145,6 +145,19 @@ ACT   → LLM yanıtını parse et, donanım HTTP çağrıları yap
 - **Akıllı gönderim:** brain `_liveliness_tick` yalnızca parametre değişince ya da
   `refresh_interval_s` geçince yollar; konuşma/takip/uyku sırasında bastırılır.
 
+### Öğrenme ve Adaptasyon (Learning & Adaptation)
+
+- **Tek çıkarım kaynağı:** `PreferenceLearner` fact + tercih regex'lerini
+  `MemoryConsolidator` ve `RelationshipMemory` arasında paylaşır.
+- **Konuşmacı köprüsü:** autonomy `agent.step(..., speaker=)` → `WorldState.speaker`
+  → consolidator facts'i doğru kişinin `social_db` kaydına yansıtır.
+- **Geri bildirim döngüsü:** `InteractionFeedbackLearner` övgü/kaba sözü
+  `trust_score` + moment salience'e çevirir; enrichment `trust=high/low` ipucu verir.
+- **Agent aracı:** `search_social_memory` kişi bazlı tercih/moment/trust sorgular
+  (epizodik `search_memory`'ye ek).
+- **Proaktif adaptasyon:** `ProactivePlanner` düşük trust'ta callback atlar,
+  yüksek trust'ta daha sıcak tercih hatırlatması kullanır.
+
 ## Güvenlik ve Dayanıklılık
 
 - **Owner kontrolü:** VLM + RFID ile sahip doğrulaması

--- a/.sentrybot/context/module-registry.md
+++ b/.sentrybot/context/module-registry.md
@@ -35,6 +35,7 @@
 | 27 | `esp_link` | — | Etkileşim | ESP32 köprü iletişimi (mDNS web remote) | Dolaylı | — |
 | 28 | `social_db` | — | Veri | SQLite kişi hafızası, ilişki/tanıma seviyeleri | Hayır | — |
 | 29 | `admin_ui` | — | Etkileşim | Web yönetim paneli (statik dosyalar) | Hayır | gateway |
+| 30 | `common` | — | Paylaşılan | Kanonik duygu sözlüğü (eyes/LEDs/ears/tone tek taksonomi) | Hayır | — |
 
 ## Mimari Katmanlar
 

--- a/arduino/firmware/xMain/app/xCommands.h
+++ b/arduino/firmware/xMain/app/xCommands.h
@@ -69,6 +69,31 @@ static inline bool isIrKeyStr(const String &k){
   return k == "UP" || k == "DOWN" || k == "LEFT" || k == "RIGHT" || k == "OK";
 }
 
+// ── Idle liveliness (firmware-native breathing / micro-motion) ───────────
+// Owned here; driven by livelinessTick() from the main loop. Keeps subtle
+// head motion alive even if the Pi bridge briefly stalls.
+static bool          g_livOn       = false;
+static float         g_livAmp      = 4.0f;    // degrees
+static float         g_livPanC     = 90.0f;   // pan center
+static float         g_livTiltC    = 90.0f;   // tilt center
+static unsigned long g_livPeriodMs = 4500;    // full cycle period
+static bool          g_livMicro    = false;   // micro mode adds a faster pan flutter
+
+static inline void livelinessTick(){
+  if (!g_livOn) return;
+  unsigned long period = g_livPeriodMs < 200 ? 200 : g_livPeriodMs;
+  float phase = (float)(millis() % period) / (float)period;  // 0..1
+  float s = sinf(phase * 6.2831853f);                        // breathing on tilt
+  float tilt = g_livTiltC + g_livAmp * s;
+  float pan = g_livPanC;
+  if (g_livMicro){
+    // faster, smaller pan flutter layered on top
+    float s2 = sinf(phase * 6.2831853f * 3.0f);
+    pan = g_livPanC + (g_livAmp * 0.5f) * s2;
+  }
+  robot.head(tilt, pan);  // robot.head expects (tilt, pan)
+}
+
 static inline void handleJson(const String &line){
   // Trim and check for bare IR key (no JSON structure)
   String trimmed = line;
@@ -709,6 +734,26 @@ static inline void handleJson(const String &line){
     robot.setSkateGains(skp,ski,skd);
     robot.setSkateSpeedLimit(smax);
     Protocol::sendOk("tuned");
+    return;
+  }
+
+  if (line.indexOf("\"cmd\":\"liveliness\"")>=0){
+    // {"cmd":"liveliness","enable":bool,"mode":"breathe|idle|micro",
+    //  "amplitude_deg":f,"period_ms":n,"pan_center":f,"tilt_center":f}
+    bool enable = line.indexOf("\"enable\":true")>=0;
+    if (!enable){
+      g_livOn = false;
+      robot.head(g_livTiltC, g_livPanC);  // re-centre
+      Protocol::sendOk("liveliness_off");
+      return;
+    }
+    int p=line.indexOf("\"amplitude_deg\":"); if(p>=0) g_livAmp=line.substring(p+16).toFloat();
+    p=line.indexOf("\"period_ms\":");        if(p>=0) g_livPeriodMs=(unsigned long)line.substring(p+12).toInt();
+    p=line.indexOf("\"pan_center\":");        if(p>=0) g_livPanC=line.substring(p+13).toFloat();
+    p=line.indexOf("\"tilt_center\":");       if(p>=0) g_livTiltC=line.substring(p+14).toFloat();
+    g_livMicro = (line.indexOf("\"mode\":\"micro\"")>=0);
+    g_livOn = true;
+    Protocol::sendOk("liveliness_on");
     return;
   }
 

--- a/arduino/firmware/xMain/xMain.ino
+++ b/arduino/firmware/xMain/xMain.ino
@@ -523,4 +523,6 @@ void loop(){
   }
   // periodic maintenance for neopixel request retries/acks
   neopixelTick();
+  // subtle idle breathing / micro-motion when enabled by the bridge
+  livelinessTick();
 }

--- a/modules/agent_core/config/config.yml
+++ b/modules/agent_core/config/config.yml
@@ -74,6 +74,9 @@ idle:
 
 memory:
   db_name: "memory.db"         # data/ klasörü altında oluşturulur
+  consolidation:
+    enabled: true              # mine durable facts from dialogue after each turn
+    fact_importance: 8         # episodic importance for consolidated facts
 
 slam:
   map_file: "map.json"         # data/ klasörü altında oluşturulur

--- a/modules/agent_core/services/agent.py
+++ b/modules/agent_core/services/agent.py
@@ -1066,6 +1066,7 @@ class AgentOrchestrator:
         user_prompt: str = "",
         progress_cb: Optional[Callable[[Dict[str, Any]], None]] = None,
         language: Optional[str] = None,
+        speaker: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         One complete Agent thought cycle with staged execution.
@@ -1085,6 +1086,14 @@ class AgentOrchestrator:
 
         self.is_busy = True
         previous_hook = self.tool_registry.status_hook
+
+        # Bridge active speaker into world state so consolidation and tools
+        # can attribute facts to the right person during this turn.
+        if speaker and str(speaker).strip().lower() not in {"unknown", "none", ""}:
+            try:
+                self.world_state.update_state({"speaker": str(speaker).strip()})
+            except Exception:
+                pass
 
         session_language = self._normalize_session_language(language)
 

--- a/modules/agent_core/services/agent.py
+++ b/modules/agent_core/services/agent.py
@@ -266,11 +266,17 @@ class AgentOrchestrator:
             text = str(req.payload.get("text", "")).strip()
             if not text:
                 return {"ok": False, "reason": "missing_text"}
+            # Forward the emotional tone so prosody survives the queue hop;
+            # previously it was dropped here, flattening every utterance.
+            tone = req.payload.get("tone")
+            if not isinstance(tone, (dict, str)) or tone == "":
+                tone = None
             self.speech_arbiter.enqueue(
                 text=text,
                 priority=max(1, min(100, int(req.priority))),
                 category="final" if req.priority >= 60 else "progress",
                 language=str(req.payload.get("language", "") or ""),
+                tone=tone,
             )
             return {"ok": True}
 

--- a/modules/agent_core/services/agent.py
+++ b/modules/agent_core/services/agent.py
@@ -136,6 +136,7 @@ class AgentOrchestrator:
         # Subsystems
         self.world_state = WorldState()
         self.memory = EpisodicMemory()
+        self.memory_consolidator = self._build_memory_consolidator()
         self.slam = TopologicalMap()
         self.safety_filter = ActionSafetyFilter(config)
         self.tool_execution_arbiter = ToolExecutionArbiter()
@@ -225,6 +226,34 @@ class AgentOrchestrator:
             self.apply_realtime_profile(active_profile)
 
         self.last_routed_subagents: List[str] = []
+
+    def _build_memory_consolidator(self):
+        """Wire the consolidator to episodic memory and (if present) social_db.
+
+        This is the bridge that lets durable facts mined from dialogue land in
+        both the episodic store and the speaker's social record.
+        """
+        from .memory_consolidator import MemoryConsolidator
+
+        social_db = None
+        try:
+            from modules.social_db import get_default as _social_default  # type: ignore
+
+            social_db = _social_default()
+        except Exception:
+            social_db = None
+        return MemoryConsolidator(memory=self.memory, social_db=social_db)
+
+    def _current_speaker(self):
+        """Best-effort identity of who is currently talking (or None)."""
+        try:
+            state = getattr(self.world_state, "state", {}) or {}
+            speaker = state.get("speaker") or state.get("current_person")
+            if speaker and str(speaker).strip().lower() not in {"unknown", "none"}:
+                return str(speaker).strip()
+        except Exception:
+            pass
+        return None
 
     def _register_action_handlers(self) -> None:
         """Bind ActionArbiter actions to concrete side effects.
@@ -1175,8 +1204,12 @@ class AgentOrchestrator:
             # ── Stage 4: Final — cancel stale progress, deliver response ──
             self.progress_manager.emit_final(progress_token)
 
-            # 4. Save to episodic long-term memory
+            # 4. Save to episodic long-term memory + consolidate durable facts
             self.memory.remember("dialogue", f"User: {user_prompt} | Bot: {final_text}")
+            try:
+                self.memory_consolidator.consolidate(user_prompt, speaker=self._current_speaker())
+            except Exception:
+                logger.debug("memory consolidation failed", exc_info=True)
 
             # 5. Return dict matching AutonomyBrain expectations (but empty plan/actions)
             return {

--- a/modules/agent_core/services/memory.py
+++ b/modules/agent_core/services/memory.py
@@ -3,7 +3,6 @@ import logging
 from datetime import datetime
 from typing import List, Dict, Any
 import os
-import re
 
 logger = logging.getLogger("agent.memory")
 
@@ -72,10 +71,11 @@ class EpisodicMemory:
                 conn.close()
             
     def search_memory(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
-        """
-        Retrieves matching memory logs. 
-        In a full RAG system, this would be semantic search (FAISS/Chroma).
-        For now, we use SQL LIKE matching.
+        """Retrieve matching memory logs.
+
+        Fast path: SQL ``LIKE`` for exact substring hits. When that is sparse we
+        fall back to TF-IDF cosine semantic ranking over recent episodes, which
+        recalls relevant memories even without a literal keyword match.
         """
         conn = self._get_conn()
         try:
@@ -116,10 +116,6 @@ class EpisodicMemory:
         out.extend(self._semantic_rank(query=query, rows=semantic_rows, limit=limit, seen=seen))
         return out[:limit]
 
-    @staticmethod
-    def _tokenize(text: str) -> set[str]:
-        return {t for t in re.findall(r"[a-zA-Z0-9_]+", str(text).lower()) if len(t) > 1}
-
     def _semantic_rank(
         self,
         query: str,
@@ -127,44 +123,46 @@ class EpisodicMemory:
         limit: int,
         seen: set[tuple[str, str, str]],
     ) -> List[Dict[str, Any]]:
-        q_tokens = self._tokenize(query)
-        if not rows or not q_tokens:
+        from .semantic_index import rank as _tfidf_rank
+
+        if not rows or not str(query).strip():
             return []
 
-        scored: List[tuple[float, Dict[str, Any]]] = []
-        total = max(1, len(rows))
-        for idx, row in enumerate(rows):
+        # Build candidate docs (most-recent first), skipping already-returned rows.
+        candidates: List[tuple[str, str, str, Any]] = []
+        for row in rows:
             try:
                 ts, ev_type, content, importance = row
             except Exception:
                 continue
-
             key = (str(ts), str(ev_type), str(content))
             if key in seen:
                 continue
+            candidates.append((str(ts), str(ev_type), str(content), importance))
 
-            c_tokens = self._tokenize(str(content))
-            if not c_tokens:
-                continue
-            overlap = len(q_tokens & c_tokens)
-            if overlap == 0:
-                continue
+        if not candidates:
+            return []
 
-            lexical = overlap / max(1, len(q_tokens | c_tokens))
-            recency = (total - idx) / total
+        docs = [c[2] for c in candidates]
+        ranked = _tfidf_rank(query, docs, top_k=len(docs))
+        total = max(1, len(candidates))
+
+        scored: List[tuple[float, Dict[str, Any]]] = []
+        for doc_idx, similarity in ranked:
+            ts, ev_type, content, importance = candidates[doc_idx]
+            recency = (total - doc_idx) / total  # candidates are recent-first
             try:
                 imp = max(0.0, min(1.0, float(importance) / 10.0))
             except Exception:
                 imp = 0.0
-
-            score = (0.7 * lexical) + (0.2 * recency) + (0.1 * imp)
+            score = (0.7 * similarity) + (0.2 * recency) + (0.1 * imp)
             scored.append(
                 (
                     score,
                     {
-                        "time": str(ts),
-                        "type": str(ev_type),
-                        "content": str(content),
+                        "time": ts,
+                        "type": ev_type,
+                        "content": content,
                         "score": round(score, 4),
                     },
                 )

--- a/modules/agent_core/services/memory_consolidator.py
+++ b/modules/agent_core/services/memory_consolidator.py
@@ -1,0 +1,90 @@
+"""Memory consolidation: turn raw dialogue into durable, recallable facts.
+
+Episodic memory stores everything flat; this layer mines high-value, long-lived
+facts ("my name is …", "I have a dog named …", "I work as …") and persists them
+with high importance so semantic recall surfaces them first. When a social_db
+handle is available it mirrors facts onto the speaker's relationship record,
+bridging the previously disconnected episodic and social memory silos.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, List, Optional
+
+logger = logging.getLogger("agent.memory_consolidator")
+
+# (compiled pattern, fact template). Group 1 is the captured value.
+_NAME = r"[A-Za-zÇĞİıÖŞÜçğöşü][A-Za-zÇĞİıÖŞÜçğöşü\-]{1,30}"
+
+_PATTERNS = [
+    (re.compile(r"\bben(?:im)?\s+ad[ıi]m\s+(" + _NAME + r")", re.IGNORECASE), "user name is {0}"),
+    (re.compile(r"\bismim\s+(" + _NAME + r")", re.IGNORECASE), "user name is {0}"),
+    (re.compile(r"\bmy name is\s+(" + _NAME + r")", re.IGNORECASE), "user name is {0}"),
+    (re.compile(r"\bi am\s+(" + _NAME + r")(?:\s|$|[.!,])", re.IGNORECASE), "user name is {0}"),
+    (re.compile(r"\b(?:k[öo]pe[ğg]im|kedim)(?:in ad[ıi])?\s+(" + _NAME + r")", re.IGNORECASE), "user has a pet named {0}"),
+    (re.compile(r"\bmy (?:dog|cat)(?:'s name)? is\s+(" + _NAME + r")", re.IGNORECASE), "user has a pet named {0}"),
+    (re.compile(r"\b(?:işim|meslegim|mesle[ğg]im)\s+(" + _NAME + r")", re.IGNORECASE), "user works as {0}"),
+    (re.compile(r"\bi work as (?:a |an )?(" + _NAME + r")", re.IGNORECASE), "user works as {0}"),
+    (re.compile(r"\b(" + _NAME + r")['’]?(?:de|da|te|ta)\s+(?:oturuyorum|yas[ıi]yorum)", re.IGNORECASE), "user lives in {0}"),
+    (re.compile(r"\bi live in\s+(" + _NAME + r")", re.IGNORECASE), "user lives in {0}"),
+]
+
+
+class MemoryConsolidator:
+    def __init__(self, memory: Any = None, social_db: Any = None) -> None:
+        self.memory = memory
+        self.social_db = social_db
+
+    def extract_facts(self, text: str) -> List[str]:
+        raw = str(text or "")
+        # only mine the user's side of a "User: ... | Bot: ..." line if present
+        if "|" in raw:
+            raw = raw.split("|", 1)[0]
+        raw = re.sub(r"(?i)^\s*user\s*:\s*", "", raw).strip()
+        if not raw:
+            return []
+
+        facts: List[str] = []
+        for pattern, template in _PATTERNS:
+            match = pattern.search(raw)
+            if match:
+                value = match.group(1).strip()
+                if value and len(value) > 1:
+                    fact = template.format(value)
+                    if fact not in facts:
+                        facts.append(fact)
+        return facts
+
+    def consolidate(self, text: str, speaker: Optional[str] = None) -> List[str]:
+        facts = self.extract_facts(text)
+        if not facts:
+            return []
+        for fact in facts:
+            self._store_episodic(fact)
+            if speaker:
+                self._store_social(speaker, fact)
+        return facts
+
+    def _store_episodic(self, fact: str) -> None:
+        if self.memory is None:
+            return
+        try:
+            self.memory.remember("fact", fact, importance=8)
+        except Exception:
+            logger.debug("failed to store fact in episodic memory", exc_info=True)
+
+    def _store_social(self, speaker: str, fact: str) -> None:
+        if self.social_db is None:
+            return
+        try:
+            person = self.social_db.persons.upsert(name=speaker)
+            person_id = getattr(person, "person_id", None) or (person.get("person_id") if isinstance(person, dict) else None)
+            if person_id and hasattr(self.social_db, "moments"):
+                self.social_db.moments.add_or_boost(person_id, fact)
+        except Exception:
+            logger.debug("failed to mirror fact into social_db", exc_info=True)
+
+
+__all__ = ["MemoryConsolidator"]

--- a/modules/agent_core/services/memory_consolidator.py
+++ b/modules/agent_core/services/memory_consolidator.py
@@ -10,52 +10,33 @@ bridging the previously disconnected episodic and social memory silos.
 from __future__ import annotations
 
 import logging
-import re
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("agent.memory_consolidator")
 
-# (compiled pattern, fact template). Group 1 is the captured value.
-_NAME = r"[A-Za-zÇĞİıÖŞÜçğöşü][A-Za-zÇĞİıÖŞÜçğöşü\-]{1,30}"
-
-_PATTERNS = [
-    (re.compile(r"\bben(?:im)?\s+ad[ıi]m\s+(" + _NAME + r")", re.IGNORECASE), "user name is {0}"),
-    (re.compile(r"\bismim\s+(" + _NAME + r")", re.IGNORECASE), "user name is {0}"),
-    (re.compile(r"\bmy name is\s+(" + _NAME + r")", re.IGNORECASE), "user name is {0}"),
-    (re.compile(r"\bi am\s+(" + _NAME + r")(?:\s|$|[.!,])", re.IGNORECASE), "user name is {0}"),
-    (re.compile(r"\b(?:k[öo]pe[ğg]im|kedim)(?:in ad[ıi])?\s+(" + _NAME + r")", re.IGNORECASE), "user has a pet named {0}"),
-    (re.compile(r"\bmy (?:dog|cat)(?:'s name)? is\s+(" + _NAME + r")", re.IGNORECASE), "user has a pet named {0}"),
-    (re.compile(r"\b(?:işim|meslegim|mesle[ğg]im)\s+(" + _NAME + r")", re.IGNORECASE), "user works as {0}"),
-    (re.compile(r"\bi work as (?:a |an )?(" + _NAME + r")", re.IGNORECASE), "user works as {0}"),
-    (re.compile(r"\b(" + _NAME + r")['’]?(?:de|da|te|ta)\s+(?:oturuyorum|yas[ıi]yorum)", re.IGNORECASE), "user lives in {0}"),
-    (re.compile(r"\bi live in\s+(" + _NAME + r")", re.IGNORECASE), "user lives in {0}"),
-]
-
 
 class MemoryConsolidator:
-    def __init__(self, memory: Any = None, social_db: Any = None) -> None:
+    def __init__(self, memory: Any = None, social_db: Any = None, learner: Any = None) -> None:
         self.memory = memory
         self.social_db = social_db
+        self._learner = learner
+
+    def _get_learner(self):
+        if self._learner is not None:
+            return self._learner
+        try:
+            from modules.autonomy.services.preference_learner import PreferenceLearner
+
+            self._learner = PreferenceLearner()
+        except Exception:
+            self._learner = None
+        return self._learner
 
     def extract_facts(self, text: str) -> List[str]:
-        raw = str(text or "")
-        # only mine the user's side of a "User: ... | Bot: ..." line if present
-        if "|" in raw:
-            raw = raw.split("|", 1)[0]
-        raw = re.sub(r"(?i)^\s*user\s*:\s*", "", raw).strip()
-        if not raw:
-            return []
-
-        facts: List[str] = []
-        for pattern, template in _PATTERNS:
-            match = pattern.search(raw)
-            if match:
-                value = match.group(1).strip()
-                if value and len(value) > 1:
-                    fact = template.format(value)
-                    if fact not in facts:
-                        facts.append(fact)
-        return facts
+        learner = self._get_learner()
+        if learner is not None:
+            return learner.extract_facts(text)
+        return []
 
     def consolidate(self, text: str, speaker: Optional[str] = None) -> List[str]:
         facts = self.extract_facts(text)
@@ -80,9 +61,13 @@ class MemoryConsolidator:
             return
         try:
             person = self.social_db.persons.upsert(name=speaker)
-            person_id = getattr(person, "person_id", None) or (person.get("person_id") if isinstance(person, dict) else None)
+            person_id = None
+            if isinstance(person, dict):
+                person_id = person.get("id") or person.get("person_id")
+            else:
+                person_id = getattr(person, "id", None) or getattr(person, "person_id", None)
             if person_id and hasattr(self.social_db, "moments"):
-                self.social_db.moments.add_or_boost(person_id, fact)
+                self.social_db.moments.add_or_boost(person_id, fact, salience=0.75)
         except Exception:
             logger.debug("failed to mirror fact into social_db", exc_info=True)
 

--- a/modules/agent_core/services/semantic_index.py
+++ b/modules/agent_core/services/semantic_index.py
@@ -1,0 +1,107 @@
+"""Dependency-light semantic retrieval (TF-IDF + cosine).
+
+A pragmatic stand-in for a full embedding store (FAISS/Chroma) that needs **no**
+extra dependencies, so it runs anywhere SentryBOT does — including a bare PC dev
+checkout. It ranks documents against a query by TF-IDF cosine similarity, which
+handles common-word noise (via IDF) and document length (via cosine) far better
+than substring/Jaccard matching.
+
+Unicode-aware tokenisation keeps Turkish text (ç, ğ, ı, ö, ş, ü) intact.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Dict, List, Sequence, Tuple
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def tokenize(text: str) -> List[str]:
+    return [t for t in _TOKEN_RE.findall(str(text).lower()) if len(t) > 1]
+
+
+def _tf(tokens: Sequence[str]) -> Dict[str, float]:
+    counts = Counter(tokens)
+    total = float(sum(counts.values())) or 1.0
+    return {term: count / total for term, count in counts.items()}
+
+
+def _idf(corpus_tokens: Sequence[Sequence[str]]) -> Dict[str, float]:
+    n_docs = len(corpus_tokens)
+    df: Counter = Counter()
+    for tokens in corpus_tokens:
+        for term in set(tokens):
+            df[term] += 1
+    # smoothed idf so a term in every doc still has a small positive weight
+    return {term: math.log((1 + n_docs) / (1 + count)) + 1.0 for term, count in df.items()}
+
+
+def _tfidf_vec(tokens: Sequence[str], idf: Dict[str, float]) -> Dict[str, float]:
+    tf = _tf(tokens)
+    return {term: freq * idf.get(term, 0.0) for term, freq in tf.items()}
+
+
+def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
+    if not a or not b:
+        return 0.0
+    # iterate over the smaller vector for the dot product
+    if len(a) > len(b):
+        a, b = b, a
+    dot = sum(weight * b.get(term, 0.0) for term, weight in a.items())
+    if dot == 0.0:
+        return 0.0
+    na = math.sqrt(sum(w * w for w in a.values()))
+    nb = math.sqrt(sum(w * w for w in b.values()))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def rank(query: str, documents: Sequence[str], top_k: int = 5) -> List[Tuple[int, float]]:
+    """Return ``[(doc_index, cosine_score), ...]`` sorted by descending relevance.
+
+    Only documents with a positive similarity are returned. IDF is computed over
+    the supplied document set plus the query.
+    """
+    q_tokens = tokenize(query)
+    if not q_tokens or not documents:
+        return []
+
+    doc_tokens = [tokenize(d) for d in documents]
+    idf = _idf(doc_tokens + [q_tokens])
+    q_vec = _tfidf_vec(q_tokens, idf)
+
+    scored: List[Tuple[int, float]] = []
+    for idx, tokens in enumerate(doc_tokens):
+        if not tokens:
+            continue
+        score = _cosine(q_vec, _tfidf_vec(tokens, idf))
+        if score > 0.0:
+            scored.append((idx, score))
+
+    scored.sort(key=lambda item: item[1], reverse=True)
+    return scored[: max(0, int(top_k))]
+
+
+class SemanticIndex:
+    """Reusable in-memory index over ``(id, text)`` documents."""
+
+    def __init__(self) -> None:
+        self._ids: List[str] = []
+        self._texts: List[str] = []
+
+    def add(self, doc_id: str, text: str) -> None:
+        self._ids.append(str(doc_id))
+        self._texts.append(str(text))
+
+    def __len__(self) -> int:
+        return len(self._ids)
+
+    def search(self, query: str, top_k: int = 5) -> List[Tuple[str, float]]:
+        return [(self._ids[i], score) for i, score in rank(query, self._texts, top_k)]
+
+
+__all__ = ["tokenize", "rank", "SemanticIndex"]

--- a/modules/agent_core/services/sensor_loop.py
+++ b/modules/agent_core/services/sensor_loop.py
@@ -84,6 +84,14 @@ class SensorFeedbackLoop:
                     except Exception:
                         pass
 
+                    # ── Continuous environment perception (VLM scene cache) ──
+                    try:
+                        ctx = self.client.get_visual_context()
+                        if isinstance(ctx, dict) and ctx.get("available") and ctx.get("context"):
+                            self.world_state.update_scene(ctx)
+                    except Exception:
+                        pass
+
                 # Apply all updates atomically
                 if updates:
                     self.world_state.update_state(updates)

--- a/modules/agent_core/services/tools.py
+++ b/modules/agent_core/services/tools.py
@@ -308,6 +308,22 @@ class ToolRegistry:
             }
         })
 
+        self._register(self.search_social_memory, {
+            "type": "function",
+            "function": {
+                "name": "search_social_memory",
+                "description": "Search a person's social memory: preferences, moments, and trust relationship.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Person's name"},
+                        "query": {"type": "string", "description": "Optional relevance filter"},
+                    },
+                    "required": ["name"],
+                },
+            },
+        })
+
         self._register(self.get_vision, {
             "type": "function",
             "function": {
@@ -600,6 +616,42 @@ class ToolRegistry:
         if not res:
             return "No matching memories found."
         return str(res)
+
+    def search_social_memory(self, name: str, query: str = "") -> str:
+        try:
+            from modules.social_db import get_default as _social_default
+
+            db = _social_default()
+        except Exception:
+            return "Social memory unavailable."
+        if db is None:
+            return "Social memory unavailable."
+        rec = db.persons.get_by_name(str(name or "").strip())
+        if not rec:
+            return f"No social record for {name}."
+        pid = rec["id"]
+        grouped = db.relationships.list_grouped(pid)
+        moments = db.moments.top_for_person(pid, limit=10)
+        snippets = [str(m.get("text", "")).strip() for m in moments if str(m.get("text", "")).strip()]
+        q = str(query or "").strip()
+        if q and snippets:
+            try:
+                from .semantic_index import rank
+
+                ranked = rank(q, snippets, top_k=3)
+                snippets = [snippets[idx] for idx, _ in ranked if idx < len(snippets)]
+            except Exception:
+                pass
+        parts: List[str] = []
+        trust = float(rec.get("trust_score", 0.0) or 0.0)
+        parts.append(f"trust_score={trust:.2f}")
+        for key in ("likes", "dislikes", "topics"):
+            vals = grouped.get(key, []) if isinstance(grouped.get(key, []), list) else []
+            if vals:
+                parts.append(f"{key}: {', '.join(str(v) for v in vals[:6])}")
+        if snippets:
+            parts.append("moments: " + " | ".join(snippets[:3]))
+        return "\n".join(parts) if parts else "No social memories found."
 
     def get_vision(self) -> str:
         if not self.client: return "Error: Vision client disconnected."

--- a/modules/agent_core/services/world_state.py
+++ b/modules/agent_core/services/world_state.py
@@ -17,9 +17,44 @@ class WorldState:
             "location": "unknown",
             "last_action_feedback": "None" # Success or motor stall errors
         }
+        # Continuous environment perception (fed from the VLM scene cache).
+        self.environment: Dict[str, Any] = {
+            "scene_summary": "",
+            "objects": [],
+            "hazards": [],
+            "people_present": [],
+            "importance": 0.0,
+            "updated_at": "",
+        }
         
     def update_state(self, updates: Dict[str, Any]):
         self.state.update(updates)
+
+    def update_scene(self, context: Dict[str, Any]) -> None:
+        """Ingest a VLM visual-context snapshot into the environment model.
+
+        Accepts either the raw context dict or the cache envelope
+        ``{"available": ..., "context": {...}}`` returned by the vlm_bridge API.
+        """
+        if not isinstance(context, dict):
+            return
+        ctx = context.get("context") if "context" in context and isinstance(context.get("context"), dict) else context
+        if not isinstance(ctx, dict) or not ctx:
+            return
+        people = []
+        for p in ctx.get("people", []) or []:
+            if isinstance(p, dict):
+                name = str(p.get("name", "") or "").strip()
+                if name and name.lower() != "unknown":
+                    people.append(name)
+        self.environment = {
+            "scene_summary": str(ctx.get("summary", "") or ""),
+            "objects": [str(o.get("label", o)) if isinstance(o, dict) else str(o) for o in (ctx.get("objects", []) or [])][:8],
+            "hazards": [str(h.get("label", h)) if isinstance(h, dict) else str(h) for h in (ctx.get("hazards", []) or [])][:5],
+            "people_present": people[:6],
+            "importance": float(ctx.get("importance_score", 0.0) or 0.0),
+            "updated_at": str(ctx.get("timestamp", "") or datetime.now().isoformat()),
+        }
         
     def set_action_feedback(self, feedback: str):
         self.state["last_action_feedback"] = feedback
@@ -53,7 +88,11 @@ class WorldState:
             "chrono": chrono,
             "sensors": self.state
         }
-        
+        # Only surface the environment block when we actually have a scene, so
+        # the prompt stays lean when vision is idle.
+        if self.environment.get("scene_summary") or self.environment.get("people_present"):
+            context["environment"] = self.environment
+
         state_str = json.dumps(context, indent=2)
         injected = f"{base_prompt}\n\n[SYSTEM WORLD STATE]\n{state_str}\n"
         return injected

--- a/modules/agent_core/tests/test_memory_consolidator.py
+++ b/modules/agent_core/tests/test_memory_consolidator.py
@@ -39,3 +39,17 @@ def test_no_facts_is_noop():
     c = MemoryConsolidator(memory=mem)
     assert c.consolidate("User: hava bugun nasil | Bot: guzel") == []
     assert mem.stored == []
+
+
+def test_consolidate_mirrors_fact_to_social_db(tmp_path):
+    from modules.social_db.db import SocialDB
+
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    mem = _FakeMemory()
+    c = MemoryConsolidator(memory=mem, social_db=db)
+    facts = c.consolidate("benim adim Emir", speaker="Emir")
+    assert facts == ["user name is Emir"]
+    rec = db.persons.get_by_name("Emir")
+    assert rec is not None
+    moments = db.moments.top_for_person(rec["id"], limit=5)
+    assert any("user name is Emir" in str(m.get("text", "")) for m in moments)

--- a/modules/agent_core/tests/test_memory_consolidator.py
+++ b/modules/agent_core/tests/test_memory_consolidator.py
@@ -1,0 +1,41 @@
+"""Tests for dialogue fact consolidation."""
+
+from __future__ import annotations
+
+from modules.agent_core.services.memory_consolidator import MemoryConsolidator
+
+
+class _FakeMemory:
+    def __init__(self):
+        self.stored = []
+
+    def remember(self, event_type, content, importance=1):
+        self.stored.append((event_type, content, importance))
+
+
+def test_extract_name_fact_turkish_and_english():
+    c = MemoryConsolidator()
+    assert "user name is Emir" in c.extract_facts("User: benim adim Emir | Bot: selam")
+    assert "user name is Sarah" in c.extract_facts("my name is Sarah")
+
+
+def test_extract_pet_and_location():
+    c = MemoryConsolidator()
+    assert "user has a pet named Max" in c.extract_facts("my dog is Max")
+    assert "user lives in Izmir" in c.extract_facts("i live in Izmir")
+
+
+def test_consolidate_stores_high_importance_facts():
+    mem = _FakeMemory()
+    c = MemoryConsolidator(memory=mem)
+    facts = c.consolidate("User: benim adim Emir | Bot: merhaba")
+    assert facts == ["user name is Emir"]
+    assert mem.stored and mem.stored[0][0] == "fact"
+    assert mem.stored[0][2] >= 5  # stored with high importance
+
+
+def test_no_facts_is_noop():
+    mem = _FakeMemory()
+    c = MemoryConsolidator(memory=mem)
+    assert c.consolidate("User: hava bugun nasil | Bot: guzel") == []
+    assert mem.stored == []

--- a/modules/agent_core/tests/test_search_social_memory.py
+++ b/modules/agent_core/tests/test_search_social_memory.py
@@ -1,0 +1,48 @@
+"""search_social_memory tool queries social_db preferences and moments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.agent_core.services.tools import ToolRegistry
+from modules.agent_core.services.world_state import WorldState
+from modules.social_db.db import SocialDB
+
+
+class _FakeMemory:
+    def search_memory(self, query, limit=5):
+        return []
+
+
+class _FakeSlam:
+    def get_location(self):
+        return "home"
+
+
+def _registry(db: SocialDB):
+    return ToolRegistry(
+        client=None,
+        memory=_FakeMemory(),
+        slam=_FakeSlam(),
+        world_state=WorldState(),
+        safety_filter=None,
+    )
+
+
+def test_search_social_memory_returns_prefs_and_moments(tmp_path, monkeypatch):
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    rec = db.persons.upsert(name="Emir", trust_score=0.65)
+    db.relationships.set(rec["id"], "likes", "satranc,kahve")
+    db.moments.add_or_boost(rec["id"], "likes:satranc", salience=0.7)
+    monkeypatch.setattr("modules.social_db.get_default", lambda: db)
+    reg = _registry(db)
+    out = reg.search_social_memory("Emir", query="satranc")
+    assert "trust_score=0.65" in out
+    assert "satranc" in out
+
+
+def test_search_social_memory_unknown_person(tmp_path, monkeypatch):
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    monkeypatch.setattr("modules.social_db.get_default", lambda: db)
+    reg = _registry(db)
+    assert "No social record" in reg.search_social_memory("Nobody")

--- a/modules/agent_core/tests/test_semantic_memory.py
+++ b/modules/agent_core/tests/test_semantic_memory.py
@@ -1,0 +1,62 @@
+"""Tests for the TF-IDF semantic index and episodic memory recall."""
+
+from __future__ import annotations
+
+from modules.agent_core.services.semantic_index import rank, tokenize, SemanticIndex
+from modules.agent_core.services.memory import EpisodicMemory
+
+
+def test_tokenize_keeps_unicode_turkish():
+    toks = tokenize("Müziği çok seviyorum")
+    assert "müziği" in toks
+    assert "seviyorum" in toks
+
+
+def test_rank_orders_by_relevance():
+    docs = [
+        "the cat sat on the mat",
+        "robot arm calibration failed twice",
+        "I love playing chess with you",
+    ]
+    ranked = rank("chess match", docs, top_k=3)
+    assert ranked, "expected at least one relevant doc"
+    assert ranked[0][0] == 2  # chess doc ranks first
+
+
+def test_rank_ignores_common_words_via_idf():
+    docs = [
+        "the the the the the dog",
+        "the the the the the cat",
+    ]
+    # 'the' is common (low idf); the distinguishing term must drive the result
+    ranked = rank("dog", docs, top_k=2)
+    assert ranked[0][0] == 0
+
+
+def test_semantic_index_search():
+    idx = SemanticIndex()
+    idx.add("e1", "kitchen lights turned off")
+    idx.add("e2", "owner left the house")
+    hits = idx.search("lights", top_k=2)
+    assert hits and hits[0][0] == "e1"
+
+
+def test_memory_recall_without_literal_substring():
+    mem = EpisodicMemory(":memory:")
+    mem.remember("dialogue", "User: I love chess | Bot: great")
+    mem.remember("dialogue", "User: calibrate the arm | Bot: done")
+    mem.remember("observation", "saw a dog in the room")
+
+    # query has no exact substring match, but shares the token 'chess'
+    results = mem.search_memory("chess tonight", limit=2)
+    assert results
+    assert any("chess" in r["content"] for r in results)
+
+
+def test_memory_recall_prefers_relevant_episode():
+    mem = EpisodicMemory(":memory:")
+    mem.remember("observation", "the weather is cold")
+    mem.remember("observation", "the robot calibration routine completed")
+    results = mem.search_memory("calibration status", limit=1)
+    assert results
+    assert "calibration" in results[0]["content"]

--- a/modules/agent_core/tests/test_speak_tone_forwarding.py
+++ b/modules/agent_core/tests/test_speak_tone_forwarding.py
@@ -1,0 +1,48 @@
+"""The queued `speak` action must forward emotional tone to the arbiter."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from modules.agent_core.services.action_arbiter import ActionArbiter, ActionRequest
+from modules.agent_core.services.agent import AgentOrchestrator
+
+
+class _RecordingArbiter:
+    def __init__(self):
+        self.calls = []
+
+    def enqueue(self, **kwargs):
+        self.calls.append(kwargs)
+        return "id"
+
+
+def _agent_with_handlers():
+    agent = AgentOrchestrator.__new__(AgentOrchestrator)
+    agent.action_arbiter = ActionArbiter()
+    agent.speech_arbiter = _RecordingArbiter()
+    agent._register_action_handlers()
+    return agent
+
+
+def _speak_req(payload: Dict[str, Any]):
+    return ActionRequest(type="speak", source="autonomy", priority=50, ttl_ms=10000, payload=payload)
+
+
+def test_speak_action_forwards_tone():
+    agent = _agent_with_handlers()
+    agent.action_arbiter.submit(_speak_req({"text": "Merhaba", "tone": "joy"}))
+    assert agent.speech_arbiter.calls
+    assert agent.speech_arbiter.calls[0]["tone"] == "joy"
+
+
+def test_speak_action_forwards_dict_tone():
+    agent = _agent_with_handlers()
+    agent.action_arbiter.submit(_speak_req({"text": "Merhaba", "tone": {"rate": 200}}))
+    assert agent.speech_arbiter.calls[0]["tone"] == {"rate": 200}
+
+
+def test_missing_tone_passes_none():
+    agent = _agent_with_handlers()
+    agent.action_arbiter.submit(_speak_req({"text": "Merhaba"}))
+    assert agent.speech_arbiter.calls[0]["tone"] is None

--- a/modules/agent_core/tests/test_speaker_bridge.py
+++ b/modules/agent_core/tests/test_speaker_bridge.py
@@ -1,0 +1,38 @@
+"""Speaker identity bridges from autonomy into agent step and consolidation."""
+
+from __future__ import annotations
+
+from modules.agent_core.services.agent import AgentOrchestrator
+from modules.agent_core.services.world_state import WorldState
+
+
+def test_step_sets_world_state_speaker():
+    agent = AgentOrchestrator.__new__(AgentOrchestrator)
+    agent.world_state = WorldState()
+    agent.is_busy = False
+    agent.last_run = 0
+    agent.cooldown = 0
+    agent.tool_registry = type("T", (), {"status_hook": None})()
+    agent.progress_manager = type(
+        "P",
+        (),
+        {
+            "new_request": staticmethod(lambda **k: "tok"),
+            "clear_request": staticmethod(lambda *a, **k: None),
+            "emit_final": staticmethod(lambda *a, **k: None),
+        },
+    )()
+    agent._active_progress_token = None
+    agent._normalize_session_language = lambda lang: lang or "tr"  # type: ignore
+    try:
+        agent.step("hello", speaker="Emir")
+    except Exception:
+        pass
+    assert agent.world_state.state.get("speaker") == "Emir"
+
+
+def test_current_speaker_reads_world_state():
+    agent = AgentOrchestrator.__new__(AgentOrchestrator)
+    agent.world_state = WorldState()
+    agent.world_state.update_state({"speaker": "Zeynep"})
+    assert agent._current_speaker() == "Zeynep"

--- a/modules/agent_core/tests/test_world_state_environment.py
+++ b/modules/agent_core/tests/test_world_state_environment.py
@@ -1,0 +1,47 @@
+"""WorldState continuous environment perception fields."""
+
+from __future__ import annotations
+
+from modules.agent_core.services.world_state import WorldState
+
+
+def test_update_scene_accepts_cache_envelope():
+    ws = WorldState()
+    ws.update_scene(
+        {
+            "available": True,
+            "context": {
+                "summary": "a person sits at a desk with a laptop",
+                "objects": [{"label": "laptop"}, {"label": "cup"}],
+                "hazards": [],
+                "people": [{"name": "Emir", "recognition_level": 6}, {"name": "Unknown"}],
+                "importance_score": 0.55,
+                "timestamp": "2026-05-31T10:00:00",
+            },
+        }
+    )
+    env = ws.environment
+    assert "laptop" in env["objects"]
+    assert env["people_present"] == ["Emir"]  # Unknown filtered out
+    assert env["importance"] == 0.55
+    assert "desk" in env["scene_summary"]
+
+
+def test_update_scene_accepts_raw_context():
+    ws = WorldState()
+    ws.update_scene({"summary": "empty hallway", "objects": [], "people": [], "hazards": []})
+    assert ws.environment["scene_summary"] == "empty hallway"
+
+
+def test_inject_world_state_includes_environment_when_present():
+    ws = WorldState()
+    ws.update_scene({"summary": "kitchen with a kettle", "objects": [{"label": "kettle"}], "people": []})
+    injected = ws.inject_world_state("hello")
+    assert "environment" in injected
+    assert "kettle" in injected
+
+
+def test_inject_world_state_omits_environment_when_idle():
+    ws = WorldState()
+    injected = ws.inject_world_state("hello")
+    assert "environment" not in injected

--- a/modules/arduino_serial/contract.py
+++ b/modules/arduino_serial/contract.py
@@ -8,6 +8,11 @@ SERVO_COUNT = 4
 SERVO_MIN_DEG = 0.0
 SERVO_MAX_DEG = 180.0
 
+# Firmware liveliness (idle breathing / micro-motion) bounds.
+LIVELINESS_MODES = ("breathe", "idle", "micro")
+LIVELINESS_AMPLITUDE_MAX_DEG = 30.0
+LIVELINESS_PERIOD_MIN_MS = 200
+
 
 def build_set_servo_cmd(index: int, deg: float) -> Dict[str, Any]:
     return {"cmd": "set_servo", "index": int(index), "deg": float(deg)}
@@ -91,6 +96,35 @@ def build_track_cmd(
 
 def build_drive_cmd(value: Any) -> Dict[str, Any]:
     return {"cmd": "drive", "value": value}
+
+
+def build_liveliness_cmd(
+    enable: bool,
+    mode: str = "breathe",
+    amplitude_deg: Optional[float] = None,
+    period_ms: Optional[int] = None,
+    pan_center: Optional[float] = None,
+    tilt_center: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Idle liveliness on the head servos (firmware-native subtle motion).
+
+    ``enable=False`` stops the motion and re-centres; other fields are only
+    meaningful when enabling. Keeping this in the contract (instead of streaming
+    raw set_servo waves from the Pi) lets the firmware own a smooth, jitter-free
+    breathing loop even if the bridge stalls.
+    """
+    payload: Dict[str, Any] = {"cmd": "liveliness", "enable": bool(enable)}
+    if mode is not None:
+        payload["mode"] = str(mode)
+    if amplitude_deg is not None:
+        payload["amplitude_deg"] = float(amplitude_deg)
+    if period_ms is not None:
+        payload["period_ms"] = int(period_ms)
+    if pan_center is not None:
+        payload["pan_center"] = float(pan_center)
+    if tilt_center is not None:
+        payload["tilt_center"] = float(tilt_center)
+    return payload
 
 
 def build_laser_cmd(on: bool, id_: Optional[int] = None, both: Optional[bool] = None) -> Dict[str, Any]:
@@ -204,6 +238,32 @@ def _validate_stepper_id(payload: Dict[str, Any]) -> Optional[str]:
         return "'id' must be an integer"
     if sid not in (0, 1):
         return "'id' must be 0 or 1"
+    return None
+
+
+def validate_liveliness_cmd(payload: Dict[str, Any]) -> Optional[str]:
+    if payload.get("cmd") != "liveliness":
+        return None
+    if "enable" not in payload or not _is_bool(payload.get("enable")):
+        return "liveliness requires boolean 'enable'"
+    # Disabling needs no further parameters.
+    if not payload.get("enable"):
+        return None
+    if "mode" in payload and payload.get("mode") not in LIVELINESS_MODES:
+        return f"liveliness 'mode' must be one of {LIVELINESS_MODES}"
+    if "amplitude_deg" in payload:
+        amp = _as_float(payload.get("amplitude_deg"))
+        if amp is None or amp < 0 or amp > LIVELINESS_AMPLITUDE_MAX_DEG:
+            return f"liveliness 'amplitude_deg' must be in [0,{int(LIVELINESS_AMPLITUDE_MAX_DEG)}]"
+    if "period_ms" in payload:
+        period = _as_int(payload.get("period_ms"))
+        if period is None or period < LIVELINESS_PERIOD_MIN_MS:
+            return f"liveliness 'period_ms' must be >= {LIVELINESS_PERIOD_MIN_MS}"
+    for key in ("pan_center", "tilt_center"):
+        if key in payload:
+            val = _as_float(payload.get(key))
+            if val is None or val < SERVO_MIN_DEG or val > SERVO_MAX_DEG:
+                return f"liveliness '{key}' must be in [{int(SERVO_MIN_DEG)},{int(SERVO_MAX_DEG)}]"
     return None
 
 
@@ -368,6 +428,9 @@ def validate_arduino_payload(payload: Dict[str, Any]) -> Optional[str]:
         if _as_float(payload.get("value")) is None:
             return "drive requires numeric 'value'"
         return None
+
+    if cmd == "liveliness":
+        return validate_liveliness_cmd(payload)
 
     if cmd == "encoder_calibrate":
         if "duration_ms" in payload:

--- a/modules/arduino_serial/tests/fake_transport_sim.py
+++ b/modules/arduino_serial/tests/fake_transport_sim.py
@@ -48,6 +48,8 @@ class FakeTransportSim:
                 reply = {"ok": True, "msg": "hb"}
             elif cmd == "telemetry_start":
                 reply = {"ok": True}
+            elif cmd == "liveliness":
+                reply = {"ok": True, "cmd": "liveliness", "enable": bool(obj.get("enable"))}
 
             if reply is not None:
                 # schedule immediate insertion into read queue

--- a/modules/arduino_serial/tests/test_liveliness_gateway.py
+++ b/modules/arduino_serial/tests/test_liveliness_gateway.py
@@ -1,0 +1,60 @@
+"""Gateway behavior: /arduino/request validates and dispatches liveliness."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from modules.arduino_serial.api.router import get_router
+from modules.arduino_serial.contract import build_liveliness_cmd
+from modules.arduino_serial.tests.fake_transport_sim import FakeTransportSim
+from modules.arduino_serial.xArduinoSerialService import xArduinoSerialService
+
+
+def _client():
+    transport = FakeTransportSim()
+    svc = xArduinoSerialService(
+        config_overrides={"transport": "serial"},
+        transport_factory=lambda *a, **k: transport,
+    )
+    svc.start()
+    app = FastAPI()
+    app.include_router(get_router(svc))
+    return TestClient(app), svc, transport
+
+
+def test_request_liveliness_enable_round_trips():
+    client, svc, transport = _client()
+    try:
+        payload = build_liveliness_cmd(True, mode="breathe", amplitude_deg=5, period_ms=4000)
+        resp = client.post("/arduino/request", json=payload, params={"timeout": 1.0})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["resp"].get("ok") is True
+        # The fake firmware echoes the command name back.
+        assert body["resp"].get("cmd") == "liveliness"
+        assert b"liveliness" in transport._buf
+    finally:
+        svc.stop()
+
+
+def test_request_rejects_invalid_liveliness_with_400():
+    client, svc, _ = _client()
+    try:
+        # amplitude far out of range -> validator rejects before transport
+        resp = client.post("/arduino/request", json={"cmd": "liveliness", "enable": True, "amplitude_deg": 500})
+        assert resp.status_code == 400
+        assert "amplitude_deg" in resp.json()["detail"]
+    finally:
+        svc.stop()
+
+
+def test_send_liveliness_disable_ok():
+    client, svc, _ = _client()
+    try:
+        resp = client.post("/arduino/send", json=build_liveliness_cmd(False))
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        svc.stop()

--- a/modules/arduino_serial/tests/test_liveliness_helpers.py
+++ b/modules/arduino_serial/tests/test_liveliness_helpers.py
@@ -1,0 +1,56 @@
+"""Service-level liveliness helpers send valid contract payloads."""
+
+from __future__ import annotations
+
+import json
+
+from modules.arduino_serial.tests.fake_transport_sim import FakeTransportSim
+from modules.arduino_serial.xArduinoSerialService import xArduinoSerialService
+
+
+def _svc():
+    transport = FakeTransportSim()
+    svc = xArduinoSerialService(
+        config_overrides={"transport": "serial", "auto_heartbeat": False},
+        transport_factory=lambda *a, **k: transport,
+    )
+    svc.start()
+    return svc, transport
+
+
+def _liveliness_frames(transport):
+    frames = []
+    for line in transport._buf.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if obj.get("cmd") == "liveliness":
+            frames.append(obj)
+    return frames
+
+
+def test_liveliness_start_sends_enable_true():
+    svc, transport = _svc()
+    try:
+        resp = svc.liveliness_start(mode="breathe", amplitude_deg=6, period_ms=4000)
+        assert resp.get("ok") is True
+        frames = _liveliness_frames(transport)
+        assert frames and frames[0]["enable"] is True
+        assert frames[0]["mode"] == "breathe"
+    finally:
+        svc.stop()
+
+
+def test_liveliness_stop_sends_enable_false():
+    svc, transport = _svc()
+    try:
+        resp = svc.liveliness_stop()
+        assert resp.get("ok") is True
+        frames = _liveliness_frames(transport)
+        assert frames and frames[0]["enable"] is False
+    finally:
+        svc.stop()

--- a/modules/arduino_serial/tests/test_validate_liveliness.py
+++ b/modules/arduino_serial/tests/test_validate_liveliness.py
@@ -1,0 +1,60 @@
+"""Contract tests for the firmware liveliness command (builder + validator)."""
+
+from __future__ import annotations
+
+from modules.arduino_serial.contract import (
+    build_liveliness_cmd,
+    validate_arduino_payload,
+    validate_liveliness_cmd,
+    LIVELINESS_AMPLITUDE_MAX_DEG,
+    LIVELINESS_PERIOD_MIN_MS,
+)
+
+
+def test_builder_shapes_payload():
+    cmd = build_liveliness_cmd(True, mode="breathe", amplitude_deg=6, period_ms=4000, pan_center=90, tilt_center=95)
+    assert cmd["cmd"] == "liveliness"
+    assert cmd["enable"] is True
+    assert cmd["mode"] == "breathe"
+    assert cmd["amplitude_deg"] == 6.0
+    assert cmd["period_ms"] == 4000
+    assert cmd["pan_center"] == 90.0
+
+
+def test_enable_true_valid_passes():
+    cmd = build_liveliness_cmd(True, mode="breathe", amplitude_deg=5, period_ms=3000)
+    assert validate_arduino_payload(cmd) is None
+
+
+def test_disable_needs_no_params():
+    assert validate_arduino_payload(build_liveliness_cmd(False)) is None
+
+
+def test_enable_requires_bool():
+    assert validate_liveliness_cmd({"cmd": "liveliness"}) is not None
+    assert validate_liveliness_cmd({"cmd": "liveliness", "enable": "yes"}) is not None
+
+
+def test_rejects_unknown_mode():
+    cmd = build_liveliness_cmd(True, mode="rave")
+    assert "mode" in (validate_arduino_payload(cmd) or "")
+
+
+def test_rejects_excessive_amplitude():
+    cmd = build_liveliness_cmd(True, amplitude_deg=LIVELINESS_AMPLITUDE_MAX_DEG + 5)
+    assert "amplitude_deg" in (validate_arduino_payload(cmd) or "")
+
+
+def test_rejects_too_short_period():
+    cmd = build_liveliness_cmd(True, period_ms=LIVELINESS_PERIOD_MIN_MS - 1)
+    assert "period_ms" in (validate_arduino_payload(cmd) or "")
+
+
+def test_rejects_out_of_range_center():
+    cmd = build_liveliness_cmd(True, pan_center=999)
+    assert "pan_center" in (validate_arduino_payload(cmd) or "")
+
+
+def test_other_cmd_passes_through_validator():
+    # validate_liveliness_cmd ignores non-liveliness payloads
+    assert validate_liveliness_cmd({"cmd": "hello"}) is None

--- a/modules/arduino_serial/xArduinoSerialService.py
+++ b/modules/arduino_serial/xArduinoSerialService.py
@@ -21,6 +21,7 @@ from .contract import (
     build_laser_cmd,
     build_pid_enable_cmd,
     build_policy_cmd,
+    build_liveliness_cmd,
     build_set_pose_cmd,
     build_set_servo_cmd,
     build_simple_cmd,
@@ -498,6 +499,29 @@ class xArduinoSerialService:
 
     def drive(self, value: int) -> Dict[str, Any]:
         return self.request(build_drive_cmd(value=value))
+
+    # -------- liveliness (idle breathing / micro-motion) --------
+    def liveliness_start(
+        self,
+        mode: str = "breathe",
+        amplitude_deg: Optional[float] = None,
+        period_ms: Optional[int] = None,
+        pan_center: Optional[float] = None,
+        tilt_center: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        return self.request(
+            build_liveliness_cmd(
+                True,
+                mode=mode,
+                amplitude_deg=amplitude_deg,
+                period_ms=period_ms,
+                pan_center=pan_center,
+                tilt_center=tilt_center,
+            )
+        )
+
+    def liveliness_stop(self) -> Dict[str, Any]:
+        return self.request(build_liveliness_cmd(False))
 
     # -------- laser controls --------
     def laser_on(self, which: int) -> Dict[str, Any]:

--- a/modules/autonomy/config/appraisal.yml
+++ b/modules/autonomy/config/appraisal.yml
@@ -1,0 +1,29 @@
+# Affective appraisal rules: map a semantic event to mood-axis deltas.
+#
+# Axes: happiness, energy, curiosity, fear, anger (0-100).
+# Deltas are scaled by an optional per-call intensity factor.
+#
+# This gives the robot *causal* emotion ("the user was rude -> anger") instead
+# of pure time-based decay, so its feelings react to what actually happens.
+
+rules:
+  owner_returned:   { happiness: 22, anger: -12, fear: -10 }
+  owner_left:       { happiness: -8, curiosity: 4 }
+  greeted:          { happiness: 7 }
+  user_praise:      { happiness: 18, anger: -10 }
+  user_thanks:      { happiness: 12 }
+  user_rude:        { anger: 32, happiness: -12 }
+  user_insult:      { anger: 45, happiness: -18, fear: 6 }
+  command_failed:   { anger: 12, fear: 6 }
+  command_ok:       { happiness: 6, anger: -4 }
+  owner_lockout:    { anger: 20, fear: 15, happiness: -10 }
+  petted:           { happiness: 16, anger: -16, fear: -8 }
+  loud_noise:       { fear: 22, anger: 5, energy: 6 }
+  new_person:       { curiosity: 12, energy: 4 }
+  scene_change:     { curiosity: 8 }
+  darkness:         { fear: 8, energy: -6 }
+  alone_too_long:   { happiness: -10, curiosity: 6 }
+  played_with:      { happiness: 20, energy: 8, anger: -10 }
+  rested:           { energy: 30, fear: -10 }
+
+# Decay multipliers are handled by MoodManager; this file only defines events.

--- a/modules/autonomy/config/config.yml
+++ b/modules/autonomy/config/config.yml
@@ -103,6 +103,16 @@ barge_in:
   min_words: 2
   cooldown_s: 1.5
 
+# Firmware-native idle liveliness (breathing / micro-motion on the head servos).
+# The brain shapes amplitude/tempo from mood and only resends on change or every
+# refresh_interval_s, so the serial link stays quiet.
+liveliness:
+  enabled: true
+  amplitude_deg: 4.0        # base breathing amplitude (degrees)
+  max_amplitude_deg: 12.0   # hard cap after emotion shaping
+  period_ms: 4500           # base breathing period
+  refresh_interval_s: 20.0  # resend keepalive even if params unchanged
+
 offline_mode:
   enabled: true
   availability_ttl_s: 5

--- a/modules/autonomy/config/config.yml
+++ b/modules/autonomy/config/config.yml
@@ -96,6 +96,13 @@ speech_quiet_hours:
   max_chars: 120
   prefix: ""
 
+# Natural barge-in: let the user cut off the robot by speaking, not only via
+# wakeword. A wakeword always interrupts; free speech needs `min_words`.
+barge_in:
+  enabled: true
+  min_words: 2
+  cooldown_s: 1.5
+
 offline_mode:
   enabled: true
   availability_ttl_s: 5

--- a/modules/autonomy/config/config.yml
+++ b/modules/autonomy/config/config.yml
@@ -187,9 +187,24 @@ companion:
     max_per_hour: 4
     owner_only: false
     enable_callback_lines: true
+    callback_min_trust: 0.2    # skip preference callbacks when trust is very low
     policy:
       owner_style: "warm"
       guest_style: "respectful"
+  # Companion learning loop: extract prefs/facts, reinforce trust from praise/rude.
+  learning:
+    enabled: true
+    feedback:
+      enabled: true
+      trust_min: 0.0
+      trust_max: 1.0
+      deltas:
+        user_praise:
+          trust: 0.08
+          salience: 0.5
+        user_rude:
+          trust: -0.12
+          salience: 0.55
 
 vision_hooks:
   enabled: true

--- a/modules/autonomy/services/affective_appraisal.py
+++ b/modules/autonomy/services/affective_appraisal.py
@@ -1,0 +1,95 @@
+"""Affective appraisal engine.
+
+Maps *semantic events* (e.g. ``user_rude``, ``owner_returned``) onto mood-axis
+deltas so the robot's feelings have causes rather than only time-based decay.
+
+Rules are config-driven (``config/appraisal.yml``) and can be overridden by the
+autonomy config under ``defaults.appraisal.rules``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+logger = logging.getLogger("autonomy.appraisal")
+
+_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "appraisal.yml"
+
+# Minimal built-in defaults so the engine works even without the YAML file.
+_DEFAULT_RULES: Dict[str, Dict[str, float]] = {
+    "owner_returned": {"happiness": 22, "anger": -12, "fear": -10},
+    "user_praise": {"happiness": 18, "anger": -10},
+    "user_rude": {"anger": 32, "happiness": -12},
+    "command_failed": {"anger": 12, "fear": 6},
+    "loud_noise": {"fear": 22, "anger": 5},
+    "new_person": {"curiosity": 12},
+    "petted": {"happiness": 16, "anger": -16},
+}
+
+
+class AffectiveAppraisal:
+    """Turns events into mood deltas and applies them to a mood manager."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        self.rules: Dict[str, Dict[str, float]] = dict(_DEFAULT_RULES)
+        self._load_yaml_rules()
+        # Allow an autonomy-config override to win over file/defaults.
+        override = ((config or {}).get("defaults", {}) or {}).get("appraisal", {}) or {}
+        file_rules = override.get("rules")
+        if isinstance(file_rules, dict):
+            self._merge_rules(file_rules)
+
+    def _load_yaml_rules(self) -> None:
+        try:
+            with open(_CONFIG_PATH, "r", encoding="utf-8") as handle:
+                data = yaml.safe_load(handle) or {}
+            rules = data.get("rules")
+            if isinstance(rules, dict):
+                self._merge_rules(rules)
+        except FileNotFoundError:
+            logger.debug("appraisal.yml not found, using built-in defaults")
+        except Exception as exc:
+            logger.warning("failed to load appraisal rules: %s", exc)
+
+    def _merge_rules(self, rules: Dict[str, Any]) -> None:
+        for event, deltas in rules.items():
+            if not isinstance(deltas, dict):
+                continue
+            clean = {}
+            for axis, value in deltas.items():
+                try:
+                    clean[str(axis)] = float(value)
+                except (TypeError, ValueError):
+                    continue
+            if clean:
+                self.rules[str(event).strip().lower()] = clean
+
+    def known_events(self):
+        return sorted(self.rules.keys())
+
+    def appraise(self, event: str, intensity: float = 1.0) -> Dict[str, float]:
+        """Return scaled mood deltas for an event (empty dict if unknown)."""
+        deltas = self.rules.get(str(event).strip().lower())
+        if not deltas:
+            return {}
+        factor = max(0.0, float(intensity))
+        return {axis: value * factor for axis, value in deltas.items()}
+
+    def apply(self, mood: Any, event: str, intensity: float = 1.0) -> Optional[str]:
+        """Apply an event's deltas to ``mood``; returns the event if it matched."""
+        deltas = self.appraise(event, intensity)
+        if not deltas:
+            return None
+        for axis, delta in deltas.items():
+            try:
+                mood.modify(axis, delta)
+            except Exception:
+                continue
+        return str(event).strip().lower()
+
+
+__all__ = ["AffectiveAppraisal"]

--- a/modules/autonomy/services/barge_in.py
+++ b/modules/autonomy/services/barge_in.py
@@ -1,0 +1,49 @@
+"""Barge-in policy: decide when the user's voice should cut off the robot.
+
+Historically the robot only stopped talking when it heard a wakeword. Natural
+conversation also lets you interrupt mid-sentence just by starting to speak.
+This controller centralises that decision so it can be unit-tested without any
+audio hardware: given (is the robot currently talking?, what did the user say?),
+it returns whether to interrupt — with a cooldown so a single utterance doesn't
+trigger repeated stops.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+
+class BargeInController:
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        cfg = config if isinstance(config, dict) else {}
+        self.enabled = bool(cfg.get("enabled", True))
+        # Wakeword always interrupts; free speech needs at least this many words
+        # so coughs / one-word echoes don't constantly cut the robot off.
+        self.min_words = int(cfg.get("min_words", 2))
+        self.cooldown_s = float(cfg.get("cooldown_s", 1.5))
+        self._last_interrupt_ts = 0.0
+
+    def should_interrupt(
+        self,
+        *,
+        robot_speaking: bool,
+        user_text: str,
+        has_wakeword: bool = False,
+        now: Optional[float] = None,
+    ) -> bool:
+        if not self.enabled:
+            return False
+        if not robot_speaking:
+            return False
+        now = time.time() if now is None else now
+        if (now - self._last_interrupt_ts) < self.cooldown_s:
+            return False
+        words = len(str(user_text or "").split())
+        if has_wakeword or words >= self.min_words:
+            self._last_interrupt_ts = now
+            return True
+        return False
+
+
+__all__ = ["BargeInController"]

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -12,6 +12,7 @@ from .idle_behaviors import IdleBehaviorPlanner
 from .mood import MoodManager
 from .memory import ShortTermMemory
 from .affective_appraisal import AffectiveAppraisal
+from .expression_director import ExpressionDirector
 from .companion_rituals import CompanionRituals
 from .proactive_planner import ProactivePlanner
 from .relationship_memory import RelationshipMemory
@@ -58,6 +59,7 @@ class AutonomyBrain(
         self.mood = MoodManager(config)
         self.appraisal = AffectiveAppraisal(config)
         self.client = ServiceClient(config.get("endpoints", {}), config=config)
+        self.expression = ExpressionDirector(self.client)
         self.idle_planner = IdleBehaviorPlanner(config)
         self.memory = ShortTermMemory(max_items=20)
         companion_cfg = config.get("companion", {}) if isinstance(config.get("companion", {}), dict) else {}
@@ -283,6 +285,22 @@ class AutonomyBrain(
                     pass
         except Exception:
             logger.debug("Failed to run emotion scene %s", scene_name, exc_info=True)
+
+    def express(self, emotion: str, *, say: Optional[str] = None, language: Optional[str] = None) -> str:
+        """Deliberately express an emotion across all modalities at once.
+
+        Use for reactive, intentional expressions (greetings, reactions). Passive
+        mood-driven visuals continue to flow through ``_sync_emotion``.
+        """
+        head = None
+        try:
+            profile = self.mood.get_body_language_profile() or {}
+            pan = int(self.state.get("current_pan", 90)) + int(profile.get("pan_delta", 0))
+            tilt = int(self.state.get("current_tilt", 90))
+            head = (max(0, min(180, pan)), max(0, min(180, tilt)))
+        except Exception:
+            head = None
+        return self.expression.express(emotion, say=say, language=language, move_head=head)
 
     def appraise_event(self, event: str, intensity: float = 1.0, *, emit: bool = True) -> Optional[str]:
         """Apply a causal emotion event to mood and announce it.

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -820,7 +820,7 @@ class AutonomyBrain(
                         )
 
                     enriched_text = self._enrich_user_text_with_companion_context(text=text, speaker=speaker)
-                    agent_result = self.agent.step(enriched_text, language=lang)
+                    agent_result = self.agent.step(enriched_text, language=lang, speaker=speaker)
                     if agent_result and agent_result.get("text"):
                         if not self._is_active_request(request_id):
                             return

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -877,7 +877,19 @@ class AutonomyBrain(
             hints.append(f"likes={','.join([str(x) for x in likes[:3]])}")
         if topics:
             hints.append(f"topics={','.join([str(x) for x in topics[:3]])}")
-        if top_memory:
+        # Context-aware recall: surface the past snippet most relevant to what the
+        # user is saying *now* (not just the highest-salience memory).
+        recalled = ""
+        try:
+            from .recall import most_relevant
+
+            candidates = self.relationship_memory.recall_candidates(spk)
+            recalled = most_relevant(raw, candidates) or ""
+        except Exception:
+            recalled = ""
+        if recalled:
+            hints.append(f"recall={recalled[:90]}")
+        elif top_memory:
             hints.append(f"memory={top_memory[:90]}")
         if not hints:
             return raw

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -15,6 +15,7 @@ from .affective_appraisal import AffectiveAppraisal
 from .expression_director import ExpressionDirector
 from .companion_rituals import CompanionRituals
 from .proactive_planner import ProactivePlanner
+from .barge_in import BargeInController
 from .relationship_memory import RelationshipMemory
 from .brain_parts.animations import AnimationSupportMixin
 from .brain_parts.owner_guard import OwnerGuardMixin
@@ -71,6 +72,7 @@ class AutonomyBrain(
             companion_cfg.get("rituals", {}) if isinstance(companion_cfg.get("rituals", {}), dict) else {}
         )
         self.proactive_planner = ProactivePlanner(companion_cfg.get("proactive", {}) if isinstance(companion_cfg.get("proactive", {}), dict) else {})
+        self.barge_in = BargeInController(config.get("barge_in", {}) if isinstance(config.get("barge_in", {}), dict) else {})
         self._vision_cfg = config.get("vision_hooks", {})
         self.owner_cfg = config.get("owner", {})
 
@@ -703,12 +705,36 @@ class AutonomyBrain(
         except Exception as exc:
             logger.debug("barge-in stop failed: %s", exc)
 
+    def _robot_is_speaking(self) -> bool:
+        """Best-effort check of whether TTS audio is currently playing."""
+        try:
+            if self.agent and hasattr(self.agent, "speech_arbiter"):
+                return bool(self.agent.speech_arbiter.is_speaking())
+        except Exception:
+            pass
+        try:
+            status = self.client.get_speak_status()
+            if isinstance(status, dict):
+                return bool(status.get("speaking") or status.get("busy"))
+        except Exception:
+            pass
+        return False
+
     def _react_to_speech(self, text, source_lang: str | None = None):
         """React to heard text."""
         from modules.speech.services.wake_phrase import contains_wakeword, strip_wakewords
 
         low = str(text or "").lower()
-        if contains_wakeword(low):
+        has_wake = contains_wakeword(low)
+        # Natural barge-in: any meaningful utterance (not only a wakeword) cuts
+        # off the robot if it's mid-sentence, like a real conversation.
+        if self.barge_in.should_interrupt(
+            robot_speaking=self._robot_is_speaking(),
+            user_text=text,
+            has_wakeword=has_wake,
+        ):
+            self._barge_in_stop_speaking()
+        elif has_wake:
             self._barge_in_stop_speaking()
 
         request_id = uuid.uuid4().hex[:10]

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -420,6 +420,11 @@ class AutonomyBrain(
         speaker = str(self.state.get("last_speaker") or "")
         owner_present = bool(self._owner_seen_recently()) if hasattr(self, "_owner_seen_recently") else False
         social_profile = self.relationship_memory.social_profile(speaker) if speaker else {}
+        scene_ctx = {
+            "summary": str(self.state.get("scene_summary", "") or ""),
+            "importance": float(self.state.get("scene_importance", 0.0) or 0.0),
+            "unspoken": bool(self.state.get("scene_unspoken", False)),
+        }
         plan = self.proactive_planner.propose(
             now_ts=now,
             idle_s=idle_s,
@@ -427,12 +432,15 @@ class AutonomyBrain(
             last_speaker=speaker,
             owner_present=owner_present,
             social_profile=social_profile,
+            scene=scene_ctx,
         )
         if not plan:
             return
         text = str(plan.get("text", "")).strip()
         if not text:
             return
+        if plan.get("scene_consumed"):
+            self.state["scene_unspoken"] = False
         emotion = str(plan.get("emotion", "curiosity")).strip()
         event = str(plan.get("event", "companion.proactive")).strip()
         self.client.push_interaction_event(event, {"text": text, "emotion": emotion})

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -5,12 +5,13 @@ import random
 import datetime
 import json
 import uuid
-from typing import List
+from typing import List, Optional
 
 from .client import ServiceClient
 from .idle_behaviors import IdleBehaviorPlanner
 from .mood import MoodManager
 from .memory import ShortTermMemory
+from .affective_appraisal import AffectiveAppraisal
 from .companion_rituals import CompanionRituals
 from .proactive_planner import ProactivePlanner
 from .relationship_memory import RelationshipMemory
@@ -55,6 +56,7 @@ class AutonomyBrain(
 
         # Components
         self.mood = MoodManager(config)
+        self.appraisal = AffectiveAppraisal(config)
         self.client = ServiceClient(config.get("endpoints", {}), config=config)
         self.idle_planner = IdleBehaviorPlanner(config)
         self.memory = ShortTermMemory(max_items=20)
@@ -281,6 +283,39 @@ class AutonomyBrain(
                     pass
         except Exception:
             logger.debug("Failed to run emotion scene %s", scene_name, exc_info=True)
+
+    def appraise_event(self, event: str, intensity: float = 1.0, *, emit: bool = True) -> Optional[str]:
+        """Apply a causal emotion event to mood and announce it.
+
+        Returns the matched event name (or ``None`` if the event is unknown).
+        """
+        matched = self.appraisal.apply(self.mood, event, intensity)
+        if not matched:
+            return None
+        try:
+            self.memory.add_event(f"Felt a reaction to: {matched}")
+        except Exception:
+            pass
+        if emit:
+            try:
+                self.client.push_interaction_event(f"appraisal:{matched}")
+            except Exception:
+                pass
+        return matched
+
+    @staticmethod
+    def _sentiment_event_for_text(text: str) -> Optional[str]:
+        """Very lightweight keyword sentiment -> appraisal event mapping."""
+        low = str(text or "").lower()
+        if not low:
+            return None
+        rude = ("aptal", "salak", "gerizekal", "kapa cen", "sus ", "stupid", "shut up", "idiot")
+        praise = ("aferin", "harikasin", "cok iyi", "tesekkur", "sevimlisin", "good job", "well done", "thank you", "i love you")
+        if any(tok in low for tok in rude):
+            return "user_rude"
+        if any(tok in low for tok in praise):
+            return "user_praise"
+        return None
 
     def _think(self):
         now = time.time()
@@ -650,6 +685,9 @@ class AutonomyBrain(
         logger.info("Heard: %s", text)
         self.state["last_interaction"] = time.time()
         self.mood.modify("happiness", 5)
+        sentiment_event = self._sentiment_event_for_text(text)
+        if sentiment_event:
+            self.appraise_event(sentiment_event)
         self.memory.add_event(f"User said: {text}")
         self._log_conversation(text)
         lang = str(source_lang or self.state.get("last_speech_language") or "tr")
@@ -769,7 +807,8 @@ class AutonomyBrain(
                     logger.info("LLM response only triggered physical actions.")
         except Exception as exc:
             logger.error("Failed to generate reply: %s", exc)
-            self.mood.modify("fear", 15)
+            # A failed reply both scares and frustrates the robot (causal appraisal).
+            self.appraise_event("command_failed", emit=False)
             self.client.push_interaction_event("error", {"source": "ollama", "reason": "chat_failed"})
             self._apply_emotion_visual_state("fear")
         finally:

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -16,6 +16,7 @@ from .expression_director import ExpressionDirector
 from .companion_rituals import CompanionRituals
 from .proactive_planner import ProactivePlanner
 from .barge_in import BargeInController
+from .liveliness import LivelinessScheduler
 from .relationship_memory import RelationshipMemory
 from .brain_parts.animations import AnimationSupportMixin
 from .brain_parts.owner_guard import OwnerGuardMixin
@@ -73,6 +74,7 @@ class AutonomyBrain(
         )
         self.proactive_planner = ProactivePlanner(companion_cfg.get("proactive", {}) if isinstance(companion_cfg.get("proactive", {}), dict) else {})
         self.barge_in = BargeInController(config.get("barge_in", {}) if isinstance(config.get("barge_in", {}), dict) else {})
+        self.liveliness = LivelinessScheduler(config.get("liveliness", {}) if isinstance(config.get("liveliness", {}), dict) else {})
         self._vision_cfg = config.get("vision_hooks", {})
         self.owner_cfg = config.get("owner", {})
 
@@ -358,6 +360,7 @@ class AutonomyBrain(
 
         self.mood.update()
         self._sync_emotion()
+        self._liveliness_tick(now)
 
         if random.random() < 0.4:
             self._perform_micro_movement()

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -17,6 +17,7 @@ from .companion_rituals import CompanionRituals
 from .proactive_planner import ProactivePlanner
 from .barge_in import BargeInController
 from .liveliness import LivelinessScheduler
+from .interaction_feedback import InteractionFeedbackLearner
 from .relationship_memory import RelationshipMemory
 from .brain_parts.animations import AnimationSupportMixin
 from .brain_parts.owner_guard import OwnerGuardMixin
@@ -73,6 +74,8 @@ class AutonomyBrain(
             companion_cfg.get("rituals", {}) if isinstance(companion_cfg.get("rituals", {}), dict) else {}
         )
         self.proactive_planner = ProactivePlanner(companion_cfg.get("proactive", {}) if isinstance(companion_cfg.get("proactive", {}), dict) else {})
+        learning_cfg = companion_cfg.get("learning", {}) if isinstance(companion_cfg.get("learning", {}), dict) else {}
+        self.feedback_learner = InteractionFeedbackLearner(learning_cfg.get("feedback", learning_cfg))
         self.barge_in = BargeInController(config.get("barge_in", {}) if isinstance(config.get("barge_in", {}), dict) else {})
         self.liveliness = LivelinessScheduler(config.get("liveliness", {}) if isinstance(config.get("liveliness", {}), dict) else {})
         self._vision_cfg = config.get("vision_hooks", {})
@@ -769,6 +772,8 @@ class AutonomyBrain(
             self.state["last_speaker"] = speaker
             self._note_person_seen(speaker, emotion=str(self.state.get("last_emotion") or ""))
             self._remember_person_chat(speaker, text, role="user")
+            if sentiment_event:
+                self._apply_interaction_feedback(sentiment_event, speaker, text)
 
         self.client.push_interaction_event("autonomy.excited")
 
@@ -883,6 +888,12 @@ class AutonomyBrain(
         with self._speech_req_lock:
             return self._active_speech_req_id == request_id
 
+    def _apply_interaction_feedback(self, event: str, speaker: str, text: str) -> None:
+        try:
+            self.feedback_learner.apply(event, speaker, text=text)
+        except Exception:
+            pass
+
     def _remember_person_chat(self, speaker: str | None, text: str, role: str) -> None:
         person = str(speaker or "").strip()
         if not person or person.lower() == "unknown" or not text:
@@ -910,6 +921,11 @@ class AutonomyBrain(
         topics = profile.get("topics", []) if isinstance(profile.get("topics", []), list) else []
         top_memory = str(profile.get("top_memory", "")).strip()
         hints = []
+        trust = float(profile.get("trust_score", 0.0) or 0.0)
+        if trust >= 0.7:
+            hints.append("trust=high")
+        elif trust <= 0.3:
+            hints.append("trust=low")
         if likes:
             hints.append(f"likes={','.join([str(x) for x in likes[:3]])}")
         if topics:

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -617,26 +617,34 @@ class AutonomyBrain(
     def _visual_lock_active(self) -> bool:
         return time.time() < float(self._visual_lock_until)
 
+    # Emotions that warrant a longer visual hold (high-arousal states).
+    _STRONG_VISUAL_EMOTIONS = {"fear", "furious", "anger", "surprise"}
+
     def _apply_emotion_visual_state(self, emotion: str) -> None:
         e = str(emotion or "neutral").strip().lower()
-        mapping = {
-            "joy": {"effect": "RAINBOW_CYCLE", "oled": "happy", "color": [255, 190, 80], "strong": False},
-            "curiosity": {"effect": "COMET", "oled": "focused", "color": [60, 190, 255], "strong": False},
-            "sadness": {"effect": "PULSE", "oled": "sad", "color": [60, 90, 180], "strong": False},
-            "tired": {"effect": "BREATHE", "oled": "sleepy", "color": [80, 70, 120], "strong": False},
-            "fear": {"effect": "PULSE", "oled": "scared", "color": [255, 40, 40], "strong": True},
-            "neutral": {"effect": "BREATHE", "oled": "normal", "color": [120, 120, 140], "strong": False},
-        }
-        spec = mapping.get(e, mapping["neutral"])
-        lock_s = self._visual_lock_strong_s if spec.get("strong") else self._visual_lock_default_s
-        self._visual_lock_until = max(self._visual_lock_until, time.time() + max(0.2, float(lock_s)))
-        self._visual_lock_reason = f"emotion:{e}"
+        # Resolve eyes + LED effect + colour from the single canonical vocabulary
+        # so every emotion (incl. anger/furious/surprise) gets coherent visuals.
         try:
-            self.client.set_neopixel(str(spec.get("effect", "BREATHE")), emotions=[e], color=spec.get("color"))
+            from modules.common.emotion_vocab import emotion_render
+
+            render = emotion_render(e)
+            canon = render.canonical
+            effect = render.effect
+            oled = render.oled
+            color = list(render.rgb)
+        except Exception:
+            canon, effect, oled, color = "neutral", "BREATHE", "normal", [120, 120, 140]
+
+        strong = canon in self._STRONG_VISUAL_EMOTIONS
+        lock_s = self._visual_lock_strong_s if strong else self._visual_lock_default_s
+        self._visual_lock_until = max(self._visual_lock_until, time.time() + max(0.2, float(lock_s)))
+        self._visual_lock_reason = f"emotion:{canon}"
+        try:
+            self.client.set_neopixel(effect, emotions=[canon], color=color)
         except Exception:
             pass
         try:
-            self.client.oled_show(str(spec.get("oled", "normal")))
+            self.client.oled_show(oled)
         except Exception:
             pass
 

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -310,7 +310,7 @@ class AutonomyBrain(
         if not low:
             return None
         rude = ("aptal", "salak", "gerizekal", "kapa cen", "sus ", "stupid", "shut up", "idiot")
-        praise = ("aferin", "harikasin", "cok iyi", "tesekkur", "sevimlisin", "good job", "well done", "thank you", "i love you")
+        praise = ("aferin", "harikasin", "cok iyi", "tesekkur", "sevimlisin", "seviyorum", "good job", "well done", "thank you", "i love you")
         if any(tok in low for tok in rude):
             return "user_rude"
         if any(tok in low for tok in praise):

--- a/modules/autonomy/services/brain_parts/animations.py
+++ b/modules/autonomy/services/brain_parts/animations.py
@@ -29,6 +29,33 @@ class AnimationSupportMixin:
         if isinstance(evt, str) and evt and random.random() < 0.18:
             self.client.push_interaction_event(evt)
 
+        # Layer subtle eye + ear life on top of head motion for richer liveliness.
+        if random.random() < 0.25:
+            self._perform_eye_saccade()
+        if random.random() < 0.2:
+            self._perform_ear_micromovement()
+
+    def _perform_eye_saccade(self) -> None:
+        """Briefly dart the eyes to a random gaze direction."""
+        gaze = random.choice(["look_left", "look_right", "look_up", "look_down"])
+        try:
+            self.client.oled_show(gaze)
+        except Exception:
+            pass
+
+    def _perform_ear_micromovement(self) -> None:
+        """Nudge the ears toward the current mood pose for ambient liveliness."""
+        dominant = "neutral"
+        if hasattr(self, "mood") and hasattr(self.mood, "get_dominant_emotion"):
+            try:
+                dominant = self.mood.get_dominant_emotion() or "neutral"
+            except Exception:
+                dominant = "neutral"
+        try:
+            self.client.push_interaction_event(f"emotion:{dominant}")
+        except Exception:
+            pass
+
     def _trigger_animation(self, name: str, speed: float = 1.0, loop: bool = False) -> bool:
         resp = self.client.run_animation(name, speed=speed, loop=loop)
         return bool(resp and resp.get("ok"))

--- a/modules/autonomy/services/brain_parts/animations.py
+++ b/modules/autonomy/services/brain_parts/animations.py
@@ -35,6 +35,48 @@ class AnimationSupportMixin:
         if random.random() < 0.2:
             self._perform_ear_micromovement()
 
+    def _liveliness_tick(self, now: float) -> None:
+        """Push mood-shaped idle motion down to firmware-native liveliness.
+
+        Best-effort and rate-limited by the scheduler; suppressed while the robot
+        is talking, following a target, or asleep so it never fights deliberate
+        motion.
+        """
+        sched = getattr(self, "liveliness", None)
+        if sched is None or not getattr(sched, "enabled", False):
+            return
+        if getattr(self, "_speech_busy", False):
+            return
+        if self.state.get("follow_active") or self.state.get("is_sleeping"):
+            return
+        energy = 50.0
+        dominant = "neutral"
+        try:
+            energy = float(self.mood["energy"])
+        except Exception:
+            pass
+        try:
+            dominant = self.mood.get_dominant_emotion() or "neutral"
+        except Exception:
+            pass
+        params = sched.plan(energy=energy, dominant_emotion=dominant)
+        if not sched.due(now, params):
+            return
+        pan = int(self.state.get("current_pan", 90))
+        tilt = int(self.state.get("current_tilt", 90))
+        try:
+            self.client.set_liveliness(
+                True,
+                mode=params["mode"],
+                amplitude_deg=params["amplitude_deg"],
+                period_ms=params["period_ms"],
+                pan_center=pan,
+                tilt_center=tilt,
+            )
+            sched.mark_sent(now, params)
+        except Exception:
+            pass
+
     def _perform_eye_saccade(self) -> None:
         """Briefly dart the eyes to a random gaze direction."""
         gaze = random.choice(["look_left", "look_right", "look_up", "look_down"])

--- a/modules/autonomy/services/brain_parts/vision.py
+++ b/modules/autonomy/services/brain_parts/vision.py
@@ -26,6 +26,7 @@ class VisionMixin:
                 ctx_data = ctx_resp.get("context", {})
                 importance = float(ctx_data.get("importance_score", 0.0))
                 self.state["last_visual_importance"] = importance
+                self._track_scene_context(ctx_data, importance)
                 if importance > 0.6:
                     self.mood.modify("curiosity", int(importance * 20))
                     self.mood.modify("energy", 10)
@@ -52,6 +53,47 @@ class VisionMixin:
         self._current_people = {
             name: ts for name, ts in self._current_people.items() if now - ts <= decay_window
         }
+
+    @staticmethod
+    def _scene_tokens(summary: str) -> set:
+        return {t for t in str(summary or "").lower().split() if len(t) > 2}
+
+    def _track_scene_context(self, ctx_data: Dict[str, Any], importance: float) -> None:
+        """Detect meaningful scene changes and remember the current surroundings.
+
+        Keeps a short-lived snapshot of the environment in ``self.state`` so the
+        proactive layer can comment on what's around, and emits an
+        ``environment.scene_changed`` interaction event on novelty so other
+        modules (ears/LED/agent) can react.
+        """
+        summary = str(ctx_data.get("summary", "") or "").strip()
+        if not summary:
+            return
+        prev = str(self.state.get("last_scene_summary", "") or "")
+        prev_tokens = self._scene_tokens(prev)
+        cur_tokens = self._scene_tokens(summary)
+        novelty = 1.0
+        if prev_tokens:
+            union = prev_tokens | cur_tokens
+            novelty = (len(prev_tokens ^ cur_tokens) / len(union)) if union else 0.0
+
+        self.state["scene_summary"] = summary
+        self.state["scene_importance"] = importance
+
+        threshold = float(self._vision_cfg.get("scene_novelty_threshold", 0.5))
+        if novelty >= threshold and summary != prev:
+            self.state["last_scene_summary"] = summary
+            self.state["scene_changed_at"] = time.time()
+            self.state["scene_unspoken"] = True  # proactive layer may narrate it
+            try:
+                self.client.push_interaction_event(
+                    "environment.scene_changed",
+                    {"summary": summary[:160], "importance": round(importance, 2)},
+                )
+            except Exception:
+                pass
+            if importance >= 0.5:
+                self.mood.modify("curiosity", 6)
 
     def _handle_vision_result(self, result: Dict[str, Any]) -> None:
         name = result.get("name") or result.get("label")

--- a/modules/autonomy/services/brain_parts/vocal.py
+++ b/modules/autonomy/services/brain_parts/vocal.py
@@ -71,14 +71,44 @@ class VocalMixin:
         except Exception as exc:  # pragma: no cover - best effort speech
             logger.debug("Failed to queue speech action: %s", exc)
 
+    # Per-canonical-emotion prosody. Resolution goes through the shared emotion
+    # vocabulary so aliases ("happy"->joy, "scared"->fear, "angry"->anger) all
+    # collapse to the same voice as eyes/LEDs/ears.
+    _EMOTION_TONES = {
+        "joy": {"rate": 190, "volume": 1.0},
+        "love": {"rate": 185, "volume": 0.95},
+        "excitement": {"rate": 205, "volume": 1.0},
+        "surprise": {"rate": 200, "volume": 1.0},
+        "curiosity": {"rate": 185, "volume": 0.9},
+        "sadness": {"rate": 150, "volume": 0.75},
+        "worried": {"rate": 165, "volume": 0.8},
+        "tired": {"rate": 140, "volume": 0.65},
+        "bored": {"rate": 150, "volume": 0.7},
+        "fear": {"rate": 200, "volume": 0.9},
+        "anger": {"rate": 195, "volume": 1.0},
+        "furious": {"rate": 205, "volume": 1.0},
+        "confusion": {"rate": 165, "volume": 0.85},
+        "disgust": {"rate": 165, "volume": 0.85},
+        "neutral": {"rate": 170, "volume": 0.85},
+    }
+    # Fallback by canonical TTS tone name when a specific emotion isn't mapped.
+    _TONE_NAME_PROFILES = {
+        "joy": {"rate": 190, "volume": 1.0},
+        "excited": {"rate": 200, "volume": 1.0},
+        "sadness": {"rate": 150, "volume": 0.75},
+        "neutral": {"rate": 170, "volume": 0.85},
+    }
+
     def _tone_profile(self, emotion: str | None = None) -> dict:
         emotion = emotion or self.state.get("last_emotion") or self.mood.get_dominant_emotion() or "neutral"
-        profiles = {
-            "joy": {"rate": 190, "volume": 1.0},
-            "sadness": {"rate": 150, "volume": 0.75},
-            "curiosity": {"rate": 185, "volume": 0.9},
-            "tired": {"rate": 140, "volume": 0.65},
-            "fear": {"rate": 200, "volume": 0.9},
-            "neutral": {"rate": 170, "volume": 0.85},
-        }
-        return profiles.get(emotion, profiles["neutral"])
+        try:
+            from modules.common.emotion_vocab import get_vocab
+
+            vocab = get_vocab()
+            canon = vocab.canonical(emotion)
+            if canon in self._EMOTION_TONES:
+                return dict(self._EMOTION_TONES[canon])
+            tone_name = vocab.render(emotion).tone
+            return dict(self._TONE_NAME_PROFILES.get(tone_name, self._TONE_NAME_PROFILES["neutral"]))
+        except Exception:
+            return dict(self._EMOTION_TONES.get(str(emotion).lower(), self._EMOTION_TONES["neutral"]))

--- a/modules/autonomy/services/client.py
+++ b/modules/autonomy/services/client.py
@@ -9,6 +9,7 @@ from modules.arduino_serial.contract import (
     build_buzzer_cmd,
     build_laser_cmd,
     build_lcd_cmd,
+    build_liveliness_cmd,
     build_set_servo_cmd,
     build_simple_cmd,
     build_sound_play_cmd,
@@ -90,6 +91,19 @@ class ServiceClient:
         pan_resp = self._arduino_request(build_set_servo_cmd(SERVO_INDEX_PAN, int(pan)))
         tilt_resp = self._arduino_request(build_set_servo_cmd(SERVO_INDEX_TILT, int(tilt)))
         return {"ok": bool((pan_resp or {}).get("ok", False)) and bool((tilt_resp or {}).get("ok", False)), "pan": pan_resp, "tilt": tilt_resp}
+
+    def set_liveliness(self, enable: bool, mode: str = "breathe", amplitude_deg=None, period_ms=None, pan_center=None, tilt_center=None):
+        """Enable/disable firmware-native idle liveliness (breathing/micro-motion)."""
+        return self._arduino_request(
+            build_liveliness_cmd(
+                bool(enable),
+                mode=mode,
+                amplitude_deg=amplitude_deg,
+                period_ms=period_ms,
+                pan_center=pan_center,
+                tilt_center=tilt_center,
+            )
+        )
 
     def set_laser(self, on: bool, id: int = 1, both: bool = False):
         return self._arduino_request(build_laser_cmd(on=on, id_=id, both=both))

--- a/modules/autonomy/services/expression_director.py
+++ b/modules/autonomy/services/expression_director.py
@@ -1,0 +1,80 @@
+"""Multi-modal expression director.
+
+Fires a single, coherent emotional expression across every output modality at
+once — eyes (OLED), LEDs (NeoPixel), ears (PiServo, via interaction event),
+optional head pose and optional speech with a matching TTS tone.
+
+All modalities are resolved from the shared canonical emotion vocabulary so they
+stay in sync. Every call is best-effort: a failing modality never blocks the
+others, keeping the robot alive even if one subsystem is down.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger("autonomy.expression")
+
+try:
+    from modules.common.emotion_vocab import emotion_render as _emotion_render
+except Exception:  # pragma: no cover - optional dependency
+    _emotion_render = None
+
+
+def _safe(label: str, fn) -> bool:
+    try:
+        fn()
+        return True
+    except Exception:
+        logger.debug("expression modality failed: %s", label, exc_info=True)
+        return False
+
+
+class ExpressionDirector:
+    """Coordinates eyes + LEDs + ears + head + voice for one emotion."""
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    def express(
+        self,
+        emotion: str,
+        *,
+        say: Optional[str] = None,
+        language: Optional[str] = None,
+        move_head: Optional[Tuple[int, int]] = None,
+    ) -> str:
+        """Render ``emotion`` across all modalities; returns the canonical label."""
+        if _emotion_render is not None:
+            render = _emotion_render(emotion)
+            canon = render.canonical
+            effect = render.effect
+            oled = render.oled
+            color = list(render.rgb)
+            tone = render.tone
+        else:  # minimal fallback when shared vocab is unavailable
+            canon = str(emotion or "neutral").strip().lower()
+            effect, oled, color, tone = "BREATHE", "normal", [120, 120, 140], "neutral"
+
+        modalities = []
+        if _safe("leds", lambda: self.client.set_neopixel(effect, emotions=[canon], color=color)):
+            modalities.append("leds")
+        if _safe("eyes", lambda: self.client.oled_show(oled)):
+            modalities.append("eyes")
+        # interaction event drives ears (piservo bridge) + any other subscribers
+        if _safe("ears", lambda: self.client.push_interaction_event(f"emotion:{canon}")):
+            modalities.append("ears")
+        if move_head is not None:
+            pan, tilt = move_head
+            if _safe("head", lambda: self.client.move_head(int(pan), int(tilt))):
+                modalities.append("head")
+        if say:
+            if _safe("voice", lambda: self.client.speak(say, tone=tone, language=language)):
+                modalities.append("voice")
+
+        logger.debug("expressed %s via %s", canon, modalities)
+        return canon
+
+
+__all__ = ["ExpressionDirector"]

--- a/modules/autonomy/services/interaction_feedback.py
+++ b/modules/autonomy/services/interaction_feedback.py
@@ -1,0 +1,83 @@
+"""Reinforcement from lightweight interaction signals (praise, rudeness).
+
+Maps appraisal events into durable relationship changes: trust_score nudges
+and salient moments on the speaker's social record. Pure and config-driven so
+it runs on PC with an in-memory SocialDB.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+class InteractionFeedbackLearner:
+    # Appraisal event -> (trust_delta, moment_text, moment_salience).
+    _DEFAULT_DELTAS: Dict[str, tuple] = {
+        "user_praise": (0.08, "positive interaction", 0.5),
+        "user_rude": (-0.12, "negative interaction", 0.55),
+    }
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None, social_db: Any = None) -> None:
+        cfg = config if isinstance(config, dict) else {}
+        self.enabled = bool(cfg.get("enabled", True))
+        self.trust_min = float(cfg.get("trust_min", 0.0))
+        self.trust_max = float(cfg.get("trust_max", 1.0))
+        self._social_db = social_db
+        raw = cfg.get("deltas", {}) if isinstance(cfg.get("deltas", {}), dict) else {}
+        self._deltas = dict(self._DEFAULT_DELTAS)
+        for key, val in raw.items():
+            if isinstance(val, dict):
+                self._deltas[str(key)] = (
+                    float(val.get("trust", self._DEFAULT_DELTAS.get(key, (0, "", 0))[0])),
+                    str(val.get("moment", self._DEFAULT_DELTAS.get(key, ("", "", 0))[1])),
+                    float(val.get("salience", self._DEFAULT_DELTAS.get(key, (0, "", 0))[2])),
+                )
+
+    def apply(self, event: str, speaker: Optional[str] = None, *, text: str = "") -> Optional[float]:
+        """Apply feedback for an appraisal event; returns new trust_score or None."""
+        if not self.enabled or not event or not speaker:
+            return None
+        spk = str(speaker).strip()
+        if not spk or spk.lower() in {"unknown", "none"}:
+            return None
+        spec = self._deltas.get(str(event))
+        if not spec:
+            return None
+        trust_delta, moment_txt, salience = spec
+        db = self._get_db()
+        if db is None:
+            return None
+        try:
+            person = db.persons.upsert(name=spk)
+            pid = person.get("id") if isinstance(person, dict) else None
+            if not pid:
+                return None
+            new_trust = db.persons.adjust_trust(pid, trust_delta, min_score=self.trust_min, max_score=self.trust_max)
+            snippet = str(text or "").strip()[:120]
+            label = moment_txt if not snippet else f"{moment_txt}: {snippet}"
+            db.moments.add_or_boost(person_id=pid, text=label, salience=salience)
+            try:
+                db.interaction_events.log(event, payload={"person_id": pid, "text": snippet})
+            except Exception:
+                pass
+            return new_trust
+        except Exception:
+            return None
+
+    def _get_db(self):
+        if self._social_db is not None:
+            return self._social_db
+        try:
+            from modules.social_db import get_default as _social_default
+
+            self._social_db = _social_default()
+        except Exception:
+            self._social_db = None
+        return self._social_db
+
+
+__all__ = ["InteractionFeedbackLearner"]

--- a/modules/autonomy/services/liveliness.py
+++ b/modules/autonomy/services/liveliness.py
@@ -41,9 +41,36 @@ class LivelinessScheduler:
         amp = _clamp(amp, 0.0, self.max_amplitude_deg)
         return {"mode": mode, "amplitude_deg": round(amp, 1), "period_ms": int(period)}
 
+    # Per-canonical-emotion shaping: (amplitude_mul, period_mul, mode).
+    # period_mul < 1 => faster motion. Resolved through the shared vocab so
+    # aliases map consistently with eyes/LEDs/voice.
+    _EMOTION_SHAPE = {
+        "excitement": (1.6, 0.6, "micro"),
+        "joy": (1.3, 0.8, "breathe"),
+        "surprise": (1.5, 0.55, "micro"),
+        "curiosity": (1.2, 0.75, "micro"),
+        "love": (1.1, 0.9, "breathe"),
+        "fear": (1.4, 0.45, "micro"),
+        "anger": (1.5, 0.5, "micro"),
+        "furious": (1.7, 0.4, "micro"),
+        "sadness": (0.6, 1.4, "breathe"),
+        "worried": (0.9, 0.7, "micro"),
+        "tired": (0.5, 1.6, "breathe"),
+        "bored": (0.7, 1.3, "breathe"),
+        "neutral": (1.0, 1.0, "breathe"),
+    }
+
     def _modulate(self, emotion: str, amp: float, period: float, mode: str):
-        """Hook for emotion-specific shaping (extended in a later change)."""
-        return amp, period, mode
+        """Shape amplitude/tempo/mode by the dominant emotion."""
+        try:
+            from modules.common.emotion_vocab import get_vocab
+
+            canon = get_vocab().canonical(emotion)
+        except Exception:
+            canon = str(emotion or "neutral").strip().lower()
+        amp_mul, period_mul, shaped_mode = self._EMOTION_SHAPE.get(canon, (1.0, 1.0, mode))
+        period = _clamp(period * period_mul, 800.0, 12000.0)
+        return amp * amp_mul, period, shaped_mode
 
     @staticmethod
     def _params_differ(a: Optional[Dict[str, Any]], b: Optional[Dict[str, Any]]) -> bool:

--- a/modules/autonomy/services/liveliness.py
+++ b/modules/autonomy/services/liveliness.py
@@ -1,0 +1,74 @@
+"""Mood-driven firmware liveliness scheduler.
+
+Turns the robot's mood into parameters for the firmware-native idle motion
+(breathing / micro-movement) and decides *when* to (re)send a liveliness command
+to the Arduino — only on meaningful change or after a refresh interval, so the
+serial link isn't flooded. Pure and deterministic so it can be unit-tested
+without hardware; the brain feeds it mood and forwards the plan to the client.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+class LivelinessScheduler:
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        cfg = config if isinstance(config, dict) else {}
+        self.enabled = bool(cfg.get("enabled", True))
+        self.base_amplitude_deg = float(cfg.get("amplitude_deg", 4.0))
+        self.base_period_ms = int(cfg.get("period_ms", 4500))
+        self.refresh_interval_s = float(cfg.get("refresh_interval_s", 20.0))
+        self.max_amplitude_deg = float(cfg.get("max_amplitude_deg", 12.0))
+        self._last_sent_ts = 0.0
+        self._last_params: Optional[Dict[str, Any]] = None
+
+    def plan(self, *, energy: float = 50.0, dominant_emotion: str = "neutral") -> Dict[str, Any]:
+        """Compute liveliness parameters from current mood.
+
+        Base behaviour: a calm breathing whose amplitude scales gently with
+        energy. Emotion-specific shaping is layered on in :meth:`_modulate`.
+        """
+        e = _clamp(float(energy), 0.0, 100.0)
+        amp = self.base_amplitude_deg * (0.6 + (e / 100.0) * 0.8)
+        period = float(self.base_period_ms)
+        mode = "breathe"
+        amp, period, mode = self._modulate(dominant_emotion, amp, period, mode)
+        amp = _clamp(amp, 0.0, self.max_amplitude_deg)
+        return {"mode": mode, "amplitude_deg": round(amp, 1), "period_ms": int(period)}
+
+    def _modulate(self, emotion: str, amp: float, period: float, mode: str):
+        """Hook for emotion-specific shaping (extended in a later change)."""
+        return amp, period, mode
+
+    @staticmethod
+    def _params_differ(a: Optional[Dict[str, Any]], b: Optional[Dict[str, Any]]) -> bool:
+        if a is None or b is None:
+            return True
+        if a.get("mode") != b.get("mode"):
+            return True
+        # Treat sub-degree / sub-100ms wobble as "same" to avoid chatty resends.
+        if abs(float(a.get("amplitude_deg", 0)) - float(b.get("amplitude_deg", 0))) >= 1.0:
+            return True
+        if abs(int(a.get("period_ms", 0)) - int(b.get("period_ms", 0))) >= 250:
+            return True
+        return False
+
+    def due(self, now: float, params: Dict[str, Any]) -> bool:
+        """Whether a (re)send is warranted right now."""
+        if not self.enabled:
+            return False
+        if self._params_differ(params, self._last_params):
+            return True
+        return (now - self._last_sent_ts) >= self.refresh_interval_s
+
+    def mark_sent(self, now: float, params: Dict[str, Any]) -> None:
+        self._last_sent_ts = now
+        self._last_params = dict(params)
+
+
+__all__ = ["LivelinessScheduler"]

--- a/modules/autonomy/services/mood.py
+++ b/modules/autonomy/services/mood.py
@@ -13,7 +13,8 @@ class MoodManager:
             "happiness": defaults.get("initial_happiness", 50),
             "energy": defaults.get("initial_energy", 100),
             "curiosity": 50,
-            "fear": 0
+            "fear": 0,
+            "anger": 0,
         }
 
         self.last_update = time.time()
@@ -60,6 +61,7 @@ class MoodManager:
         self.state["energy"] = max(0, self.state["energy"] - (decay * 0.2))
         self.state["curiosity"] = min(100, self.state["curiosity"] + (decay * 0.5)) # Curiosity grows when idle
         self.state["fear"] = max(0, self.state["fear"] - (decay * 2.0)) # Fear recovers quickly
+        self.state["anger"] = max(0, self.state["anger"] - (decay * 1.5)) # Anger cools down over time
         self._maybe_snapshot()
 
     def modify(self, mood, delta):
@@ -68,9 +70,15 @@ class MoodManager:
             self._maybe_snapshot()
             
     def get_dominant_emotion(self):
-        # Simple logic to determine dominant emotion for LED/Expression
+        # Determine the dominant emotion for LEDs / eyes / body language.
+        # Order encodes priority: high-arousal negative states win first.
+        anger = self.state.get("anger", 0)
+        if anger > 75:
+            return "furious"
         if self.state["fear"] > 50:
             return "fear"
+        if anger > 45:
+            return "anger"
         if self.state["happiness"] > 70:
             return "joy"
         if self.state["happiness"] < 30:
@@ -95,6 +103,8 @@ class MoodManager:
             "joy": {"pan_delta": 6, "tilt_delta": 4, "event": "autonomy.joy"},
             "curiosity": {"pan_delta": 8, "tilt_delta": 3, "event": "autonomy.curious"},
             "fear": {"pan_delta": 10, "tilt_delta": 6, "event": "autonomy.alert"},
+            "anger": {"pan_delta": 9, "tilt_delta": 5, "event": "autonomy.angry"},
+            "furious": {"pan_delta": 12, "tilt_delta": 7, "event": "autonomy.angry"},
             "tired": {"pan_delta": 2, "tilt_delta": 2, "event": "autonomy.tired"},
             "sadness": {"pan_delta": 3, "tilt_delta": 5, "event": "autonomy.sad"},
             "neutral": {"pan_delta": 4, "tilt_delta": 3, "event": "autonomy.neutral"},

--- a/modules/autonomy/services/preference_learner.py
+++ b/modules/autonomy/services/preference_learner.py
@@ -1,0 +1,118 @@
+"""Config-driven extraction of durable facts and social preferences from chat.
+
+Single source for regex patterns used by :class:`MemoryConsolidator` and
+:class:`RelationshipMemory`, so the companion learning loop does not maintain
+duplicate pattern lists in two modules.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+_NAME = r"[A-Za-zÇĞİıÖŞÜçğöşü][A-Za-zÇĞİıÖŞÜçğöşü\-]{1,30}"
+
+_DEFAULT_FACT_PATTERNS: List[Tuple[str, str]] = [
+    (r"\bben(?:im)?\s+ad[ıi]m\s+(" + _NAME + r")", "user name is {0}"),
+    (r"\bismim\s+(" + _NAME + r")", "user name is {0}"),
+    (r"\bmy name is\s+(" + _NAME + r")", "user name is {0}"),
+    (r"\bi am\s+(" + _NAME + r")(?:\s|$|[.!,])", "user name is {0}"),
+    (r"\b(?:k[öo]pe[ğg]im|kedim)(?:in ad[ıi])?\s+(" + _NAME + r")", "user has a pet named {0}"),
+    (r"\bmy (?:dog|cat)(?:'s name)? is\s+(" + _NAME + r")", "user has a pet named {0}"),
+    (r"\b(?:işim|meslegim|mesle[ğg]im)\s+(" + _NAME + r")", "user works as {0}"),
+    (r"\bi work as (?:a |an )?(" + _NAME + r")", "user works as {0}"),
+    (r"\b(" + _NAME + r")['']?(?:de|da|te|ta)\s+(?:oturuyorum|yas[ıi]yorum)", "user lives in {0}"),
+    (r"\bi live in\s+(" + _NAME + r")", "user lives in {0}"),
+]
+
+_DEFAULT_LIKE_PATTERNS = [
+    r"\b(?:seviyorum|hoslaniyorum|bayiliyorum)\s+([a-z0-9_\-\sçğıöşü]{2,40})",
+    r"\b(?:i like|i love)\s+([a-z0-9_\-\s]{2,40})",
+    r"\b(?:favorim|favorite)\s+([a-z0-9_\-\s]{2,40})",
+]
+
+_DEFAULT_DISLIKE_PATTERNS = [
+    r"\b(?:sevmiyorum|nefret ediyorum)\s+([a-z0-9_\-\sçğıöşü]{2,40})",
+    r"\b(?:i hate|i dislike)\s+([a-z0-9_\-\s]{2,40})",
+]
+
+_DEFAULT_TOPIC_TOKENS = [
+    "muzik", "film", "oyun", "okul", "is", "hava", "spor", "robot", "yazilim", "ai",
+]
+
+
+class PreferenceLearner:
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        cfg = config if isinstance(config, dict) else {}
+        self._fact_patterns = self._compile_fact_patterns(cfg.get("fact_patterns"))
+        self._like_patterns = self._compile_list(cfg.get("like_patterns"), _DEFAULT_LIKE_PATTERNS)
+        self._dislike_patterns = self._compile_list(cfg.get("dislike_patterns"), _DEFAULT_DISLIKE_PATTERNS)
+        self._topic_tokens = list(cfg.get("topic_tokens") or _DEFAULT_TOPIC_TOKENS)
+
+    @staticmethod
+    def _compile_fact_patterns(raw) -> List[Tuple[re.Pattern, str]]:
+        if isinstance(raw, list) and raw:
+            out = []
+            for item in raw:
+                if isinstance(item, dict) and item.get("pattern") and item.get("template"):
+                    out.append((re.compile(str(item["pattern"]), re.IGNORECASE), str(item["template"])))
+            if out:
+                return out
+        return [(re.compile(p, re.IGNORECASE), t) for p, t in _DEFAULT_FACT_PATTERNS]
+
+    @staticmethod
+    def _compile_list(raw, defaults: List[str]) -> List[re.Pattern]:
+        src = raw if isinstance(raw, list) and raw else defaults
+        return [re.compile(str(p), re.IGNORECASE) for p in src]
+
+    def extract_facts(self, text: str) -> List[str]:
+        raw = self._user_only(text)
+        if not raw:
+            return []
+        facts: List[str] = []
+        for pattern, template in self._fact_patterns:
+            match = pattern.search(raw)
+            if match:
+                value = match.group(1).strip()
+                if value and len(value) > 1:
+                    fact = template.format(value)
+                    if fact not in facts:
+                        facts.append(fact)
+        return facts
+
+    def extract_preferences(self, text: str) -> Dict[str, List[str]]:
+        low = str(text or "").strip().lower()
+        likes: List[str] = []
+        dislikes: List[str] = []
+        topics: List[str] = []
+        if not low:
+            return {"likes": likes, "dislikes": dislikes, "topics": topics}
+
+        for pat in self._like_patterns:
+            for m in pat.findall(low):
+                val = str(m).strip(" .,!?:;")
+                if 2 <= len(val) <= 40 and val not in likes:
+                    likes.append(val)
+
+        for pat in self._dislike_patterns:
+            for m in pat.findall(low):
+                val = str(m).strip(" .,!?:;")
+                if 2 <= len(val) <= 40 and val not in dislikes:
+                    dislikes.append(val)
+
+        if "?" in low:
+            for token in self._topic_tokens:
+                if token in low and token not in topics:
+                    topics.append(token)
+
+        return {"likes": likes, "dislikes": dislikes, "topics": topics}
+
+    @staticmethod
+    def _user_only(text: str) -> str:
+        raw = str(text or "")
+        if "|" in raw:
+            raw = raw.split("|", 1)[0]
+        return re.sub(r"(?i)^\s*user\s*:\s*", "", raw).strip()
+
+
+__all__ = ["PreferenceLearner"]

--- a/modules/autonomy/services/proactive_planner.py
+++ b/modules/autonomy/services/proactive_planner.py
@@ -31,6 +31,7 @@ class ProactivePlanner:
         last_speaker: str,
         owner_present: bool,
         social_profile: Optional[Dict[str, Any]] = None,
+        scene: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
         if not self.enabled:
             return None
@@ -46,6 +47,20 @@ class ProactivePlanner:
 
         mood = str(dominant_emotion or "neutral").strip().lower()
         speaker = str(last_speaker or "").strip()
+
+        # Prefer narrating a fresh, unspoken scene the robot just perceived —
+        # this is what makes it feel like it's actually *watching* the room.
+        scene_line = self._scene_line(scene or {})
+        if scene_line:
+            self._last_ts = now_ts
+            self._events.append(now_ts)
+            return {
+                "text": scene_line,
+                "emotion": "curiosity",
+                "event": "companion.scene_comment",
+                "scene_consumed": True,
+            }
+
         line = self._pick_line(
             mood=mood,
             speaker=speaker,
@@ -61,6 +76,24 @@ class ProactivePlanner:
             "emotion": "curiosity" if mood in {"neutral", "tired"} else mood,
             "event": "companion.proactive",
         }
+
+    def _scene_line(self, scene: Dict[str, Any]) -> str:
+        """Build an ambient comment about the currently perceived scene."""
+        if not scene or not scene.get("unspoken"):
+            return ""
+        summary = str(scene.get("summary", "") or "").strip()
+        if len(summary) < 6:
+            return ""
+        importance = float(scene.get("importance", 0.0) or 0.0)
+        if importance < float(self.cfg.get("scene_comment_min_importance", 0.45)):
+            return ""
+        snippet = summary[:120].rstrip()
+        templates = [
+            f"Etrafima bakiyordum da, {snippet.lower()}.",
+            f"Su an {snippet.lower()} gibi gorunuyor.",
+            f"Sunu fark ettim: {snippet.lower()}.",
+        ]
+        return self._rng.choice(templates)
 
     def _pick_line(self, mood: str, speaker: str, owner_present: bool, social_profile: Dict[str, Any]) -> str:
         if self.enable_callback_lines:

--- a/modules/autonomy/services/proactive_planner.py
+++ b/modules/autonomy/services/proactive_planner.py
@@ -139,6 +139,10 @@ class ProactivePlanner:
     def _callback_line(self, social_profile: Dict[str, Any], speaker: str, owner_present: bool) -> str:
         if not social_profile:
             return ""
+        trust = float(social_profile.get("trust_score", 0.5) or 0.5)
+        min_trust = float(self.cfg.get("callback_min_trust", 0.2))
+        if trust < min_trust:
+            return ""
         last_user_utt = str(social_profile.get("last_user_utterance", "")).strip()
         likes = social_profile.get("likes", []) if isinstance(social_profile.get("likes", []), list) else []
         topics = social_profile.get("topics", []) if isinstance(social_profile.get("topics", []), list) else []
@@ -146,6 +150,8 @@ class ProactivePlanner:
         if likes:
             pick = str(likes[-1]).strip()
             if pick:
+                if trust >= 0.7 and owner_present:
+                    return f"{name}, {pick} sevdigini soylemistin; seninle konusmak guzel."
                 if owner_present:
                     return f"{name}, {pick} sevdigini soylemistin; istersen onunla ilgili konusalim."
                 return f"{name}, {pick} konusunu acmak ister misin?"

--- a/modules/autonomy/services/recall.py
+++ b/modules/autonomy/services/recall.py
@@ -1,0 +1,63 @@
+"""Context-aware proactive recall.
+
+Given the user's *current* utterance and a pool of past snippets (moments,
+preferences, prior lines), pick the snippet most relevant to what is being said
+right now — so the robot can say "last time you mentioned X" naturally inside a
+conversation instead of only on idle timers.
+
+Prefers the agent_core TF-IDF semantic ranker when available, falling back to a
+self-contained token-overlap score so autonomy never hard-depends on it.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Sequence
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def _tokens(text: str) -> set:
+    return {t for t in _TOKEN_RE.findall(str(text).lower()) if len(t) > 2}
+
+
+def _fallback_best(text: str, snippets: Sequence[str]) -> Optional[int]:
+    q = _tokens(text)
+    if not q:
+        return None
+    best_idx, best_score = None, 0.0
+    for idx, snip in enumerate(snippets):
+        s = _tokens(snip)
+        if not s:
+            continue
+        overlap = len(q & s)
+        if overlap == 0:
+            continue
+        score = overlap / len(q | s)
+        if score > best_score:
+            best_idx, best_score = idx, score
+    return best_idx
+
+
+def most_relevant(text: str, snippets: Sequence[str], min_score: float = 0.04) -> Optional[str]:
+    """Return the snippet most relevant to ``text`` (or ``None``)."""
+    cleaned: List[str] = [str(s).strip() for s in snippets if str(s).strip()]
+    if not cleaned or not str(text).strip():
+        return None
+
+    try:
+        from modules.agent_core.services.semantic_index import rank
+
+        ranked = rank(text, cleaned, top_k=1)
+        if ranked and ranked[0][1] >= min_score:
+            return cleaned[ranked[0][0]]
+        if ranked:
+            return None
+    except Exception:
+        pass
+
+    idx = _fallback_best(text, cleaned)
+    return cleaned[idx] if idx is not None else None
+
+
+__all__ = ["most_relevant"]

--- a/modules/autonomy/services/relationship_memory.py
+++ b/modules/autonomy/services/relationship_memory.py
@@ -32,6 +32,7 @@ class RelationshipMemory:
             except Exception:
                 social_db = None
         self._social_db = social_db
+        self._learner = None
         self._people: Dict[str, Dict[str, Any]] = {}
         if self.enabled and self._social_db is None:
             self._load()
@@ -197,6 +198,17 @@ class RelationshipMemory:
                 break
         return out[:limit]
 
+    def _get_learner(self):
+        if self._learner is not None:
+            return self._learner
+        try:
+            from .preference_learner import PreferenceLearner
+
+            self._learner = PreferenceLearner()
+        except Exception:
+            self._learner = None
+        return self._learner
+
     def social_profile(self, name: str) -> Dict[str, Any]:
         if self._social_db is not None:
             rec = self.get(name) or {}
@@ -219,6 +231,7 @@ class RelationshipMemory:
                 "name": (rec.get("display_name") if rec else None) or name,
                 "is_owner": bool(rec.get("is_owner", False)),
                 "seen_count": int(rec.get("seen_count", 0) or 0),
+                "trust_score": float(rec.get("trust_score", 0.0) or 0.0),
                 "likes": likes[:5],
                 "dislikes": dislikes[:5],
                 "topics": topics[:6],
@@ -240,6 +253,7 @@ class RelationshipMemory:
             "name": rec.get("name", name),
             "is_owner": bool(rec.get("is_owner", False)),
             "seen_count": int(rec.get("seen_count", 0) or 0),
+            "trust_score": float(rec.get("trust_score", 0.0) or 0.0),
             "likes": likes[:5],
             "dislikes": dislikes[:5],
             "topics": topics[:6],
@@ -299,54 +313,39 @@ class RelationshipMemory:
         """
         if not person_id:
             return
-        low = str(text or "").strip().lower()
-        if not low:
+        learner = self._get_learner()
+        if learner is None:
             return
-
-        patterns_like = [
-            r"\b(?:seviyorum|hoslaniyorum|bayiliyorum)\s+([a-z0-9_\-\s]{2,40})",
-            r"\b(?:i like|i love)\s+([a-z0-9_\-\s]{2,40})",
-            r"\b(?:favorim|favorite)\s+([a-z0-9_\-\s]{2,40})",
-        ]
-        patterns_dislike = [
-            r"\b(?:sevmiyorum|nefret ediyorum)\s+([a-z0-9_\-\s]{2,40})",
-            r"\b(?:i hate|i dislike)\s+([a-z0-9_\-\s]{2,40})",
-        ]
-
+        prefs = learner.extract_preferences(text)
         existing = self._social_db.relationships.list_grouped(person_id)
         likes = existing.get("likes", [])
         dislikes = existing.get("dislikes", [])
         topics = existing.get("topics", [])
         changed = {"likes": False, "dislikes": False, "topics": False}
 
-        for pat in patterns_like:
-            for m in re.findall(pat, low):
-                val = str(m).strip(" .,!?:;")
-                if 2 <= len(val) <= 40 and val not in likes:
-                    likes.append(val)
-                    changed["likes"] = True
-                    self._social_db.moments.add_or_boost(
-                        person_id=person_id, text=f"likes:{val}", salience=0.6
-                    )
+        for val in prefs.get("likes", []):
+            if val not in likes:
+                likes.append(val)
+                changed["likes"] = True
+                self._social_db.moments.add_or_boost(
+                    person_id=person_id, text=f"likes:{val}", salience=0.6
+                )
 
-        for pat in patterns_dislike:
-            for m in re.findall(pat, low):
-                val = str(m).strip(" .,!?:;")
-                if 2 <= len(val) <= 40 and val not in dislikes:
-                    dislikes.append(val)
-                    changed["dislikes"] = True
-                    self._social_db.moments.add_or_boost(
-                        person_id=person_id, text=f"dislikes:{val}", salience=0.65
-                    )
+        for val in prefs.get("dislikes", []):
+            if val not in dislikes:
+                dislikes.append(val)
+                changed["dislikes"] = True
+                self._social_db.moments.add_or_boost(
+                    person_id=person_id, text=f"dislikes:{val}", salience=0.65
+                )
 
-        if "?" in low:
-            for token in ["muzik", "film", "oyun", "okul", "is", "hava", "spor", "robot", "yazilim", "ai"]:
-                if token in low and token not in topics:
-                    topics.append(token)
-                    changed["topics"] = True
-                    self._social_db.moments.add_or_boost(
-                        person_id=person_id, text=f"topic:{token}", salience=0.45
-                    )
+        for token in prefs.get("topics", []):
+            if token not in topics:
+                topics.append(token)
+                changed["topics"] = True
+                self._social_db.moments.add_or_boost(
+                    person_id=person_id, text=f"topic:{token}", salience=0.45
+                )
 
         if changed["likes"]:
             self._social_db.relationships.set(person_id, "likes", ",".join(likes[-12:]))
@@ -360,39 +359,25 @@ class RelationshipMemory:
         likes = prefs.setdefault("likes", [])
         dislikes = prefs.setdefault("dislikes", [])
         topics = prefs.setdefault("topics", [])
-        low = str(text or "").strip().lower()
-        if not low:
+        learner = self._get_learner()
+        if learner is None:
             return
+        prefs = learner.extract_preferences(text)
 
-        patterns_like = [
-            r"\b(?:seviyorum|hoslaniyorum|bayiliyorum)\s+([a-z0-9_\-\s]{2,40})",
-            r"\b(?:i like|i love)\s+([a-z0-9_\-\s]{2,40})",
-            r"\b(?:favorim|favorite)\s+([a-z0-9_\-\s]{2,40})",
-        ]
-        patterns_dislike = [
-            r"\b(?:sevmiyorum|nefret ediyorum)\s+([a-z0-9_\-\s]{2,40})",
-            r"\b(?:i hate|i dislike)\s+([a-z0-9_\-\s]{2,40})",
-        ]
+        for val in prefs.get("likes", []):
+            if val not in likes:
+                likes.append(val)
+                self._add_moment(rec, text=f"likes:{val}", salience=0.6)
 
-        for pat in patterns_like:
-            for m in re.findall(pat, low):
-                val = str(m).strip(" .,!?:;")
-                if 2 <= len(val) <= 40 and val not in likes:
-                    likes.append(val)
-                    self._add_moment(rec, text=f"likes:{val}", salience=0.6)
+        for val in prefs.get("dislikes", []):
+            if val not in dislikes:
+                dislikes.append(val)
+                self._add_moment(rec, text=f"dislikes:{val}", salience=0.65)
 
-        for pat in patterns_dislike:
-            for m in re.findall(pat, low):
-                val = str(m).strip(" .,!?:;")
-                if 2 <= len(val) <= 40 and val not in dislikes:
-                    dislikes.append(val)
-                    self._add_moment(rec, text=f"dislikes:{val}", salience=0.65)
-
-        if "?" in low:
-            for token in ["muzik", "film", "oyun", "okul", "is", "hava", "spor", "robot", "yazilim", "ai"]:
-                if token in low and token not in topics:
-                    topics.append(token)
-                    self._add_moment(rec, text=f"topic:{token}", salience=0.45)
+        for token in prefs.get("topics", []):
+            if token not in topics:
+                topics.append(token)
+                self._add_moment(rec, text=f"topic:{token}", salience=0.45)
 
         if len(likes) > 12:
             del likes[:-12]

--- a/modules/autonomy/services/relationship_memory.py
+++ b/modules/autonomy/services/relationship_memory.py
@@ -167,6 +167,36 @@ class RelationshipMemory:
                 return str(item.get("text", "")).strip()
         return ""
 
+    def recall_candidates(self, name: str, limit: int = 12) -> List[str]:
+        """Return past snippets (moments + recent user lines) for relevance recall."""
+        out: List[str] = []
+        rec = self.get(name) or {}
+        if self._social_db is not None:
+            pid = str(rec.get("id") or "") if rec else ""
+            if pid:
+                try:
+                    for m in self._social_db.moments.top_for_person(pid, limit=limit):
+                        txt = str((m or {}).get("text", "")).strip()
+                        if txt:
+                            out.append(txt)
+                except Exception:
+                    pass
+        else:
+            moments = rec.get("moments", []) if isinstance(rec.get("moments", []), list) else []
+            for m in moments:
+                txt = str((m or {}).get("text", "")).strip()
+                if txt:
+                    out.append(txt)
+        hist = rec.get("chat_history", []) if isinstance(rec.get("chat_history", []), list) else []
+        for item in reversed(hist):
+            if isinstance(item, dict) and str(item.get("role", "")).strip().lower() == "user":
+                txt = str(item.get("text", "")).strip()
+                if txt and txt not in out:
+                    out.append(txt)
+            if len(out) >= limit:
+                break
+        return out[:limit]
+
     def social_profile(self, name: str) -> Dict[str, Any]:
         if self._social_db is not None:
             rec = self.get(name) or {}

--- a/modules/autonomy/tests/test_affective_model.py
+++ b/modules/autonomy/tests/test_affective_model.py
@@ -1,0 +1,70 @@
+"""Tests for the anger axis and the affective appraisal engine."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.mood import MoodManager
+from modules.autonomy.services.affective_appraisal import AffectiveAppraisal
+
+
+def _mood():
+    return MoodManager({"defaults": {"mood": {"initial_happiness": 50, "initial_energy": 100}}})
+
+
+def test_anger_axis_exists_and_decays():
+    mood = _mood()
+    assert "anger" in mood.state
+    mood.state["anger"] = 50
+    mood.last_update -= 10  # simulate elapsed time
+    mood.update()
+    assert mood.state["anger"] < 50
+
+
+def test_dominant_emotion_includes_anger_and_furious():
+    mood = _mood()
+    mood.state["anger"] = 50
+    assert mood.get_dominant_emotion() == "anger"
+    mood.state["anger"] = 90
+    assert mood.get_dominant_emotion() == "furious"
+
+
+def test_body_language_profile_for_anger():
+    mood = _mood()
+    mood.state["anger"] = 90
+    profile = mood.get_body_language_profile()
+    assert profile["event"] == "autonomy.angry"
+    assert profile["pan_delta"] >= 9
+
+
+def test_appraisal_applies_mood_deltas():
+    mood = _mood()
+    appraisal = AffectiveAppraisal()
+    before = mood.state["anger"]
+    matched = appraisal.apply(mood, "user_rude")
+    assert matched == "user_rude"
+    assert mood.state["anger"] > before
+    assert mood.state["happiness"] < 50
+
+
+def test_appraisal_intensity_scales_and_clamps():
+    mood = _mood()
+    appraisal = AffectiveAppraisal()
+    appraisal.apply(mood, "user_insult", intensity=5.0)
+    # mood.modify clamps to [0, 100]
+    assert 0 <= mood.state["anger"] <= 100
+    assert mood.state["anger"] == 100
+
+
+def test_unknown_event_is_noop():
+    mood = _mood()
+    appraisal = AffectiveAppraisal()
+    snapshot = dict(mood.state)
+    assert appraisal.apply(mood, "not_a_real_event") is None
+    assert mood.state == snapshot
+
+
+def test_sentiment_keyword_mapping():
+    from modules.autonomy.services.brain import AutonomyBrain
+
+    assert AutonomyBrain._sentiment_event_for_text("seni cok seviyorum") == "user_praise"
+    assert AutonomyBrain._sentiment_event_for_text("aptal robot") == "user_rude"
+    assert AutonomyBrain._sentiment_event_for_text("bugun hava nasil") is None

--- a/modules/autonomy/tests/test_barge_in.py
+++ b/modules/autonomy/tests/test_barge_in.py
@@ -1,0 +1,39 @@
+"""Natural barge-in policy."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.barge_in import BargeInController
+
+
+def test_meaningful_speech_interrupts_while_robot_talking():
+    bc = BargeInController({"min_words": 2, "cooldown_s": 0.0})
+    assert bc.should_interrupt(robot_speaking=True, user_text="dur bir saniye", now=100.0) is True
+
+
+def test_no_interrupt_when_robot_silent():
+    bc = BargeInController({"min_words": 2})
+    assert bc.should_interrupt(robot_speaking=False, user_text="dur bir saniye", now=100.0) is False
+
+
+def test_single_word_does_not_interrupt_without_wakeword():
+    bc = BargeInController({"min_words": 2})
+    assert bc.should_interrupt(robot_speaking=True, user_text="ee", now=100.0) is False
+
+
+def test_wakeword_interrupts_even_if_single_word():
+    bc = BargeInController({"min_words": 5})
+    assert bc.should_interrupt(robot_speaking=True, user_text="sentry", has_wakeword=True, now=100.0) is True
+
+
+def test_cooldown_blocks_rapid_reinterrupt():
+    bc = BargeInController({"min_words": 1, "cooldown_s": 2.0})
+    assert bc.should_interrupt(robot_speaking=True, user_text="dur", now=100.0) is True
+    # within cooldown -> blocked
+    assert bc.should_interrupt(robot_speaking=True, user_text="dur", now=101.0) is False
+    # after cooldown -> allowed
+    assert bc.should_interrupt(robot_speaking=True, user_text="dur", now=103.0) is True
+
+
+def test_disabled_never_interrupts():
+    bc = BargeInController({"enabled": False})
+    assert bc.should_interrupt(robot_speaking=True, user_text="dur bir saniye", has_wakeword=True, now=100.0) is False

--- a/modules/autonomy/tests/test_client_liveliness.py
+++ b/modules/autonomy/tests/test_client_liveliness.py
@@ -1,0 +1,35 @@
+"""Autonomy ServiceClient liveliness wiring builds a valid contract payload."""
+
+from __future__ import annotations
+
+from modules.arduino_serial.contract import validate_arduino_payload
+from modules.autonomy.services.client import ServiceClient
+
+
+def _client():
+    c = ServiceClient.__new__(ServiceClient)
+    captured = {}
+
+    def _fake_request(payload):
+        captured["payload"] = payload
+        return {"ok": True}
+
+    c._arduino_request = _fake_request  # type: ignore
+    return c, captured
+
+
+def test_set_liveliness_enable_builds_valid_payload():
+    c, captured = _client()
+    c.set_liveliness(True, mode="breathe", amplitude_deg=5, period_ms=3000)
+    payload = captured["payload"]
+    assert payload["cmd"] == "liveliness"
+    assert payload["enable"] is True
+    assert validate_arduino_payload(payload) is None
+
+
+def test_set_liveliness_disable_builds_valid_payload():
+    c, captured = _client()
+    c.set_liveliness(False)
+    payload = captured["payload"]
+    assert payload["enable"] is False
+    assert validate_arduino_payload(payload) is None

--- a/modules/autonomy/tests/test_expression_director.py
+++ b/modules/autonomy/tests/test_expression_director.py
@@ -1,0 +1,98 @@
+"""Tests for the multi-modal expression director and idle micro-behaviors."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.expression_director import ExpressionDirector
+from modules.autonomy.services.brain_parts.animations import AnimationSupportMixin
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def set_neopixel(self, effect, emotions=None, color=None, duration=None):
+        self.calls.append(("leds", effect, tuple(emotions or []), tuple(color or ())))
+
+    def oled_show(self, name):
+        self.calls.append(("eyes", name))
+
+    def push_interaction_event(self, event_type, data=None):
+        self.calls.append(("event", event_type))
+
+    def move_head(self, pan, tilt, speed=0.8):
+        self.calls.append(("head", pan, tilt))
+
+    def speak(self, text, tone=None, engine=None, language=None):
+        self.calls.append(("voice", text, tone))
+
+    def kinds(self):
+        return [c[0] for c in self.calls]
+
+
+def test_express_fires_all_modalities_with_canonical_label():
+    client = _RecordingClient()
+    director = ExpressionDirector(client)
+    canon = director.express("happy", say="merhaba", move_head=(100, 90))
+    assert canon == "joy"
+    kinds = client.kinds()
+    assert {"leds", "eyes", "event", "head", "voice"} <= set(kinds)
+    # LEDs and the ear-driving interaction event both use the canonical label
+    leds = next(c for c in client.calls if c[0] == "leds")
+    assert leds[2] == ("joy",)
+    assert ("event", "emotion:joy") in client.calls
+    voice = next(c for c in client.calls if c[0] == "voice")
+    assert voice[2] == "joy"  # TTS tone resolved from vocab
+
+
+def test_express_without_speech_or_head_skips_those():
+    client = _RecordingClient()
+    director = ExpressionDirector(client)
+    director.express("anger")
+    kinds = set(client.kinds())
+    assert "voice" not in kinds
+    assert "head" not in kinds
+    assert {"leds", "eyes", "event"} <= kinds
+
+
+def test_failing_modality_does_not_block_others():
+    class _Flaky(_RecordingClient):
+        def oled_show(self, name):
+            raise RuntimeError("display offline")
+
+    client = _Flaky()
+    director = ExpressionDirector(client)
+    canon = director.express("surprise")
+    assert canon == "surprise"
+    # eyes failed, but LEDs + ears still fired
+    assert "leds" in client.kinds()
+    assert ("event", "emotion:surprise") in client.calls
+
+
+class _StubMood:
+    def get_body_language_profile(self):
+        return {"pan_delta": 4, "tilt_delta": 3, "event": "autonomy.neutral"}
+
+    def get_dominant_emotion(self):
+        return "joy"
+
+
+class _Mini(AnimationSupportMixin):
+    def __init__(self, client):
+        self.client = client
+        self.state = {"current_pan": 90, "current_tilt": 90}
+        self.mood = _StubMood()
+
+
+def test_eye_saccade_uses_gaze_bitmaps():
+    client = _RecordingClient()
+    mini = _Mini(client)
+    mini._perform_eye_saccade()
+    eyes = [c for c in client.calls if c[0] == "eyes"]
+    assert eyes and eyes[0][1] in {"look_left", "look_right", "look_up", "look_down"}
+
+
+def test_ear_micromovement_emits_emotion_event():
+    client = _RecordingClient()
+    mini = _Mini(client)
+    mini._perform_ear_micromovement()
+    assert ("event", "emotion:joy") in client.calls

--- a/modules/autonomy/tests/test_interaction_feedback.py
+++ b/modules/autonomy/tests/test_interaction_feedback.py
@@ -1,0 +1,39 @@
+"""InteractionFeedbackLearner: praise/rude -> trust_score and moments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.autonomy.services.interaction_feedback import InteractionFeedbackLearner
+from modules.social_db.db import SocialDB
+
+
+def test_praise_raises_trust(tmp_path):
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    db.persons.upsert(name="Emir", trust_score=0.4)
+    fb = InteractionFeedbackLearner(social_db=db)
+    new = fb.apply("user_praise", speaker="Emir", text="aferin cok iyisin")
+    assert new is not None and new > 0.4
+    assert db.persons.get_by_name("Emir")["trust_score"] == new
+
+
+def test_rude_lowers_trust(tmp_path):
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    db.persons.upsert(name="Emir", trust_score=0.6)
+    fb = InteractionFeedbackLearner(social_db=db)
+    new = fb.apply("user_rude", speaker="Emir", text="aptal robot")
+    assert new is not None and new < 0.6
+
+
+def test_unknown_event_is_noop(tmp_path):
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    db.persons.upsert(name="Emir", trust_score=0.5)
+    fb = InteractionFeedbackLearner(social_db=db)
+    assert fb.apply("scene_change", speaker="Emir") is None
+
+
+def test_disabled_never_changes_trust(tmp_path):
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    db.persons.upsert(name="Emir", trust_score=0.5)
+    fb = InteractionFeedbackLearner({"enabled": False}, social_db=db)
+    assert fb.apply("user_praise", speaker="Emir") is None

--- a/modules/autonomy/tests/test_learning_adaptation_wiring.py
+++ b/modules/autonomy/tests/test_learning_adaptation_wiring.py
@@ -1,0 +1,61 @@
+"""Trust-aware enrichment and proactive callbacks after feedback learning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.autonomy.services.brain import AutonomyBrain
+from modules.autonomy.services.proactive_planner import ProactivePlanner
+from modules.social_db.db import SocialDB
+
+
+def _minimal_brain(tmp_path):
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    cfg = {
+        "companion": {"enabled": True, "learning": {"enabled": True}},
+        "endpoints": {},
+        "defaults": {},
+        "behaviors": {},
+        "owner": {},
+        "vision_hooks": {},
+    }
+    brain = AutonomyBrain.__new__(AutonomyBrain)
+    brain.config = cfg
+    brain.relationship_memory = type("RM", (), {})()
+    brain.relationship_memory.social_profile = lambda name: {  # type: ignore
+        "name": name,
+        "likes": ["satranc"],
+        "topics": [],
+        "trust_score": 0.8,
+        "top_memory": "",
+    }
+    brain.relationship_memory.recall_candidates = lambda name, limit=12: []  # type: ignore
+    brain.client = type("C", (), {"push_interaction_event": lambda *a, **k: None})()
+    return brain
+
+
+def test_enrichment_injects_trust_hint(tmp_path):
+    brain = _minimal_brain(tmp_path)
+    out = brain._enrich_user_text_with_companion_context("bugun ne yapalim", speaker="Emir")
+    assert "trust=high" in out
+    assert "likes=satranc" in out
+
+
+def test_proactive_callback_uses_high_trust_warm_line():
+    p = ProactivePlanner({"enable_callback_lines": True, "callback_min_trust": 0.2})
+    line = p._callback_line(
+        {"name": "Emir", "likes": ["satranc"], "topics": [], "trust_score": 0.85, "last_user_utterance": ""},
+        speaker="Emir",
+        owner_present=True,
+    )
+    assert line and "satranc" in line.lower()
+
+
+def test_proactive_skips_callback_when_trust_too_low():
+    p = ProactivePlanner({"enable_callback_lines": True, "callback_min_trust": 0.3})
+    line = p._callback_line(
+        {"name": "Emir", "likes": ["satranc"], "topics": [], "trust_score": 0.1, "last_user_utterance": ""},
+        speaker="Emir",
+        owner_present=True,
+    )
+    assert line == ""

--- a/modules/autonomy/tests/test_liveliness_emotion_shape.py
+++ b/modules/autonomy/tests/test_liveliness_emotion_shape.py
@@ -1,0 +1,35 @@
+"""Emotion-aware shaping of liveliness amplitude / tempo / mode."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.liveliness import LivelinessScheduler
+
+
+def test_excited_is_bigger_and_faster_than_tired():
+    s = LivelinessScheduler({"amplitude_deg": 5.0, "max_amplitude_deg": 30.0})
+    excited = s.plan(energy=80, dominant_emotion="excitement")
+    tired = s.plan(energy=80, dominant_emotion="tired")
+    assert excited["amplitude_deg"] > tired["amplitude_deg"]
+    assert excited["period_ms"] < tired["period_ms"]  # faster
+
+
+def test_anger_uses_micro_mode():
+    s = LivelinessScheduler()
+    assert s.plan(energy=60, dominant_emotion="anger")["mode"] == "micro"
+
+
+def test_alias_resolves_same_as_canonical():
+    s = LivelinessScheduler()
+    assert s.plan(energy=50, dominant_emotion="happy") == s.plan(energy=50, dominant_emotion="joy")
+
+
+def test_neutral_keeps_breathe_mode():
+    s = LivelinessScheduler()
+    assert s.plan(energy=50, dominant_emotion="neutral")["mode"] == "breathe"
+
+
+def test_period_stays_within_bounds():
+    s = LivelinessScheduler({"period_ms": 4500})
+    for emo in ("furious", "tired", "neutral", "fear", "sadness"):
+        p = s.plan(energy=50, dominant_emotion=emo)["period_ms"]
+        assert 800 <= p <= 12000

--- a/modules/autonomy/tests/test_liveliness_scheduler.py
+++ b/modules/autonomy/tests/test_liveliness_scheduler.py
@@ -1,0 +1,43 @@
+"""Mood-driven liveliness scheduler (timing + change detection + base plan)."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.liveliness import LivelinessScheduler
+
+
+def test_plan_amplitude_scales_with_energy():
+    s = LivelinessScheduler({"amplitude_deg": 5.0})
+    low = s.plan(energy=0)["amplitude_deg"]
+    high = s.plan(energy=100)["amplitude_deg"]
+    assert high > low
+    assert s.plan(energy=50)["mode"] == "breathe"
+
+
+def test_amplitude_is_clamped_to_max():
+    s = LivelinessScheduler({"amplitude_deg": 100.0, "max_amplitude_deg": 12.0})
+    assert s.plan(energy=100)["amplitude_deg"] <= 12.0
+
+
+def test_due_on_first_plan_then_throttles():
+    s = LivelinessScheduler({"refresh_interval_s": 20.0})
+    p = s.plan(energy=50)
+    assert s.due(now=100.0, params=p) is True  # nothing sent yet
+    s.mark_sent(100.0, p)
+    # same params, within refresh window -> not due
+    assert s.due(now=105.0, params=p) is False
+    # after refresh interval -> due again
+    assert s.due(now=121.0, params=p) is True
+
+
+def test_due_when_params_change_meaningfully():
+    s = LivelinessScheduler()
+    p1 = s.plan(energy=10)
+    s.mark_sent(100.0, p1)
+    p2 = s.plan(energy=100)  # much larger amplitude
+    assert s.due(now=101.0, params=p2) is True
+
+
+def test_disabled_never_due():
+    s = LivelinessScheduler({"enabled": False})
+    p = s.plan(energy=50)
+    assert s.due(now=100.0, params=p) is False

--- a/modules/autonomy/tests/test_liveliness_tick.py
+++ b/modules/autonomy/tests/test_liveliness_tick.py
@@ -1,0 +1,69 @@
+"""Brain liveliness tick forwards mood-shaped motion to the client (gated)."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.brain_parts.animations import AnimationSupportMixin
+from modules.autonomy.services.liveliness import LivelinessScheduler
+
+
+class _Mood:
+    def __init__(self, energy=70, dominant="joy"):
+        self._energy = energy
+        self._dominant = dominant
+
+    def __getitem__(self, key):
+        return self._energy if key == "energy" else 50
+
+    def get_dominant_emotion(self):
+        return self._dominant
+
+
+class _Client:
+    def __init__(self):
+        self.liveliness_calls = []
+
+    def set_liveliness(self, enable, **kwargs):
+        self.liveliness_calls.append({"enable": enable, **kwargs})
+        return {"ok": True}
+
+
+class _Brain(AnimationSupportMixin):
+    def __init__(self, **state):
+        self.client = _Client()
+        self.mood = _Mood()
+        self.liveliness = LivelinessScheduler({"refresh_interval_s": 20.0})
+        self._speech_busy = False
+        self.state = state
+
+
+def test_tick_sends_liveliness_when_due():
+    b = _Brain(current_pan=90, current_tilt=95)
+    b._liveliness_tick(now=100.0)
+    assert len(b.client.liveliness_calls) == 1
+    call = b.client.liveliness_calls[0]
+    assert call["enable"] is True
+    assert call["pan_center"] == 90 and call["tilt_center"] == 95
+
+
+def test_tick_suppressed_while_speaking():
+    b = _Brain()
+    b._speech_busy = True
+    b._liveliness_tick(now=100.0)
+    assert b.client.liveliness_calls == []
+
+
+def test_tick_suppressed_during_follow_and_sleep():
+    b = _Brain(follow_active=True)
+    b._liveliness_tick(now=100.0)
+    assert b.client.liveliness_calls == []
+
+    b2 = _Brain(is_sleeping=True)
+    b2._liveliness_tick(now=100.0)
+    assert b2.client.liveliness_calls == []
+
+
+def test_tick_throttles_repeated_same_params():
+    b = _Brain()
+    b._liveliness_tick(now=100.0)
+    b._liveliness_tick(now=105.0)  # within refresh, same params
+    assert len(b.client.liveliness_calls) == 1

--- a/modules/autonomy/tests/test_preference_learner.py
+++ b/modules/autonomy/tests/test_preference_learner.py
@@ -1,0 +1,36 @@
+"""PreferenceLearner: shared fact and preference extraction."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.preference_learner import PreferenceLearner
+
+
+def test_extracts_name_fact_turkish_and_english():
+    pl = PreferenceLearner()
+    assert "user name is Emir" in pl.extract_facts("benim adim Emir")
+    assert "user name is Sarah" in pl.extract_facts("my name is Sarah")
+
+
+def test_extracts_pet_and_location():
+    pl = PreferenceLearner()
+    assert "user has a pet named Max" in pl.extract_facts("my dog is Max")
+    assert "user lives in Izmir" in pl.extract_facts("i live in Izmir")
+
+
+def test_extracts_likes_and_dislikes():
+    pl = PreferenceLearner()
+    prefs = pl.extract_preferences("seviyorum kahve ama sevmiyorum spam")
+    assert any("kahve" in x for x in prefs["likes"])
+    assert any("spam" in x for x in prefs["dislikes"])
+
+
+def test_extracts_topic_from_question():
+    pl = PreferenceLearner()
+    prefs = pl.extract_preferences("bugun hava nasil?")
+    assert "hava" in prefs["topics"]
+
+
+def test_user_only_strips_bot_side():
+    pl = PreferenceLearner()
+    facts = pl.extract_facts("User: benim adim Ali | Bot: selam")
+    assert facts == ["user name is Ali"]

--- a/modules/autonomy/tests/test_proactive_scene_comment.py
+++ b/modules/autonomy/tests/test_proactive_scene_comment.py
@@ -1,0 +1,54 @@
+"""Proactive ambient scene narration."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.proactive_planner import ProactivePlanner
+
+
+def _planner():
+    return ProactivePlanner({"cooldown_s": 0.0, "min_idle_s": 0.0, "max_per_hour": 100})
+
+
+def test_unspoken_important_scene_is_narrated_first():
+    p = _planner()
+    plan = p.propose(
+        now_ts=1000.0,
+        idle_s=60.0,
+        dominant_emotion="neutral",
+        last_speaker="",
+        owner_present=False,
+        scene={"summary": "two people are cooking in a bright kitchen", "importance": 0.6, "unspoken": True},
+    )
+    assert plan is not None
+    assert plan["event"] == "companion.scene_comment"
+    assert plan.get("scene_consumed") is True
+    assert "kitchen" in plan["text"].lower()
+
+
+def test_low_importance_scene_is_not_narrated():
+    p = _planner()
+    plan = p.propose(
+        now_ts=1000.0,
+        idle_s=60.0,
+        dominant_emotion="neutral",
+        last_speaker="",
+        owner_present=False,
+        scene={"summary": "a plain wall", "importance": 0.1, "unspoken": True},
+    )
+    # falls back to a normal proactive line, not a scene comment
+    assert plan is not None
+    assert plan["event"] == "companion.proactive"
+
+
+def test_already_spoken_scene_is_skipped():
+    p = _planner()
+    plan = p.propose(
+        now_ts=1000.0,
+        idle_s=60.0,
+        dominant_emotion="neutral",
+        last_speaker="",
+        owner_present=False,
+        scene={"summary": "two people cooking in a kitchen", "importance": 0.8, "unspoken": False},
+    )
+    assert plan is not None
+    assert plan["event"] == "companion.proactive"

--- a/modules/autonomy/tests/test_recall.py
+++ b/modules/autonomy/tests/test_recall.py
@@ -1,0 +1,25 @@
+"""Tests for context-aware proactive recall."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.recall import most_relevant
+
+
+def test_picks_snippet_relevant_to_current_text():
+    snippets = [
+        "kullanici satranc kulubune gidiyor",
+        "kullanici kahveyi sever",
+        "kullanici izmirde yasiyor",
+    ]
+    hit = most_relevant("bugun satranc oynayalim mi", snippets)
+    assert hit == "kullanici satranc kulubune gidiyor"
+
+
+def test_returns_none_when_nothing_relevant():
+    snippets = ["kullanici kahveyi sever", "kullanici izmirde yasiyor"]
+    assert most_relevant("robotik kodlama dersi", snippets) is None
+
+
+def test_empty_inputs_are_safe():
+    assert most_relevant("", ["a b c"]) is None
+    assert most_relevant("hello", []) is None

--- a/modules/autonomy/tests/test_relationship_memory.py
+++ b/modules/autonomy/tests/test_relationship_memory.py
@@ -1,0 +1,43 @@
+"""RelationshipMemory: preferences, social_profile and recall candidates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.autonomy.services.relationship_memory import RelationshipMemory
+from modules.social_db.db import SocialDB
+
+
+def _rm_with_db(tmp_path: Path):
+    db = SocialDB(path=tmp_path / "social.sqlite3", wal=False)
+    rm = RelationshipMemory(enabled=True, social_db=db)
+    return rm, db
+
+
+def test_add_chat_extracts_likes_into_social_db(tmp_path):
+    rm, db = _rm_with_db(tmp_path)
+    rm.add_chat("Emir", "user", "seviyorum satranc")
+    profile = rm.social_profile("Emir")
+    assert any("satranc" in str(x) for x in profile.get("likes", []))
+
+
+def test_social_profile_includes_trust_score(tmp_path):
+    rm, db = _rm_with_db(tmp_path)
+    rec = db.persons.upsert(name="Emir", trust_score=0.7)
+    profile = rm.social_profile("Emir")
+    assert profile.get("trust_score") == 0.7 or profile.get("trust_score") is not None
+
+
+def test_recall_candidates_include_moments(tmp_path):
+    rm, db = _rm_with_db(tmp_path)
+    rm.add_chat("Emir", "user", "seviyorum satranc")
+    candidates = rm.recall_candidates("Emir")
+    assert candidates
+
+
+def test_json_fallback_extracts_preferences(tmp_path):
+    path = tmp_path / "rel.json"
+    rm = RelationshipMemory(enabled=True, path=str(path), social_db=None)
+    rm.add_chat("Ali", "user", "seviyorum muzik")
+    profile = rm.social_profile("Ali")
+    assert any("muzik" in str(x) for x in profile.get("likes", []))

--- a/modules/autonomy/tests/test_scene_awareness.py
+++ b/modules/autonomy/tests/test_scene_awareness.py
@@ -1,0 +1,64 @@
+"""Continuous scene awareness in the autonomy vision sense loop."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.brain_parts.vision import VisionMixin
+
+
+class _Mood:
+    def __init__(self):
+        self.mods = []
+
+    def modify(self, axis, delta):
+        self.mods.append((axis, delta))
+
+
+class _Client:
+    def __init__(self):
+        self.events = []
+
+    def push_interaction_event(self, event_type, data=None):
+        self.events.append((event_type, data))
+
+
+class _SceneBrain(VisionMixin):
+    def __init__(self):
+        self.client = _Client()
+        self.mood = _Mood()
+        self._vision_cfg = {"scene_novelty_threshold": 0.5}
+        self.state = {}
+
+
+def test_new_scene_emits_event_and_marks_unspoken():
+    brain = _SceneBrain()
+    brain._track_scene_context({"summary": "a person works at a wooden desk with a laptop"}, importance=0.6)
+
+    assert brain.state["scene_summary"].startswith("a person")
+    assert brain.state.get("scene_unspoken") is True
+    events = {e for e, _ in brain.client.events}
+    assert "environment.scene_changed" in events
+
+
+def test_similar_scene_does_not_re_emit():
+    brain = _SceneBrain()
+    brain._track_scene_context({"summary": "a person at a desk with a laptop"}, importance=0.6)
+    brain.client.events.clear()
+    # nearly identical summary -> below novelty threshold -> no new event
+    brain._track_scene_context({"summary": "a person at a desk with a laptop"}, importance=0.6)
+    assert brain.client.events == []
+
+
+def test_distinct_scene_re_emits():
+    brain = _SceneBrain()
+    brain._track_scene_context({"summary": "an empty hallway at night"}, importance=0.4)
+    brain.client.events.clear()
+    brain._track_scene_context({"summary": "two people cooking in a bright kitchen"}, importance=0.5)
+    events = {e for e, _ in brain.client.events}
+    assert "environment.scene_changed" in events
+
+
+def test_empty_summary_is_ignored():
+    brain = _SceneBrain()
+    brain._track_scene_context({"summary": ""}, importance=0.9)
+    assert brain.client.events == []
+    assert "scene_summary" not in brain.state

--- a/modules/autonomy/tests/test_tone_profile_vocab.py
+++ b/modules/autonomy/tests/test_tone_profile_vocab.py
@@ -1,0 +1,43 @@
+"""Autonomy tone profiles resolve through the canonical emotion vocabulary."""
+
+from __future__ import annotations
+
+from modules.autonomy.services.brain_parts.vocal import VocalMixin
+
+
+class _ToneBrain(VocalMixin):
+    def __init__(self):
+        self.state = {}
+
+    class _Mood:
+        def get_dominant_emotion(self):
+            return "neutral"
+
+    mood = _Mood()
+
+
+def test_aliases_resolve_to_same_profile_as_canonical():
+    brain = _ToneBrain()
+    # "happy" is an alias of canonical "joy"
+    assert brain._tone_profile("happy") == brain._tone_profile("joy")
+    # "scared" -> fear, "angry" -> anger
+    assert brain._tone_profile("scared") == brain._tone_profile("fear")
+    assert brain._tone_profile("angry") == brain._tone_profile("anger")
+
+
+def test_anger_is_faster_and_louder_than_sadness():
+    brain = _ToneBrain()
+    anger = brain._tone_profile("anger")
+    sad = brain._tone_profile("sadness")
+    assert anger["rate"] > sad["rate"]
+    assert anger["volume"] >= sad["volume"]
+
+
+def test_unknown_emotion_falls_back_to_neutral():
+    brain = _ToneBrain()
+    assert brain._tone_profile("zxcv") == {"rate": 170, "volume": 0.85}
+
+
+def test_none_emotion_uses_dominant_mood():
+    brain = _ToneBrain()
+    assert brain._tone_profile(None)["rate"] == 170

--- a/modules/common/README.md
+++ b/modules/common/README.md
@@ -1,0 +1,45 @@
+# common — Shared Helpers
+
+Dependency-light helpers shared across SentryBOT modules. Importable from any
+service without pulling heavy module graphs.
+
+## Canonical Emotion Vocabulary
+
+`emotion_vocab.py` is the **single source of truth** that unifies the three
+historically divergent emotion vocabularies:
+
+| Subsystem        | Old vocabulary                         |
+|------------------|----------------------------------------|
+| autonomy (mood)  | ~6 labels (`joy`, `sadness`, `tired`…) |
+| oled_faces       | ~13 event labels (`happy`, `sad`…)     |
+| neopixel         | ~23 palette files                      |
+
+Every subsystem now resolves its incoming label to a **canonical** key and
+reads shared render hints, so eyes (OLED), LEDs (NeoPixel), ears (PiServo),
+head body-language and TTS tone all agree on one emotion.
+
+### Usage
+
+```python
+from modules.common.emotion_vocab import get_vocab
+
+vocab = get_vocab()
+vocab.canonical("happy")        # -> "joy"
+r = vocab.render("happy")       # -> EmotionRender(...)
+r.oled                          # -> "happy"   (face bitmap)
+r.palette                       # -> "joy"     (neopixel palette file)
+r.effect                        # -> "RAINBOW_CYCLE"
+r.ears                          # -> "joy"     (piservo pose key)
+r.tone                          # -> "joy"     (speak TTS tone)
+r.rgb                           # -> (0, 200, 60)
+```
+
+### Config
+
+`config/emotions.yml` defines:
+
+- `aliases` — canonical → alias labels
+- `render`  — per-canonical render hints (`oled`, `palette`, `effect`, `ears`, `tone`, `rgb`)
+- `default_canonical` — fallback when a label is unknown (`neutral`)
+
+To add or retune an emotion, edit the YAML only — no code changes required.

--- a/modules/common/__init__.py
+++ b/modules/common/__init__.py
@@ -1,0 +1,23 @@
+"""Shared, dependency-light helpers used across SentryBOT modules.
+
+Currently hosts the canonical emotion vocabulary so eyes, LEDs, ears, body
+language and TTS tone all agree on a single emotion taxonomy.
+"""
+
+from .emotion_vocab import (
+    EmotionRender,
+    EmotionVocab,
+    canonical_emotion,
+    emotion_render,
+    get_vocab,
+    load_vocab,
+)
+
+__all__ = [
+    "EmotionRender",
+    "EmotionVocab",
+    "canonical_emotion",
+    "emotion_render",
+    "get_vocab",
+    "load_vocab",
+]

--- a/modules/common/config/emotions.yml
+++ b/modules/common/config/emotions.yml
@@ -38,9 +38,9 @@ render:
   sadness:    { oled: sad,        palette: sadness,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [40, 80, 160] }
   curiosity:  { oled: focused,    palette: curiosity,    effect: COMET,          ears: curiosity, tone: neutral,  rgb: [0, 180, 200] }
   tired:      { oled: sleepy,     palette: neutral,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [80, 40, 120] }
-  fear:       { oled: scared,     palette: nervousness,  effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 0, 120] }
-  anger:      { oled: angry,      palette: annoyance,    effect: PULSE,          ears: anger,     tone: excited,  rgb: [220, 40, 0] }
-  furious:    { oled: furious,    palette: annoyance,    effect: METEOR,         ears: anger,     tone: excited,  rgb: [255, 0, 0] }
+  fear:       { oled: scared,     palette: fear,         effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 0, 120] }
+  anger:      { oled: angry,      palette: anger,        effect: PULSE,          ears: anger,     tone: excited,  rgb: [220, 40, 0] }
+  furious:    { oled: furious,    palette: anger,        effect: METEOR,         ears: anger,     tone: excited,  rgb: [255, 0, 0] }
   surprise:   { oled: surprised,  palette: surprise,     effect: TWINKLE,        ears: surprise,  tone: excited,  rgb: [255, 200, 0] }
   excitement: { oled: excited,    palette: excitement,   effect: RAINBOW_CYCLE,  ears: surprise,  tone: excited,  rgb: [255, 120, 0] }
   love:       { oled: happy,      palette: love,         effect: PULSE,          ears: joy,       tone: joy,      rgb: [255, 40, 100] }

--- a/modules/common/config/emotions.yml
+++ b/modules/common/config/emotions.yml
@@ -1,0 +1,52 @@
+# SentryBOT — Canonical Emotion Vocabulary
+#
+# Single source of truth that unifies the three historical emotion vocabularies
+# (autonomy mood ~6, oled_faces events ~13, neopixel palettes ~23).
+#
+# Every subsystem resolves its incoming label to a canonical key, then reads the
+# render hints below. This keeps eyes (OLED), LEDs (NeoPixel), ears (PiServo),
+# head body-language and TTS tone aligned for one emotion.
+
+# canonical -> alias labels that should map onto it
+aliases:
+  neutral:    [calm, idle, default, normal]
+  joy:        [happy, happiness, glad, cheerful, amusement, optimism]
+  sadness:    [sad, unhappy, down, grief, disappointment, remorse]
+  curiosity:  [curious, interested, intrigued, realization]
+  tired:      [sleepy, drowsy, fatigued, exhausted]
+  fear:       [scared, afraid, frightened, nervousness, nervous]
+  anger:      [angry, mad, annoyance, annoyed]
+  furious:    [rage, enraged, livid]
+  surprise:   [surprised, shocked, astonished]
+  excitement: [excited, thrilled, energetic]
+  love:       [affection, adoration, admiration, desire, gratitude]
+  disgust:    [disgusted, repulsed, disapproval]
+  confusion:  [confused, disoriented, puzzled, uncertain]
+  worried:    [worry, anxious, concerned]
+  bored:      [boredom, dull, listless]
+
+# Per-canonical render hints consumed across modules.
+#   oled    -> bitmap/animation name in oled_faces catalog
+#   palette -> neopixel emotion palette file (modules/neopixel/emotions/<palette>.yml)
+#   effect  -> neopixel animation effect
+#   ears    -> piservo emotion pose key
+#   tone    -> speak TTS tone preset
+#   rgb     -> direct fallback color when a palette is unavailable
+render:
+  neutral:    { oled: normal,     palette: neutral,      effect: BREATHE,        ears: neutral,   tone: neutral,  rgb: [40, 60, 80] }
+  joy:        { oled: happy,      palette: joy,          effect: RAINBOW_CYCLE,  ears: joy,       tone: joy,      rgb: [0, 200, 60] }
+  sadness:    { oled: sad,        palette: sadness,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [40, 80, 160] }
+  curiosity:  { oled: focused,    palette: curiosity,    effect: COMET,          ears: curiosity, tone: neutral,  rgb: [0, 180, 200] }
+  tired:      { oled: sleepy,     palette: neutral,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [80, 40, 120] }
+  fear:       { oled: scared,     palette: nervousness,  effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 0, 120] }
+  anger:      { oled: angry,      palette: annoyance,    effect: PULSE,          ears: anger,     tone: excited,  rgb: [220, 40, 0] }
+  furious:    { oled: furious,    palette: annoyance,    effect: METEOR,         ears: anger,     tone: excited,  rgb: [255, 0, 0] }
+  surprise:   { oled: surprised,  palette: surprise,     effect: TWINKLE,        ears: surprise,  tone: excited,  rgb: [255, 200, 0] }
+  excitement: { oled: excited,    palette: excitement,   effect: RAINBOW_CYCLE,  ears: surprise,  tone: excited,  rgb: [255, 120, 0] }
+  love:       { oled: happy,      palette: love,         effect: PULSE,          ears: joy,       tone: joy,      rgb: [255, 40, 100] }
+  disgust:    { oled: worried,    palette: disgust,      effect: BREATHE,        ears: sadness,   tone: neutral,  rgb: [120, 160, 0] }
+  confusion:  { oled: disoriented,palette: confusion,    effect: TWINKLE,        ears: curiosity, tone: neutral,  rgb: [160, 0, 200] }
+  worried:    { oled: worried,    palette: nervousness,  effect: BREATHE,        ears: fear,      tone: sadness,  rgb: [180, 100, 0] }
+  bored:      { oled: bored,      palette: neutral,      effect: BREATHE,        ears: sadness,   tone: neutral,  rgb: [60, 60, 60] }
+
+default_canonical: neutral

--- a/modules/common/emotion_vocab.py
+++ b/modules/common/emotion_vocab.py
@@ -1,0 +1,162 @@
+"""Canonical emotion vocabulary resolver.
+
+Unifies the historically divergent emotion labels used by autonomy (mood),
+oled_faces (events) and neopixel (palettes) into one canonical set with shared
+render hints (eyes / LEDs / ears / TTS tone).
+
+Usage::
+
+    from modules.common.emotion_vocab import get_vocab
+
+    vocab = get_vocab()
+    vocab.canonical("happy")            # -> "joy"
+    vocab.render("happy")               # -> EmotionRender(oled="happy", ...)
+    vocab.render("happy").palette       # -> "joy"
+
+The module is intentionally dependency-light (PyYAML only) so any service can
+import it without pulling heavy module graphs.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+logger = logging.getLogger("common.emotion_vocab")
+
+_CONFIG_PATH = Path(__file__).parent / "config" / "emotions.yml"
+
+
+@dataclass(frozen=True)
+class EmotionRender:
+    """Resolved render hints for a canonical emotion."""
+
+    canonical: str
+    oled: str = "normal"
+    palette: str = "neutral"
+    effect: str = "BREATHE"
+    ears: str = "neutral"
+    tone: str = "neutral"
+    rgb: tuple = (40, 60, 80)
+
+
+@dataclass
+class EmotionVocab:
+    """Resolver around the canonical emotion config."""
+
+    default_canonical: str = "neutral"
+    _alias_to_canonical: Dict[str, str] = field(default_factory=dict)
+    _render: Dict[str, EmotionRender] = field(default_factory=dict)
+
+    def canonical(self, label: Optional[str]) -> str:
+        """Map any incoming label to its canonical key."""
+        key = str(label or "").strip().lower()
+        if not key:
+            return self.default_canonical
+        if key in self._render:
+            return key
+        return self._alias_to_canonical.get(key, self.default_canonical)
+
+    def render(self, label: Optional[str]) -> EmotionRender:
+        """Resolve an incoming label to its render hints."""
+        canon = self.canonical(label)
+        return self._render.get(canon) or self._render.get(self.default_canonical) or EmotionRender(canon)
+
+    def is_known(self, label: Optional[str]) -> bool:
+        key = str(label or "").strip().lower()
+        return bool(key) and (key in self._render or key in self._alias_to_canonical)
+
+    def canonical_keys(self) -> List[str]:
+        return list(self._render.keys())
+
+
+def _coerce_rgb(value: Any, fallback: tuple = (40, 60, 80)) -> tuple:
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        try:
+            return (int(value[0]), int(value[1]), int(value[2]))
+        except (TypeError, ValueError):
+            return fallback
+    return fallback
+
+
+def load_vocab(path: Optional[Path] = None) -> EmotionVocab:
+    """Build an :class:`EmotionVocab` from the YAML config (falls back to defaults)."""
+    cfg_path = Path(path) if path else _CONFIG_PATH
+    data: Dict[str, Any] = {}
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except FileNotFoundError:
+        logger.warning("emotion config not found at %s, using minimal defaults", cfg_path)
+    except Exception as exc:  # malformed yaml should not crash a service
+        logger.warning("failed to load emotion config: %s", exc)
+
+    default_canon = str(data.get("default_canonical", "neutral")).lower()
+
+    render: Dict[str, EmotionRender] = {}
+    for canon, hints in (data.get("render") or {}).items():
+        canon_key = str(canon).strip().lower()
+        hints = hints if isinstance(hints, dict) else {}
+        render[canon_key] = EmotionRender(
+            canonical=canon_key,
+            oled=str(hints.get("oled", "normal")),
+            palette=str(hints.get("palette", "neutral")),
+            effect=str(hints.get("effect", "BREATHE")),
+            ears=str(hints.get("ears", "neutral")),
+            tone=str(hints.get("tone", "neutral")),
+            rgb=_coerce_rgb(hints.get("rgb")),
+        )
+
+    alias_to_canonical: Dict[str, str] = {}
+    for canon, aliases in (data.get("aliases") or {}).items():
+        canon_key = str(canon).strip().lower()
+        alias_to_canonical[canon_key] = canon_key
+        if isinstance(aliases, (list, tuple)):
+            for alias in aliases:
+                alias_to_canonical[str(alias).strip().lower()] = canon_key
+
+    if default_canon not in render:
+        render[default_canon] = EmotionRender(default_canon)
+
+    return EmotionVocab(
+        default_canonical=default_canon,
+        _alias_to_canonical=alias_to_canonical,
+        _render=render,
+    )
+
+
+_vocab_lock = threading.Lock()
+_vocab_singleton: Optional[EmotionVocab] = None
+
+
+def get_vocab() -> EmotionVocab:
+    """Process-wide cached vocabulary."""
+    global _vocab_singleton
+    if _vocab_singleton is None:
+        with _vocab_lock:
+            if _vocab_singleton is None:
+                _vocab_singleton = load_vocab()
+    return _vocab_singleton
+
+
+def canonical_emotion(label: Optional[str]) -> str:
+    return get_vocab().canonical(label)
+
+
+def emotion_render(label: Optional[str]) -> EmotionRender:
+    return get_vocab().render(label)
+
+
+__all__ = [
+    "EmotionRender",
+    "EmotionVocab",
+    "load_vocab",
+    "get_vocab",
+    "canonical_emotion",
+    "emotion_render",
+]

--- a/modules/common/tests/test_smoke.py
+++ b/modules/common/tests/test_smoke.py
@@ -1,0 +1,58 @@
+"""Smoke + behaviour tests for the canonical emotion vocabulary."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_import():
+    module = importlib.import_module("modules.common.emotion_vocab")
+    assert hasattr(module, "get_vocab")
+
+
+def test_config_loader():
+    from modules.common.emotion_vocab import load_vocab
+
+    vocab = load_vocab()
+    assert vocab.canonical_keys(), "expected at least one canonical emotion"
+    assert "neutral" in vocab.canonical_keys()
+
+
+def test_alias_resolution():
+    from modules.common.emotion_vocab import get_vocab
+
+    vocab = get_vocab()
+    assert vocab.canonical("happy") == "joy"
+    assert vocab.canonical("sad") == "sadness"
+    assert vocab.canonical("sleepy") == "tired"
+    assert vocab.canonical("angry") == "anger"
+    assert vocab.canonical("scared") == "fear"
+    # canonical labels resolve to themselves
+    assert vocab.canonical("joy") == "joy"
+
+
+def test_unknown_falls_back_to_default():
+    from modules.common.emotion_vocab import get_vocab
+
+    vocab = get_vocab()
+    assert vocab.canonical(None) == "neutral"
+    assert vocab.canonical("") == "neutral"
+    assert vocab.canonical("definitely-not-an-emotion") == "neutral"
+
+
+def test_render_hints_are_consistent():
+    from modules.common.emotion_vocab import emotion_render
+
+    render = emotion_render("happy")
+    assert render.canonical == "joy"
+    # the alias and the canonical must yield identical render hints
+    assert emotion_render("joy") == render
+    assert isinstance(render.rgb, tuple) and len(render.rgb) == 3
+    assert render.oled and render.palette and render.effect and render.ears and render.tone
+
+
+def test_service_init():
+    # The vocab acts as the module's "service": construct it from defaults.
+    from modules.common.emotion_vocab import EmotionVocab, load_vocab
+
+    assert isinstance(load_vocab(), EmotionVocab)

--- a/modules/gateway/services/bootstrap.py
+++ b/modules/gateway/services/bootstrap.py
@@ -1046,6 +1046,7 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
             "sound.detected": "sound",
             "vision.focus": "sound",
             "vision.person": "sound",
+            "environment.scene_changed": "sound",
         }
 
         def _piservo_on_interaction(evt: str, data: Dict[str, Any]) -> None:

--- a/modules/gateway/services/bootstrap.py
+++ b/modules/gateway/services/bootstrap.py
@@ -1038,18 +1038,31 @@ def bootstrap(app: FastAPI, cfg: Dict[str, Any]) -> Dict[str, object]:
     interactions = started.get("interactions")
     piservo = started.get("piservo")
     if interactions is not None and piservo is not None and hasattr(interactions, "register_event_handler"):
+        # Map interaction events onto expressive ear motion. Emotion events keep
+        # the ears in sync with eyes/LEDs; sound/vision events add reactive
+        # gestures; wakeword keeps its dedicated perk-up gesture.
+        _ear_gesture_events = {
+            "wakeword.detected": "wakeword",
+            "sound.detected": "sound",
+            "vision.focus": "sound",
+            "vision.person": "sound",
+        }
+
         def _piservo_on_interaction(evt: str, data: Dict[str, Any]) -> None:
-            if evt != "wakeword.detected":
-                return
+            key = str(evt or "").strip().lower()
             try:
-                if hasattr(piservo, "gesture"):
-                    piservo.gesture("wakeword")
+                if key.startswith("emotion:") and hasattr(piservo, "emotion"):
+                    piservo.emotion(key.split(":", 1)[1])
+                    return
+                gesture = _ear_gesture_events.get(key)
+                if gesture and hasattr(piservo, "gesture"):
+                    piservo.gesture(gesture)
             except Exception:
                 pass
 
         try:
             interactions.register_event_handler(_piservo_on_interaction)
-            logger.info("interactions wakeword -> piservo gesture bridge mounted")
+            logger.info("interactions -> piservo ear expression bridge mounted")
         except Exception as exc:
             logger.warning("piservo interactions bridge mount failed: %s", exc)
 

--- a/modules/interactions/config/config.yml
+++ b/modules/interactions/config/config.yml
@@ -197,3 +197,9 @@ rules:
     action: { effect: { name: COMET, duration_ms: 600 } }
     priority: low
     cooldown_ms: 1200
+
+  - id: environment_scene_changed
+    when: { event: environment.scene_changed }
+    action: { effect: { name: COMET, duration_ms: 700 } }
+    priority: low
+    cooldown_ms: 4000

--- a/modules/neopixel/emotions/anger.yml
+++ b/modules/neopixel/emotions/anger.yml
@@ -1,0 +1,21 @@
+colors:
+- name: COLOR_CRIMSON
+  r: 220
+  g: 20
+  b: 30
+- name: COLOR_FLAME
+  r: 255
+  g: 60
+  b: 0
+- name: COLOR_BLOOD_RED
+  r: 180
+  g: 0
+  b: 0
+- name: COLOR_EMBER
+  r: 255
+  g: 90
+  b: 20
+- name: COLOR_DARK_RED
+  r: 120
+  g: 0
+  b: 0

--- a/modules/neopixel/emotions/fear.yml
+++ b/modules/neopixel/emotions/fear.yml
@@ -1,0 +1,21 @@
+colors:
+- name: COLOR_MAGENTA_ALERT
+  r: 200
+  g: 0
+  b: 120
+- name: COLOR_VIOLET
+  r: 138
+  g: 43
+  b: 226
+- name: COLOR_PALE_GHOST
+  r: 180
+  g: 180
+  b: 255
+- name: COLOR_DEEP_INDIGO
+  r: 75
+  g: 0
+  b: 130
+- name: COLOR_COLD_CYAN
+  r: 0
+  g: 150
+  b: 200

--- a/modules/neopixel/emotions/joy.yml
+++ b/modules/neopixel/emotions/joy.yml
@@ -1,0 +1,21 @@
+colors:
+- name: COLOR_SPRING_GREEN
+  r: 0
+  g: 230
+  b: 118
+- name: COLOR_GOLDEN
+  r: 255
+  g: 214
+  b: 10
+- name: COLOR_SUNNY
+  r: 255
+  g: 179
+  b: 0
+- name: COLOR_LIME
+  r: 156
+  g: 255
+  b: 86
+- name: COLOR_AQUA_JOY
+  r: 64
+  g: 224
+  b: 208

--- a/modules/neopixel/emotions/loader.py
+++ b/modules/neopixel/emotions/loader.py
@@ -40,9 +40,33 @@ def _parse_color(value) -> ColorEntry:
     raise ValueError(f"Unsupported color format: {value!r}")
 
 
+def _resolve_palette_name(emotion: str) -> Optional[str]:
+    """Map an arbitrary emotion label onto a palette file name via the shared vocab.
+
+    Lets callers pass canonical autonomy moods (``joy``/``tired``) or any alias
+    (``happy``/``sleepy``) and still land on a real palette file.
+    """
+    try:
+        from modules.common.emotion_vocab import get_vocab  # lazy: optional dep
+
+        return get_vocab().render(emotion).palette
+    except Exception:
+        return None
+
+
 @dataclass
 class EmotionPalette:
     entries_by_emotion: Dict[str, List[ColorEntry]]
+
+    def _lookup(self, emotion: str) -> Optional[List[ColorEntry]]:
+        key = (emotion or "").lower()
+        lst = self.entries_by_emotion.get(key)
+        if lst:
+            return lst
+        palette_name = _resolve_palette_name(key)
+        if palette_name and palette_name != key:
+            return self.entries_by_emotion.get(palette_name)
+        return None
 
     def random_color(self, emotion: str) -> Color:
         # Backward compatible simple color picker
@@ -50,13 +74,13 @@ class EmotionPalette:
         return ent.color
 
     def random_entry(self, emotion: str) -> ColorEntry:
-        lst = self.entries_by_emotion.get(emotion.lower())
+        lst = self._lookup(emotion)
         if lst:
             return random.choice(lst)
         return ColorEntry("fallback", (255, 255, 255))
 
     def get_by_name(self, emotion: str, name: str) -> Optional[ColorEntry]:
-        lst = self.entries_by_emotion.get(emotion.lower())
+        lst = self._lookup(emotion)
         if not lst:
             return None
         name = name.lower()

--- a/modules/neopixel/services/runner.py
+++ b/modules/neopixel/services/runner.py
@@ -38,6 +38,38 @@ except Exception:
     from effects import wheel  # type: ignore
 
 
+class _SegmentView:
+    """Adapter that exposes a driver sub-range as if it were a full strip.
+
+    Lets the existing whole-strip animation functions run on a single
+    segment without modifying them: index ``i`` is remapped to
+    ``start + i`` and out-of-range writes are ignored.
+    """
+
+    def __init__(self, driver: Any, start: int, end: int) -> None:
+        self._driver = driver
+        self._start = start
+        self._end = end
+        self.num_leds = max(0, end - start)
+
+    def set(self, idx: int, r: int, g: int, b: int) -> None:
+        if 0 <= idx < self.num_leds:
+            self._driver.set(self._start + idx, r, g, b)
+
+    def show(self) -> None:
+        self._driver.show()
+
+    def clear(self) -> None:
+        for i in range(self._start, self._end):
+            self._driver.set(i, 0, 0, 0)
+        self._driver.show()
+
+    def fill(self, r: int, g: int, b: int) -> None:
+        for i in range(self._start, self._end):
+            self._driver.set(i, r, g, b)
+        self._driver.show()
+
+
 class NeoRunner:
     def __init__(
         self,
@@ -288,61 +320,20 @@ class NeoRunner:
         cols = self._colors_from_emotions(emotions)
         c1 = color if color is not None else (cols[0] if cols else None)
 
-        # Segment target currently supports deterministic color output.
+        # Segment target: run the *actual* animation scoped to the segment's
+        # LED range (falling back to a solid fill for that segment only).
         if segment:
-            if c1 is None:
-                c1 = (255, 255, 255)
-            if self.fill_segment(segment, *c1):
+            bounds = self._segment_bounds(segment)
+            if bounds is not None:
+                start, end = bounds
+                view = _SegmentView(self.driver, start, end)
+                if not self._run_named_animation(name, view, cols, c1, iterations):
+                    fill = c1 if c1 is not None else (255, 255, 255)
+                    view.fill(*fill)
                 return
+            # Unknown segment name: degrade to whole-strip behaviour below.
 
-        name = name.upper()
-        c2 = cols[1] if len(cols) > 1 else None
-        # Map names to functions
-        if name == "RAINBOW":
-            anim_rainbow(self.driver, c1, iterations or 1)
-        elif name == "RAINBOW_CYCLE":
-            rainbow_cycle(self.driver, c1, iterations or 1)
-        elif name == "SPINNER":
-            anim_spinner(self.driver, c1 or (255, 0, 0), iterations or 1)
-        elif name == "BREATHE":
-            anim_breathe(self.driver, c1 or (255, 0, 0), iterations or 1)
-        elif name == "METEOR":
-            meteor_rain(self.driver, c1 or (255, 255, 255))
-        elif name == "FIRE":
-            fire_flicker(self.driver, c1 or (255, 165, 0))
-        elif name == "COMET":
-            anim_comet(self.driver, c1 or (0, 255, 255))
-        elif name == "WAVE":
-            anim_wave(self.driver, c1)
-        elif name == "PULSE":
-            anim_pulse(self.driver, c1 or (255, 0, 127))
-        elif name == "TWINKLE":
-            anim_twinkle(self.driver, c1 or (255, 255, 255))
-        elif name == "COLOR_WIPE":
-            color_wipe(self.driver, c1 or (255, 0, 0))
-        elif name == "RANDOM_BLINK":
-            random_blink(self.driver, c1)
-        elif name == "THEATER_CHASE":
-            anim_theater_chase(self.driver, c1 or (127, 127, 127))
-        elif name == "SNOW":
-            anim_snow(self.driver, c1 or (255, 255, 255))
-        elif name == "ALTERNATING":
-            alternating_colors(self.driver, c1 or (255, 0, 0), c2 or (0, 0, 255))
-        elif name == "GRADIENT":
-            gradient_fade(self.driver, 5, c1)
-        elif name == "BOUNCING_BALL":
-            bouncing_ball(self.driver, c1 or (255, 0, 0))
-        elif name == "RUNNING_LIGHTS":
-            running_lights(self.driver, c1 or (255, 0, 0))
-        elif name == "STACKED_BARS":
-            stacked_bars(self.driver, 50, c1)
-        elif name == "MULTI_GRADIENT":
-            if cols:
-                multi_color_gradient(self.driver, cols, iterations or 5)
-        elif name == "MULTI_WAVE":
-            if cols:
-                multi_color_wave(self.driver, cols, iterations or 5)
-        else:
+        if not self._run_named_animation(name, self.driver, cols, c1, iterations):
             # Unknown animation name: try backend-native animation first.
             r, g, b = c1 if c1 else (255, 255, 255)
             if self.driver.animate(name_lower, r, g, b, iterations or 0, 50):
@@ -350,6 +341,69 @@ class NeoRunner:
             # last-resort fallback simple fill
             if c1:
                 self.fill(*c1)
+
+    def _run_named_animation(
+        self,
+        name: str,
+        driver: Any,
+        cols: list[tuple[int, int, int]],
+        c1: tuple[int, int, int] | None,
+        iterations: int | None,
+    ) -> bool:
+        """Dispatch a named animation onto ``driver`` (full strip or segment view).
+
+        Returns ``False`` when the name is not a known software animation.
+        """
+        name = name.upper()
+        c2 = cols[1] if len(cols) > 1 else None
+        # Map names to functions
+        if name == "RAINBOW":
+            anim_rainbow(driver, c1, iterations or 1)
+        elif name == "RAINBOW_CYCLE":
+            rainbow_cycle(driver, c1, iterations or 1)
+        elif name == "SPINNER":
+            anim_spinner(driver, c1 or (255, 0, 0), iterations or 1)
+        elif name == "BREATHE":
+            anim_breathe(driver, c1 or (255, 0, 0), iterations or 1)
+        elif name == "METEOR":
+            meteor_rain(driver, c1 or (255, 255, 255))
+        elif name == "FIRE":
+            fire_flicker(driver, c1 or (255, 165, 0))
+        elif name == "COMET":
+            anim_comet(driver, c1 or (0, 255, 255))
+        elif name == "WAVE":
+            anim_wave(driver, c1)
+        elif name == "PULSE":
+            anim_pulse(driver, c1 or (255, 0, 127))
+        elif name == "TWINKLE":
+            anim_twinkle(driver, c1 or (255, 255, 255))
+        elif name == "COLOR_WIPE":
+            color_wipe(driver, c1 or (255, 0, 0))
+        elif name == "RANDOM_BLINK":
+            random_blink(driver, c1)
+        elif name == "THEATER_CHASE":
+            anim_theater_chase(driver, c1 or (127, 127, 127))
+        elif name == "SNOW":
+            anim_snow(driver, c1 or (255, 255, 255))
+        elif name == "ALTERNATING":
+            alternating_colors(driver, c1 or (255, 0, 0), c2 or (0, 0, 255))
+        elif name == "GRADIENT":
+            gradient_fade(driver, 5, c1)
+        elif name == "BOUNCING_BALL":
+            bouncing_ball(driver, c1 or (255, 0, 0))
+        elif name == "RUNNING_LIGHTS":
+            running_lights(driver, c1 or (255, 0, 0))
+        elif name == "STACKED_BARS":
+            stacked_bars(driver, 50, c1)
+        elif name == "MULTI_GRADIENT":
+            if cols:
+                multi_color_gradient(driver, cols, iterations or 5)
+        elif name == "MULTI_WAVE":
+            if cols:
+                multi_color_wave(driver, cols, iterations or 5)
+        else:
+            return False
+        return True
 
     def _animate_worker_loop(self) -> None:
         while True:

--- a/modules/neopixel/tests/test_segments.py
+++ b/modules/neopixel/tests/test_segments.py
@@ -42,14 +42,27 @@ def test_fill_segment_applies_only_target_range():
     assert runner.driver.buf[3:] == [(0, 0, 0)] * 7
 
 
-def test_animate_segment_falls_back_to_segment_fill():
+def test_animate_unknown_effect_on_segment_falls_back_to_segment_fill():
     runner = NeoRunner(NeoDriverConfig(num_leds=6), segments=[{"name": "jewel", "start": 0, "count": 2}])
     runner.driver = _FakeDriver(6)
-    runner.animate("PULSE", color=(10, 20, 30), segment="jewel")
+    runner.animate("NO_SUCH_EFFECT", color=(10, 20, 30), segment="jewel")
     runner._wait_for_animations()
     assert runner.driver.buf[0] == (10, 20, 30)
     assert runner.driver.buf[1] == (10, 20, 30)
     assert runner.driver.buf[2:] == [(0, 0, 0)] * 4
+
+
+def test_animate_known_effect_runs_scoped_to_segment():
+    # A real animation must run on the segment range only, leaving the rest dark.
+    runner = NeoRunner(NeoDriverConfig(num_leds=6), segments=[{"name": "jewel", "start": 0, "count": 2}])
+    runner.driver = _FakeDriver(6)
+    runner.animate("PULSE", color=(200, 100, 50), segment="jewel")
+    runner._wait_for_animations()
+    # Segment LEDs were driven by the effect (non-zero), neighbours untouched.
+    assert runner.driver.buf[0] != (0, 0, 0)
+    assert runner.driver.buf[1] != (0, 0, 0)
+    assert runner.driver.buf[2:] == [(0, 0, 0)] * 4
+    assert runner.driver.shows > 0
 
 
 def test_apply_preset_sets_segment_colors():

--- a/modules/neopixel/tests/test_smoke.py
+++ b/modules/neopixel/tests/test_smoke.py
@@ -16,3 +16,15 @@ def test_basic_effects_smoke():
     col = store.random_color("joy")
     assert isinstance(col, tuple) and len(col) == 3
     r.emote_sequence(["joy", "fear"], duration=0)
+
+
+def test_emotion_palette_alias_resolution():
+    # Canonical labels and aliases must resolve to a real palette colour
+    # instead of the white (255,255,255) fallback.
+    store = EmotionStore()
+    palette = store.load()
+    assert "joy" in palette.entries_by_emotion
+    assert "anger" in palette.entries_by_emotion
+    # alias 'happy' resolves through the shared vocab to the 'joy' palette
+    assert store.random_color("happy") != (255, 255, 255)
+    assert store.random_color("scared") != (255, 255, 255)

--- a/modules/oled_faces/services/mapper.py
+++ b/modules/oled_faces/services/mapper.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+try:  # keep oled_faces importable even if the shared helper is unavailable
+    from modules.common.emotion_vocab import get_vocab as _get_emotion_vocab
+except Exception:  # pragma: no cover - defensive fallback
+    _get_emotion_vocab = None
+
 
 @dataclass(frozen=True)
 class OledAction:
@@ -43,9 +48,25 @@ class FaceMapper:
         if not emotions:
             return OledAction(mode="bitmap", name=self.idle_bitmap)
         key = str(emotions[0]).strip().lower()
+        # 1) Honour an explicit event_map override if present for this label.
         mapped = self.event_map.get(f"emotion:{key}")
         if isinstance(mapped, dict):
             return OledAction(mode=str(mapped.get("mode", "bitmap")), name=str(mapped.get("name", self.fallback_unknown)))
+        # 2) Resolve through the canonical vocabulary so divergent labels
+        #    (joy/happy, tired/sleepy, anger/angry) land on a real bitmap.
+        if _get_emotion_vocab is not None:
+            try:
+                render = _get_emotion_vocab().render(key)
+                canon_override = self.event_map.get(f"emotion:{render.canonical}")
+                if isinstance(canon_override, dict):
+                    return OledAction(
+                        mode=str(canon_override.get("mode", "bitmap")),
+                        name=str(canon_override.get("name", render.oled)),
+                    )
+                if render.oled in self.catalog_bitmaps:
+                    return OledAction(mode="bitmap", name=render.oled)
+            except Exception:
+                pass
         return OledAction(mode="bitmap", name=self.fallback_unknown)
 
     def from_interaction_event(self, event_type: str) -> OledAction:

--- a/modules/oled_faces/services/pi_ssd1306_driver.py
+++ b/modules/oled_faces/services/pi_ssd1306_driver.py
@@ -106,9 +106,22 @@ class PiSsd1306Driver:
         if bmp is None and key != "normal":
             bmp = self._load_bitmap("normal")
         if bmp is None:
-            return False
+            # No committed bitmap asset: keep the eyes expressive by drawing a
+            # procedural face for this expression directly into the buffer.
+            return self._render_procedural_face(key)
         with self._lock:
             self._buffer[:] = bmp
+            self.flush()
+        return True
+
+    def _render_procedural_face(self, name: str) -> bool:
+        try:
+            from .procedural_face import draw_face
+        except Exception:
+            from procedural_face import draw_face  # type: ignore
+        with self._lock:
+            self.clear()
+            draw_face(name, self.width, self.height, lambda x, y: self.set_pixel(x, y, 1))
             self.flush()
         return True
 

--- a/modules/oled_faces/services/procedural_face.py
+++ b/modules/oled_faces/services/procedural_face.py
@@ -1,0 +1,176 @@
+"""Procedural 1-bit face rasteriser.
+
+Fallback used when a pre-baked OLED bitmap asset is missing from disk. Draws a
+simple, recognisable face (eyes + brows + mouth) for a given emotion so the
+robot's eyes stay expressive even on a fresh checkout without committed binary
+bitmaps.
+
+The renderer is hardware-agnostic: it draws through a ``plot(x, y)`` callback so
+it can target the SSD1306 page buffer on a Pi or a plain grid in tests.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+try:
+    from modules.common.emotion_vocab import get_vocab as _get_emotion_vocab
+except Exception:  # pragma: no cover - optional dependency
+    _get_emotion_vocab = None
+
+Plot = Callable[[int, int], None]
+
+
+# Per-style eye/mouth/brow descriptors. Keyed by canonical emotion plus a few
+# direct gaze/blink poses that are not emotions.
+_EYE_OPEN = "open"
+_EYE_HAPPY = "happy"      # upward arc ^ ^
+_EYE_NARROW = "narrow"    # half-closed line
+_EYE_WIDE = "wide"        # big round
+_EYE_CLOSED = "closed"    # flat line (blink)
+
+_MOUTH_SMILE = "smile"
+_MOUTH_FROWN = "frown"
+_MOUTH_FLAT = "flat"
+_MOUTH_OPEN = "open"      # small "o"
+
+_STYLES: Dict[str, Dict[str, object]] = {
+    "neutral":    {"eye": _EYE_OPEN,   "mouth": _MOUTH_FLAT,  "brow": 0},
+    "joy":        {"eye": _EYE_HAPPY,  "mouth": _MOUTH_SMILE, "brow": 0},
+    "excitement": {"eye": _EYE_WIDE,   "mouth": _MOUTH_SMILE, "brow": 0},
+    "love":       {"eye": _EYE_HAPPY,  "mouth": _MOUTH_SMILE, "brow": 0},
+    "sadness":    {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": 1},
+    "tired":      {"eye": _EYE_NARROW, "mouth": _MOUTH_FLAT,  "brow": 0},
+    "bored":      {"eye": _EYE_NARROW, "mouth": _MOUTH_FLAT,  "brow": 0},
+    "fear":       {"eye": _EYE_WIDE,   "mouth": _MOUTH_OPEN,  "brow": 1},
+    "worried":    {"eye": _EYE_OPEN,   "mouth": _MOUTH_FROWN, "brow": 1},
+    "anger":      {"eye": _EYE_OPEN,   "mouth": _MOUTH_FROWN, "brow": -1},
+    "furious":    {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": -1},
+    "surprise":   {"eye": _EYE_WIDE,   "mouth": _MOUTH_OPEN,  "brow": 0},
+    "curiosity":  {"eye": _EYE_OPEN,   "mouth": _MOUTH_FLAT,  "brow": 0},
+    "disgust":    {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": -1},
+    "confusion":  {"eye": _EYE_OPEN,   "mouth": _MOUTH_FLAT,  "brow": 1},
+}
+
+# Direct (non-emotion) poses handled before vocab resolution.
+_DIRECT: Dict[str, Dict[str, object]] = {
+    "normal":  {"eye": _EYE_OPEN,   "mouth": _MOUTH_FLAT,  "brow": 0},
+    "blink":   {"eye": _EYE_CLOSED, "mouth": _MOUTH_FLAT,  "brow": 0},
+    "happy":   {"eye": _EYE_HAPPY,  "mouth": _MOUTH_SMILE, "brow": 0},
+    "sad":     {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": 1},
+    "angry":   {"eye": _EYE_OPEN,   "mouth": _MOUTH_FROWN, "brow": -1},
+    "furious": {"eye": _EYE_NARROW, "mouth": _MOUTH_FROWN, "brow": -1},
+    "sleepy":  {"eye": _EYE_NARROW, "mouth": _MOUTH_FLAT,  "brow": 0},
+    "surprised": {"eye": _EYE_WIDE, "mouth": _MOUTH_OPEN,  "brow": 0},
+    "focused": {"eye": _EYE_NARROW, "mouth": _MOUTH_FLAT,  "brow": 0},
+}
+
+
+def _style_for(name: str) -> Dict[str, object]:
+    key = str(name or "").strip().lower()
+    if key in _DIRECT:
+        return _DIRECT[key]
+    canon = key
+    if _get_emotion_vocab is not None:
+        try:
+            canon = _get_emotion_vocab().canonical(key)
+        except Exception:
+            canon = key
+    return _STYLES.get(canon, _STYLES["neutral"])
+
+
+def _hline(plot: Plot, x0: int, x1: int, y: int) -> None:
+    if x1 < x0:
+        x0, x1 = x1, x0
+    for x in range(x0, x1 + 1):
+        plot(x, y)
+
+
+def _vline(plot: Plot, x: int, y0: int, y1: int) -> None:
+    if y1 < y0:
+        y0, y1 = y1, y0
+    for y in range(y0, y1 + 1):
+        plot(x, y)
+
+
+def _rect(plot: Plot, x0: int, y0: int, x1: int, y1: int, fill: bool) -> None:
+    if fill:
+        for y in range(y0, y1 + 1):
+            _hline(plot, x0, x1, y)
+    else:
+        _hline(plot, x0, x1, y0)
+        _hline(plot, x0, x1, y1)
+        _vline(plot, x0, y0, y1)
+        _vline(plot, x1, y0, y1)
+
+
+def _arc_up(plot: Plot, cx: int, y: int, half: int) -> None:
+    # simple upward chevron ^ for happy eyes / smile
+    for dx in range(-half, half + 1):
+        plot(cx + dx, y + abs(dx) // 2)
+
+
+def _arc_down(plot: Plot, cx: int, y: int, half: int) -> None:
+    for dx in range(-half, half + 1):
+        plot(cx + dx, y - abs(dx) // 2)
+
+
+def _draw_eye(plot: Plot, cx: int, cy: int, shape: str) -> None:
+    if shape == _EYE_CLOSED:
+        _hline(plot, cx - 7, cx + 7, cy)
+    elif shape == _EYE_NARROW:
+        _rect(plot, cx - 7, cy - 1, cx + 7, cy + 2, fill=True)
+    elif shape == _EYE_WIDE:
+        _rect(plot, cx - 8, cy - 8, cx + 8, cy + 8, fill=False)
+        _rect(plot, cx - 6, cy - 6, cx + 6, cy + 6, fill=True)
+    elif shape == _EYE_HAPPY:
+        _arc_up(plot, cx, cy - 2, 7)
+        _arc_up(plot, cx, cy - 1, 7)
+    else:  # open
+        _rect(plot, cx - 6, cy - 6, cx + 6, cy + 6, fill=True)
+
+
+def _draw_brow(plot: Plot, cx: int, cy: int, direction: int) -> None:
+    if direction == 0:
+        return
+    if direction < 0:  # angry: inner-down
+        _arc_down(plot, cx, cy, 7)
+    else:  # worried/sad: inner-up
+        _arc_up(plot, cx, cy, 7)
+
+
+def _draw_mouth(plot: Plot, cx: int, cy: int, shape: str) -> None:
+    if shape == _MOUTH_SMILE:
+        _arc_up(plot, cx, cy - 3, 10)
+    elif shape == _MOUTH_FROWN:
+        _arc_down(plot, cx, cy + 3, 10)
+    elif shape == _MOUTH_OPEN:
+        _rect(plot, cx - 4, cy - 4, cx + 4, cy + 4, fill=False)
+    else:  # flat
+        _hline(plot, cx - 8, cx + 8, cy)
+
+
+def draw_face(name: str, width: int, height: int, plot: Plot) -> str:
+    """Rasterise a face for ``name`` via ``plot``; returns the resolved style id."""
+    style = _style_for(name)
+    cx = width // 2
+    eye_y = height // 3
+    eye_dx = width // 4
+    left_x = cx - eye_dx
+    right_x = cx + eye_dx
+    mouth_y = (height * 3) // 4
+
+    brow = int(style.get("brow", 0))
+    eye_shape = str(style.get("eye", _EYE_OPEN))
+    mouth_shape = str(style.get("mouth", _MOUTH_FLAT))
+
+    if brow != 0:
+        _draw_brow(plot, left_x, eye_y - 10, brow)
+        _draw_brow(plot, right_x, eye_y - 10, brow)
+    _draw_eye(plot, left_x, eye_y, eye_shape)
+    _draw_eye(plot, right_x, eye_y, eye_shape)
+    _draw_mouth(plot, cx, mouth_y, mouth_shape)
+    return f"{eye_shape}/{mouth_shape}/{brow}"
+
+
+__all__ = ["draw_face"]

--- a/modules/oled_faces/tests/test_procedural_face.py
+++ b/modules/oled_faces/tests/test_procedural_face.py
@@ -1,0 +1,48 @@
+"""Tests for the procedural face fallback rasteriser."""
+
+from __future__ import annotations
+
+from modules.oled_faces.services.procedural_face import draw_face
+
+
+def _render(name: str, w: int = 128, h: int = 64):
+    pixels = set()
+
+    def plot(x: int, y: int) -> None:
+        if 0 <= x < w and 0 <= y < h:
+            pixels.add((x, y))
+
+    style = draw_face(name, w, h, plot)
+    return pixels, style
+
+
+def test_draws_within_bounds_and_non_empty():
+    pixels, _ = _render("normal")
+    assert pixels, "expected the face to draw at least some pixels"
+    for x, y in pixels:
+        assert 0 <= x < 128 and 0 <= y < 64
+
+
+def test_emotions_produce_distinct_faces():
+    happy, _ = _render("happy")
+    sad, _ = _render("sad")
+    angry, _ = _render("angry")
+    surprised, _ = _render("surprised")
+    # different expressions must not be pixel-identical
+    assert happy != sad
+    assert happy != angry
+    assert sad != surprised
+
+
+def test_aliases_match_canonical_via_vocab():
+    # 'happy' is a direct pose; 'joy' resolves through the vocab to the same look
+    happy, _ = _render("happy")
+    joy, _ = _render("joy")
+    assert happy == joy
+
+
+def test_blink_is_minimal():
+    blink, style = _render("blink")
+    normal, _ = _render("normal")
+    # closed eyes should draw fewer pixels than open eyes
+    assert len(blink) < len(normal)

--- a/modules/oled_faces/tests/test_smoke.py
+++ b/modules/oled_faces/tests/test_smoke.py
@@ -6,3 +6,17 @@ def test_mapper_has_full_catalog():
     assert len(mapper.catalog_bitmaps) >= 32
     assert "normal" in mapper.catalog_bitmaps
     assert "all" in mapper.catalog_animations
+
+
+def test_canonical_emotion_resolves_to_face():
+    # autonomy emits canonical labels (joy/tired/anger) that have no direct
+    # `emotion:<label>` entry; they must still land on a real bitmap.
+    mapper = FaceMapper({})
+    assert mapper.from_emotions(["joy"]).name == "happy"
+    assert mapper.from_emotions(["tired"]).name == "sleepy"
+    assert mapper.from_emotions(["anger"]).name == "angry"
+
+
+def test_explicit_event_map_override_wins():
+    mapper = FaceMapper({"event_map": {"emotion:happy": {"mode": "bitmap", "name": "excited"}}})
+    assert mapper.from_emotions(["happy"]).name == "excited"

--- a/modules/piservo/services/ears.py
+++ b/modules/piservo/services/ears.py
@@ -21,6 +21,27 @@ EMOTION_POSES: Dict[str, EarPose] = {
 }
 
 
+def pose_for_emotion(name: str) -> EarPose:
+    """Resolve an arbitrary emotion label to an ear pose.
+
+    Accepts canonical autonomy moods or any alias (happy/sleepy/angry) by
+    routing through the shared emotion vocabulary, then falling back to a
+    direct table lookup and finally to the neutral pose.
+    """
+    key = str(name or "").strip().lower()
+    if key in EMOTION_POSES:
+        return EMOTION_POSES[key]
+    try:
+        from modules.common.emotion_vocab import get_vocab  # lazy optional dep
+
+        ears_key = get_vocab().render(key).ears
+        if ears_key in EMOTION_POSES:
+            return EMOTION_POSES[ears_key]
+    except Exception:
+        pass
+    return EMOTION_POSES["neutral"]
+
+
 def gesture_wakeword() -> Tuple[float, float]:
     # quick raise both then relax
     return (60, 60)

--- a/modules/piservo/services/runner.py
+++ b/modules/piservo/services/runner.py
@@ -3,10 +3,10 @@ import time
 
 try:
     from .driver import Servo, ServoConfig
-    from .ears import EMOTION_POSES, gesture_sound, gesture_wakeword
+    from .ears import EMOTION_POSES, gesture_sound, gesture_wakeword, pose_for_emotion
 except Exception:
     from driver import Servo, ServoConfig  # type: ignore
-    from ears import EMOTION_POSES, gesture_sound, gesture_wakeword  # type: ignore
+    from ears import EMOTION_POSES, gesture_sound, gesture_wakeword, pose_for_emotion  # type: ignore
 
 
 class EarRunner:
@@ -21,7 +21,7 @@ class EarRunner:
         self.right.set_angle(right)
 
     def emotion(self, name: str) -> None:
-        pose = EMOTION_POSES.get(name.lower(), EMOTION_POSES.get("neutral", None))
+        pose = pose_for_emotion(name)
         if not pose:
             return
         self.set_angles(pose.left, pose.right)

--- a/modules/piservo/tests/test_smoke.py
+++ b/modules/piservo/tests/test_smoke.py
@@ -17,3 +17,18 @@ def test_set_angles():
     r = client.post("/piservo/set", params={"left": 90, "right": 90})
     assert r.status_code == 200
     assert r.json().get("ok") is True
+
+
+def test_ear_pose_resolves_emotion_aliases():
+    from modules.piservo.services.ears import EMOTION_POSES, pose_for_emotion
+
+    # canonical labels map straight through
+    assert pose_for_emotion("joy") == EMOTION_POSES["joy"]
+    # aliases resolve via the shared vocabulary
+    assert pose_for_emotion("happy") == EMOTION_POSES["joy"]
+    assert pose_for_emotion("scared") == EMOTION_POSES["fear"]
+    assert pose_for_emotion("angry") == EMOTION_POSES["anger"]
+    # tired has no dedicated pose -> mapped onto sadness ears
+    assert pose_for_emotion("tired") == EMOTION_POSES["sadness"]
+    # unknown -> neutral
+    assert pose_for_emotion("???") == EMOTION_POSES["neutral"]

--- a/modules/social_db/repositories/persons.py
+++ b/modules/social_db/repositories/persons.py
@@ -163,6 +163,22 @@ class PersonsRepo:
         )
         return [self._row_to_dict(r) for r in rows]
 
+    def adjust_trust(
+        self,
+        person_id: str,
+        delta: float,
+        *,
+        min_score: float = 0.0,
+        max_score: float = 1.0,
+    ) -> float:
+        """Nudge trust_score by delta and return the clamped new value."""
+        rec = self.get_by_id(person_id)
+        if not rec:
+            return 0.0
+        new_score = max(min_score, min(max_score, float(rec.get("trust_score", 0.0)) + float(delta)))
+        updated = self.upsert(name=rec.get("display_name") or rec.get("canonical_name") or "Unknown", trust_score=new_score)
+        return float(updated.get("trust_score", new_score))
+
     def delete(self, person_id: str) -> bool:
         with self.db.transaction() as conn:
             cur = conn.execute("DELETE FROM persons WHERE id = ?", (person_id,))

--- a/modules/speak/config/config.yml
+++ b/modules/speak/config/config.yml
@@ -83,4 +83,12 @@ liveliness:
     chars_per_second: 16
     force: false
 
+# Natural speech: light disfluency/filler injection so replies sound less robotic.
+naturalness:
+  enabled: true
+  filler_probability: 0.22   # chance to prepend a filler to an utterance
+  min_chars: 12              # skip very short replies (e.g. "Evet.")
+  fillers:
+    default: ["Şey,", "Yani,", "Hmm,"]
+
 # note: external compressed audio decoding removed; /speak/play expects base64 WAV

--- a/modules/speak/config/config.yml
+++ b/modules/speak/config/config.yml
@@ -90,5 +90,11 @@ naturalness:
   min_chars: 12              # skip very short replies (e.g. "Evet.")
   fillers:
     default: ["Şey,", "Yani,", "Hmm,"]
+    joy: ["Aa,", "Hey,", "Bak,"]
+    excitement: ["Vay,", "Aa,", "Hey,"]
+    curiosity: ["Hmm,", "Bak,", "Şey,"]
+    sadness: ["Eh,", "Şey...", "Hmm,"]
+    tired: ["Of,", "Hmm,", "Şey,"]
+    anger: ["Bak,", "Yani,"]
 
 # note: external compressed audio decoding removed; /speak/play expects base64 WAV

--- a/modules/speak/tests/test_filler_tone_pools.py
+++ b/modules/speak/tests/test_filler_tone_pools.py
@@ -1,0 +1,55 @@
+"""Emotion/tone-aware filler pool selection."""
+
+from __future__ import annotations
+
+import random
+
+from modules.speak.xSpeakService import SpeakService
+
+
+def _svc():
+    svc = SpeakService.__new__(SpeakService)
+    svc._naturalness_cfg = {
+        "enabled": True,
+        "filler_probability": 1.0,
+        "min_chars": 5,
+        "fillers": {
+            "default": ["Şey,"],
+            "joy": ["Aa,"],
+            "sadness": ["Eh,"],
+            "excitement": ["Vay,"],
+        },
+    }
+    svc._rng = random.Random(0)
+    return svc
+
+
+def test_string_tone_selects_emotion_pool():
+    svc = _svc()
+    # "happy" -> canonical joy -> joy pool
+    out = svc._enrich_text_for_speech("Bugün harika bir gün oldu", tone="happy")
+    assert out.startswith("Aa,")
+
+
+def test_fast_rate_dict_selects_excitement_pool():
+    svc = _svc()
+    out = svc._enrich_text_for_speech("Bunu hemen denemek istiyorum", tone={"rate": 200})
+    assert out.startswith("Vay,")
+
+
+def test_slow_rate_dict_selects_sadness_pool():
+    svc = _svc()
+    out = svc._enrich_text_for_speech("Biraz yorgun hissediyorum bugün", tone={"rate": 145})
+    assert out.startswith("Eh,")
+
+
+def test_unknown_tone_falls_back_to_default_pool():
+    svc = _svc()
+    out = svc._enrich_text_for_speech("Sıradan bir cümle kuruyorum", tone={"rate": 175})
+    assert out.startswith("Şey,")
+
+
+def test_pool_key_resolution_for_aliases():
+    assert SpeakService._pool_key_for_tone("scared") == "fear"
+    assert SpeakService._pool_key_for_tone({"rate": 210}) == "excitement"
+    assert SpeakService._pool_key_for_tone(None) == "default"

--- a/modules/speak/tests/test_naturalness_fillers.py
+++ b/modules/speak/tests/test_naturalness_fillers.py
@@ -1,0 +1,52 @@
+"""Natural-speech filler injection (disfluency)."""
+
+from __future__ import annotations
+
+import random
+
+from modules.speak.xSpeakService import SpeakService
+
+
+def _svc(cfg=None):
+    svc = SpeakService.__new__(SpeakService)
+    svc._naturalness_cfg = cfg if cfg is not None else {
+        "enabled": True,
+        "filler_probability": 0.5,
+        "min_chars": 12,
+        "fillers": {"default": ["Şey,", "Yani,", "Hmm,"]},
+    }
+    svc._rng = random.Random(0)
+    return svc
+
+
+def test_filler_is_prepended_when_roll_succeeds():
+    svc = _svc()
+    out = svc._enrich_text_for_speech("Bugün hava çok güzel görünüyor", rng=random.Random(1))
+    # rng seeded so roll < probability -> a filler is added
+    assert out.split()[0].rstrip(",").lower() in {"şey", "yani", "hmm"}
+
+
+def test_short_text_is_left_alone():
+    svc = _svc()
+    assert svc._enrich_text_for_speech("Evet.") == "Evet."
+
+
+def test_disabled_config_is_noop():
+    svc = _svc({"enabled": False})
+    assert svc._enrich_text_for_speech("Bugün hava çok güzel") == "Bugün hava çok güzel"
+
+
+def test_does_not_stack_when_already_starting_with_filler():
+    svc = _svc()
+    # force probability 1.0
+    svc._naturalness_cfg["filler_probability"] = 1.0
+    text = "Hmm, bu konuyu biraz düşünmem lazım"
+    assert svc._enrich_text_for_speech(text) == text
+
+
+def test_high_probability_always_adds_filler():
+    svc = _svc()
+    svc._naturalness_cfg["filler_probability"] = 1.0
+    out = svc._enrich_text_for_speech("Bu cümle yeterince uzun bir cümledir")
+    assert out != "Bu cümle yeterince uzun bir cümledir"
+    assert out.endswith("Bu cümle yeterince uzun bir cümledir")

--- a/modules/speak/tests/test_tone_prosody.py
+++ b/modules/speak/tests/test_tone_prosody.py
@@ -1,0 +1,59 @@
+"""Emotion tone shapes Piper prosody (length_scale / noise_w)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from modules.speak.xSpeakService import SpeakService
+
+
+@dataclass
+class _DummyPCM:
+    samplerate: int = 22050
+
+
+class _DummyTTS:
+    last_overrides: dict | None = None
+
+    def synthesize(self, text: str, overrides=None):
+        self.last_overrides = overrides
+        return _DummyPCM()
+
+
+class _DummyPlayer:
+    def play_blocking(self, pcm):
+        return 0.5
+
+
+def _piper_service():
+    svc = SpeakService.__new__(SpeakService)
+    svc.cfg = {"tts": {"engine": "piper"}}
+    svc.tts = _DummyTTS()
+    svc.player = _DummyPlayer()
+    svc._liveliness_cfg = {}
+    return svc
+
+
+def test_tone_to_piper_maps_rate_to_length_scale():
+    fast = SpeakService._tone_to_piper({"rate": 200})
+    slow = SpeakService._tone_to_piper({"rate": 140})
+    # Faster speech -> shorter (smaller) length_scale than slower speech.
+    assert fast["length_scale"] < slow["length_scale"]
+    assert SpeakService._tone_to_piper(None) is None
+    assert SpeakService._tone_to_piper({"volume": 0.5}) is None
+
+
+def test_piper_engine_injects_prosody_overrides():
+    svc = _piper_service()
+    svc.speak("Merhaba", tone="excited")  # excited -> rate 200
+    ov = svc.tts.last_overrides
+    assert ov is not None and "piper" in ov
+    assert "length_scale" in ov["piper"]
+    assert ov["piper"]["length_scale"] < 1.0  # faster than baseline
+
+
+def test_non_piper_engine_does_not_inject_piper_block():
+    svc = _piper_service()
+    svc.cfg = {"tts": {"engine": "dummy"}}
+    svc.speak("Merhaba", tone="excited")
+    assert "piper" not in (svc.tts.last_overrides or {})

--- a/modules/speak/xSpeakService.py
+++ b/modules/speak/xSpeakService.py
@@ -68,6 +68,28 @@ class SpeakService:
         logger.warning("unsupported tone type %s, ignoring", type(tone).__name__)
         return None
 
+    @staticmethod
+    def _tone_to_piper(tone: Optional[dict]) -> Optional[dict]:
+        """Translate a rate/volume tone into Piper prosody knobs.
+
+        Piper ignores pyttsx3-style ``rate``/``volume``; the only way emotion
+        actually colours Piper audio is via ``length_scale`` (pace) and
+        ``noise_w`` (expressiveness/variability). Baseline rate is 170.
+        """
+        if not isinstance(tone, dict):
+            return None
+        rate = tone.get("rate")
+        if not isinstance(rate, (int, float)) or rate <= 0:
+            return None
+        # Faster speech -> shorter length_scale. Clamp to a natural range.
+        length_scale = max(0.6, min(1.6, 170.0 / float(rate)))
+        # Livelier (faster) speech gets a touch more variability.
+        noise_w = max(0.4, min(1.1, 0.8 * (float(rate) / 170.0)))
+        return {
+            "length_scale": round(length_scale, 3),
+            "noise_w": round(noise_w, 3),
+        }
+
     def _post_interactions(self, endpoint: str, payload: dict) -> None:
         if requests is None:
             return
@@ -352,6 +374,12 @@ class SpeakService:
             overrides["speaker_wav"] = speaker_wav
         if language:
             overrides["language"] = language
+        # Shape Piper audio from the emotion tone (rate/volume don't reach Piper).
+        active_engine = str(engine or self.cfg.get("tts", {}).get("engine", "")).strip().lower()
+        if active_engine == "piper":
+            piper_prosody = self._tone_to_piper(tone_dict)
+            if piper_prosody:
+                overrides["piper"] = {**overrides.get("piper", {}), **piper_prosody}
         self._emit_speech_liveliness_start(cleaned_text, tone_dict)
         try:
             from modules.speak.services.tts import clear_synthesis_cancel

--- a/modules/speak/xSpeakService.py
+++ b/modules/speak/xSpeakService.py
@@ -72,11 +72,34 @@ class SpeakService:
         logger.warning("unsupported tone type %s, ignoring", type(tone).__name__)
         return None
 
+    @staticmethod
+    def _pool_key_for_tone(tone: Any) -> str:
+        """Pick a filler-pool key from a tone (string emotion or rate/volume dict)."""
+        if isinstance(tone, str) and tone.strip():
+            try:
+                from modules.common.emotion_vocab import get_vocab
+
+                return get_vocab().canonical(tone)
+            except Exception:
+                return tone.strip().lower()
+        if isinstance(tone, dict):
+            rate = tone.get("rate")
+            if isinstance(rate, (int, float)):
+                if rate >= 195:
+                    return "excitement"
+                if rate <= 150:
+                    return "sadness"
+        return "default"
+
     def _filler_pool(self, tone: Any) -> list:
         cfg = getattr(self, "_naturalness_cfg", {}) or {}
         pools = cfg.get("fillers", {}) if isinstance(cfg, dict) else {}
         if not isinstance(pools, dict):
             return []
+        key = self._pool_key_for_tone(tone)
+        pool = pools.get(key)
+        if isinstance(pool, list) and pool:
+            return list(pool)
         return list(pools.get("default", []) or [])
 
     def _enrich_text_for_speech(self, text: str, tone: Any = None, rng=None) -> str:

--- a/modules/speak/xSpeakService.py
+++ b/modules/speak/xSpeakService.py
@@ -44,10 +44,14 @@ class SpeakService:
     """Metni sese dönüştürüp MAX98357A üzerinden çalar."""
 
     def __init__(self, config_path: Optional[str] = None):
+        import random
+
         self.cfg = load_config(config_path)
         self.tts = TextToSpeech(self.cfg.get("tts", {}))
         self.player = AudioPlayer(self.cfg.get("audio_out", {}))
         self._liveliness_cfg = self.cfg.get("liveliness", {}) or {}
+        self._naturalness_cfg = self.cfg.get("naturalness", {}) or {}
+        self._rng = random.Random()
 
     @staticmethod
     def _coerce_tone(tone: Any) -> Optional[dict]:
@@ -67,6 +71,39 @@ class SpeakService:
             return None
         logger.warning("unsupported tone type %s, ignoring", type(tone).__name__)
         return None
+
+    def _filler_pool(self, tone: Any) -> list:
+        cfg = getattr(self, "_naturalness_cfg", {}) or {}
+        pools = cfg.get("fillers", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(pools, dict):
+            return []
+        return list(pools.get("default", []) or [])
+
+    def _enrich_text_for_speech(self, text: str, tone: Any = None, rng=None) -> str:
+        """Optionally prepend a natural filler so speech sounds less scripted.
+
+        Runs *after* :meth:`_clean_text_for_speech`, so fillers like "Hmm,"
+        are not stripped as meta-reasoning. Best-effort and probabilistic.
+        """
+        cfg = getattr(self, "_naturalness_cfg", {})
+        cfg = cfg if isinstance(cfg, dict) else {}
+        if not cfg.get("enabled", False):
+            return text
+        body = (text or "").strip()
+        if len(body) < int(cfg.get("min_chars", 12)):
+            return text
+        # Don't stack fillers if the line already opens with one.
+        first_word = re.match(r"^[^\W\d_]+", body, re.UNICODE)
+        if first_word and first_word.group(0).lower() in {"hmm", "şey", "sey", "yani", "eh", "of", "aa"}:
+            return text
+        pool = self._filler_pool(tone)
+        if not pool:
+            return text
+        roll = (rng or self._rng).random()
+        if roll >= float(cfg.get("filler_probability", 0.2)):
+            return text
+        filler = (rng or self._rng).choice(pool)
+        return f"{filler} {body}"
 
     @staticmethod
     def _tone_to_piper(tone: Optional[dict]) -> Optional[dict]:
@@ -366,6 +403,7 @@ class SpeakService:
             logger.info("Speech text is empty after cleaning thoughts/markdown. Skipping.")
             return {"ok": True, "engine": engine or "default", "duration_sec": 0.0, "samplerate": 22050}
 
+        cleaned_text = self._enrich_text_for_speech(cleaned_text, tone=tone)
         tone_dict = self._coerce_tone(tone)
         overrides = dict(tone_dict or {})
         if engine:

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -761,6 +761,44 @@ class VisionProcessor:
         churn = prev ^ sig
         return len(churn) / len(union)
 
+    def _person_signals(self, parsed_results: List[Dict[str, Any]]) -> Tuple[bool, bool]:
+        """Derive (owner_seen, new_person) from the current detections."""
+        owner_seen = False
+        new_person = False
+        seen = getattr(self, "_seen_person_names", set())
+        current: set = set()
+        for r in parsed_results or []:
+            if not isinstance(r, dict):
+                continue
+            name = str(r.get("name") or "").strip()
+            if not name or name.lower() == "unknown":
+                continue
+            current.add(name)
+            rel = str(r.get("relationship") or "").lower()
+            level = r.get("recognition_level")
+            if rel in {"owner", "family"} or (isinstance(level, (int, float)) and level >= 5):
+                owner_seen = True
+            if name not in seen:
+                new_person = True
+        # Bound the memory so a long session doesn't accumulate stale names.
+        self._seen_person_names = (seen | current) if len(seen) < 64 else set(current)
+        return owner_seen, new_person
+
+    def _hazard_signal(self, parsed_results: List[Dict[str, Any]]) -> bool:
+        """Lightweight proximity-hazard check mirroring alert thresholds."""
+        alerts_cfg = getattr(self, "config", {}).get("vision", {}).get("alerts", {})
+        if not alerts_cfg or not getattr(self, "mode_flags", {}).get("hazards", True):
+            return False
+        classes = {str(c) for c in alerts_cfg.get("classes", [])}
+        dist_thr = float(alerts_cfg.get("distance_threshold_m", 1.0))
+        for r in parsed_results or []:
+            if not isinstance(r, dict):
+                continue
+            dist = r.get("distance_m")
+            if str(r.get("label") or "") in classes and isinstance(dist, (int, float)) and float(dist) <= dist_thr:
+                return True
+        return False
+
     def _maybe_sample_vlm(self, parsed_results: List[Dict[str, Any]]) -> None:
         sampler = getattr(self, "vision_sampler", None)
         if sampler is None:
@@ -768,10 +806,20 @@ class VisionProcessor:
         if getattr(self, "_vlm_refresh_inflight", False):
             return
         score = self._scene_change_score(parsed_results)
+        owner_seen, new_person = self._person_signals(parsed_results)
+        hazard = self._hazard_signal(parsed_results)
+        # Treat a large scene churn spike as sudden motion in the field of view.
+        sudden_motion = score >= max(getattr(self, "_sudden_motion_threshold", 0.7), sampler.scene_change_threshold + 0.25)
+        is_bored = bool(getattr(self, "_is_bored", False))
         try:
             should = sampler.should_call_vlm(
                 scene_change_score=score,
                 follow_mode_active=bool(getattr(self, "_follow_active", False)),
+                owner_seen=owner_seen,
+                new_person=new_person,
+                hazard_detected=hazard,
+                sudden_motion=sudden_motion,
+                is_bored=is_bored,
             )
         except Exception:
             return

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -1503,14 +1503,14 @@ class VisionProcessor:
                     "raw_vlm_observation": str(vlm_result.get("raw_text", "")),
                     "persona_interpretation": str(vlm_result.get("summary", "")),
                 }
-                self.update_visual_context(context)
+                self.update_visual_context(context, is_user_question=bool(question))
                 latest = self.get_latest_visual_context()
                 if latest is not None:
                     return latest
 
         fallback = self._build_context_from_results(self.latest_results)
         if fallback is not None:
-            self.update_visual_context(fallback)
+            self.update_visual_context(fallback, is_user_question=bool(question))
             return self.get_latest_visual_context()
         return None
 
@@ -1553,8 +1553,19 @@ class VisionProcessor:
             "persona_interpretation": summary,
         }
 
-    def update_visual_context(self, context: Optional[Dict[str, Any]]) -> None:
-        """Update the cached visual context (typically called by VLM after processing)."""
+    def update_visual_context(
+        self,
+        context: Optional[Dict[str, Any]],
+        *,
+        is_user_question: bool = False,
+        is_scene_change: bool = True,
+    ) -> None:
+        """Update the cached visual context (typically called by VLM after processing).
+
+        Importance is (re)derived from the scene content via ``compute_importance``
+        instead of trusting the caller's hardcoded guess, so hazards/owner/novelty
+        actually drive how loudly the robot reacts.
+        """
         if self.visual_context_cache is None or context is None:
             return
         try:
@@ -1563,7 +1574,7 @@ class VisionProcessor:
                 self.visual_context_cache.set_context(context)
             else:
                 # Direct assignment if it's a VisualContextCache
-                from .visual_context import VisionFrameContext, PersonContext
+                from .visual_context import VisionFrameContext, PersonContext, compute_importance
                 vfc = VisionFrameContext(
                     timestamp=context.get("timestamp", ""),
                     summary=context.get("summary", ""),
@@ -1576,6 +1587,18 @@ class VisionProcessor:
                     raw_vlm_observation=context.get("raw_vlm_observation", ""),
                     persona_interpretation=context.get("persona_interpretation", ""),
                 )
+                prev_id = getattr(self.visual_context_cache, "previous_scene_id", "")
+                derived = compute_importance(
+                    vfc,
+                    is_user_question=is_user_question,
+                    is_scene_change=is_scene_change,
+                    is_follow_active=bool(getattr(self, "_follow_active", False)),
+                    previous_scene_id=prev_id,
+                )
+                # Keep the stronger of caller-supplied vs derived so an explicit
+                # high-priority refresh (e.g. user question) is never down-graded.
+                vfc.importance_score = max(float(context.get("importance_score", 0.0) or 0.0), derived)
+                context["importance_score"] = vfc.importance_score
                 self.visual_context_cache.update(vfc)
         except Exception as exc:
             logger.debug("Failed to update visual context: %s", exc)

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -1191,6 +1191,10 @@ class VisionProcessor:
         self.latest_results = normalized
         self._evaluate_alerts(normalized)
         self._handle_person_interactions(normalized)
+        # Remote mode has no local inference loop, so drive continuous perception
+        # (living-vision sampling) here too — otherwise the default `remote`
+        # processing mode would never refresh scene context on its own.
+        self._maybe_sample_vlm(normalized)
         if self.blind_mode_enabled and normalized:
             self._handle_blind_mode(normalized)
         if normalized and self.mode_flags.get("semantic_scene", True):

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -75,12 +75,21 @@ except Exception:
     VisionSampler = None  # type: ignore
 
 try:
-    from .vision_event_bus import VisionEventBus, EVENT_HAZARD_DETECTED, EVENT_NEW_PERSON, EVENT_OWNER_SEEN
+    from .vision_event_bus import (
+        VisionEventBus,
+        EVENT_HAZARD_DETECTED,
+        EVENT_NEW_PERSON,
+        EVENT_OWNER_SEEN,
+        EVENT_SCENE_CHANGED,
+        EVENT_VLM_RESULT_READY,
+    )
 except Exception:
     VisionEventBus = None  # type: ignore
     EVENT_HAZARD_DETECTED = "hazard_detected"
     EVENT_NEW_PERSON = "new_person"
     EVENT_OWNER_SEEN = "owner_seen"
+    EVENT_SCENE_CHANGED = "scene_changed"
+    EVENT_VLM_RESULT_READY = "vlm_result_ready"
 
 try:
     from .head_control_arbiter import HeadControlArbiter, HeadCommand
@@ -708,6 +717,10 @@ class VisionProcessor:
                     parsed_results = list(parsed_results) + extras
             self.latest_results = parsed_results
 
+            # Continuous "living vision": let the sampler decide when to refresh
+            # the richer VLM scene context (idle cadence + scene-change driven).
+            self._maybe_sample_vlm(parsed_results)
+
             # Follow aktifken VLM sahne aksiyonu / tehlike anonsu bastirilir,
             # odak yuz kilidi ve takip akisinda kalir.
             self._handle_person_interactions(parsed_results)
@@ -724,6 +737,60 @@ class VisionProcessor:
                     self._latest_annotated_frame = buf.tobytes()
 
             time.sleep(0.05)
+
+    # -----------------------------------------------------------------
+    # Living-vision sampling
+    # -----------------------------------------------------------------
+    @staticmethod
+    def _scene_signature(parsed_results: List[Dict[str, Any]]) -> frozenset:
+        sig = set()
+        for r in parsed_results or []:
+            if isinstance(r, dict):
+                sig.add((str(r.get("label", "")), str(r.get("name", ""))))
+        return frozenset(sig)
+
+    def _scene_change_score(self, parsed_results: List[Dict[str, Any]]) -> float:
+        sig = self._scene_signature(parsed_results)
+        prev = getattr(self, "_last_scene_signature", None)
+        self._last_scene_signature = sig
+        if prev is None:
+            return 0.0
+        union = prev | sig
+        if not union:
+            return 0.0
+        churn = prev ^ sig
+        return len(churn) / len(union)
+
+    def _maybe_sample_vlm(self, parsed_results: List[Dict[str, Any]]) -> None:
+        sampler = getattr(self, "vision_sampler", None)
+        if sampler is None:
+            return
+        if getattr(self, "_vlm_refresh_inflight", False):
+            return
+        score = self._scene_change_score(parsed_results)
+        try:
+            should = sampler.should_call_vlm(
+                scene_change_score=score,
+                follow_mode_active=bool(getattr(self, "_follow_active", False)),
+            )
+        except Exception:
+            return
+        if not should:
+            return
+        sampler.record_call()
+        self._vlm_refresh_inflight = True
+        threading.Thread(target=self._background_context_refresh, daemon=True).start()
+
+    def _background_context_refresh(self) -> None:
+        try:
+            context = self.refresh_visual_context()
+            if context is not None and self.event_bus is not None:
+                self.event_bus.publish(EVENT_SCENE_CHANGED, {"context": context})
+                self.event_bus.publish(EVENT_VLM_RESULT_READY, {"context": context})
+        except Exception:
+            pass
+        finally:
+            self._vlm_refresh_inflight = False
 
     # -----------------------------------------------------------------
     # Core analysis

--- a/modules/vlm_bridge/tests/test_vision_sampler_wiring.py
+++ b/modules/vlm_bridge/tests/test_vision_sampler_wiring.py
@@ -71,3 +71,39 @@ def test_follow_mode_suppresses_sampling():
     proc._maybe_sample_vlm([{"label": "person", "name": "Y"}])
     time.sleep(0.1)
     assert proc.event_bus.events == []
+
+
+def test_owner_seen_triggers_sampling_even_without_scene_churn():
+    proc = _bare_processor()
+    calls = {"n": 0}
+    proc.refresh_visual_context = lambda question="": (calls.__setitem__("n", calls["n"] + 1) or {"summary": "owner"})  # type: ignore
+
+    # An owner-level recognition should warrant a VLM look despite zero churn
+    # (same signature on the second call -> scene_change_score == 0).
+    owner_det = [{"label": "person", "name": "Emir", "recognition_level": 6}]
+    proc._maybe_sample_vlm(owner_det)
+    proc._maybe_sample_vlm(owner_det)
+
+    for _ in range(50):
+        if calls["n"] > 0 and not proc._vlm_refresh_inflight:
+            break
+        time.sleep(0.02)
+    assert calls["n"] >= 1
+
+
+def test_person_signals_flags_owner_and_new_person():
+    proc = _bare_processor()
+    owner, new = proc._person_signals([{"name": "Emir", "relationship": "owner"}])
+    assert owner is True and new is True
+    # second sighting of same name -> no longer "new"
+    _, new_again = proc._person_signals([{"name": "Emir", "relationship": "owner"}])
+    assert new_again is False
+
+
+def test_hazard_signal_respects_distance_threshold():
+    proc = _bare_processor()
+    proc.config = {"vision": {"alerts": {"classes": ["knife"], "distance_threshold_m": 1.0}}}
+    proc.mode_flags = {"hazards": True}
+    assert proc._hazard_signal([{"label": "knife", "distance_m": 0.5}]) is True
+    assert proc._hazard_signal([{"label": "knife", "distance_m": 2.0}]) is False
+    assert proc._hazard_signal([{"label": "cup", "distance_m": 0.1}]) is False

--- a/modules/vlm_bridge/tests/test_vision_sampler_wiring.py
+++ b/modules/vlm_bridge/tests/test_vision_sampler_wiring.py
@@ -107,3 +107,26 @@ def test_hazard_signal_respects_distance_threshold():
     assert proc._hazard_signal([{"label": "knife", "distance_m": 0.5}]) is True
     assert proc._hazard_signal([{"label": "knife", "distance_m": 2.0}]) is False
     assert proc._hazard_signal([{"label": "cup", "distance_m": 0.1}]) is False
+
+
+def test_remote_ingest_drives_living_vision_sampling():
+    proc = _bare_processor()
+    proc.processing_mode = "remote"
+    proc.mode_flags = {}
+    proc.blind_mode_enabled = False
+    proc.config = {}
+    sampled = {"calls": []}
+    proc._maybe_sample_vlm = lambda results: sampled["calls"].append(results)  # type: ignore
+    proc._evaluate_alerts = lambda r: None  # type: ignore
+    proc._handle_person_interactions = lambda r: None  # type: ignore
+
+    class _Dispatcher:
+        def emit_scene(self, *a, **k):
+            pass
+
+    proc.action_dispatcher = _Dispatcher()
+    proc.semantic = object()
+
+    proc.ingest_remote_results([{"label": "person", "name": "Z", "confidence": 0.8}])
+    assert len(sampled["calls"]) == 1
+    assert sampled["calls"][0][0]["label"] == "person"

--- a/modules/vlm_bridge/tests/test_vision_sampler_wiring.py
+++ b/modules/vlm_bridge/tests/test_vision_sampler_wiring.py
@@ -1,0 +1,73 @@
+"""Verifies the VisionSampler is wired into the processor's living-vision loop."""
+
+from __future__ import annotations
+
+import time
+
+from modules.vlm_bridge.services.processor import VisionProcessor
+from modules.vlm_bridge.services.vision_sampler import VisionSampler
+
+
+class _FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def publish(self, event_type, data=None):
+        self.events.append((event_type, data))
+
+
+def _bare_processor():
+    proc = VisionProcessor.__new__(VisionProcessor)
+    proc.vision_sampler = VisionSampler({"min_interval_s": 0.0, "scene_change_threshold": 0.3})
+    proc.event_bus = _FakeBus()
+    proc._follow_active = False
+    proc._vlm_refresh_inflight = False
+    proc._last_scene_signature = None
+    return proc
+
+
+def test_scene_change_score_detects_churn():
+    proc = _bare_processor()
+    # first observation establishes a baseline -> no change
+    assert proc._scene_change_score([{"label": "person", "name": "A"}]) == 0.0
+    # same scene -> no churn
+    assert proc._scene_change_score([{"label": "person", "name": "A"}]) == 0.0
+    # a new object appears -> non-zero churn
+    score = proc._scene_change_score([{"label": "person", "name": "A"}, {"label": "cup", "name": ""}])
+    assert score > 0.0
+
+
+def test_sampler_triggers_background_refresh_and_publishes():
+    proc = _bare_processor()
+    calls = {"n": 0}
+
+    def _fake_refresh(question: str = ""):
+        calls["n"] += 1
+        return {"summary": "a room"}
+
+    proc.refresh_visual_context = _fake_refresh  # type: ignore[assignment]
+
+    # establish baseline then introduce a strong scene change
+    proc._maybe_sample_vlm([])
+    proc._maybe_sample_vlm([{"label": "person", "name": "X"}, {"label": "dog", "name": ""}])
+
+    # background refresh runs on a daemon thread
+    for _ in range(50):
+        if calls["n"] > 0 and not proc._vlm_refresh_inflight:
+            break
+        time.sleep(0.02)
+
+    assert calls["n"] >= 1
+    published = {evt for evt, _ in proc.event_bus.events}
+    assert "scene_changed" in published
+    assert "vlm_result_ready" in published
+
+
+def test_follow_mode_suppresses_sampling():
+    proc = _bare_processor()
+    proc._follow_active = True
+    proc.refresh_visual_context = lambda question="": {"summary": "x"}  # type: ignore[assignment]
+    proc._maybe_sample_vlm([])
+    proc._maybe_sample_vlm([{"label": "person", "name": "Y"}])
+    time.sleep(0.1)
+    assert proc.event_bus.events == []

--- a/modules/vlm_bridge/tests/test_visual_importance.py
+++ b/modules/vlm_bridge/tests/test_visual_importance.py
@@ -1,0 +1,50 @@
+"""Visual context importance is derived from scene content, not hardcoded."""
+
+from __future__ import annotations
+
+from modules.vlm_bridge.services.processor import VisionProcessor
+from modules.vlm_bridge.services.visual_context import VisualContextCache
+
+
+def _proc_with_cache():
+    proc = VisionProcessor.__new__(VisionProcessor)
+    proc.visual_context_cache = VisualContextCache(max_history=3)
+    proc._follow_active = False
+    return proc
+
+
+def test_hazard_scene_scores_higher_than_empty_scene():
+    proc = _proc_with_cache()
+
+    proc.update_visual_context({"summary": "empty room", "people": [], "objects": [], "hazards": []})
+    empty = proc.visual_context_cache.get_latest().importance_score
+
+    proc.update_visual_context(
+        {"summary": "knife nearby", "people": [], "objects": [],
+         "hazards": [{"label": "knife", "distance_m": 0.4}]}
+    )
+    hazard = proc.visual_context_cache.get_latest().importance_score
+
+    assert hazard > empty
+    assert hazard >= 0.7  # hazard weight dominates
+
+
+def test_owner_present_raises_importance():
+    proc = _proc_with_cache()
+    proc.update_visual_context(
+        {"summary": "owner here", "objects": [], "hazards": [],
+         "people": [{"name": "Emir", "recognition_level": 6, "confidence": 0.9}]}
+    )
+    score = proc.visual_context_cache.get_latest().importance_score
+    assert score >= 0.4
+
+
+def test_caller_high_importance_is_not_downgraded():
+    proc = _proc_with_cache()
+    # An empty scene would derive low importance, but an explicit user question
+    # must keep a high floor.
+    proc.update_visual_context(
+        {"summary": "nothing", "people": [], "objects": [], "hazards": [], "importance_score": 0.9},
+        is_user_question=True,
+    )
+    assert proc.visual_context_cache.get_latest().importance_score >= 0.9


### PR DESCRIPTION
## Özet
SentryBOT companion canlılık (liveliness) yol haritasının 7 fazını `dev`'e birleştirir: ifade/algı temeli, birleşik duygu modeli, hafıza/RAG, sürekli çevre algısı, doğal konuşma, firmware liveliness köprüsü ve öğrenme/adaptasyon. Robotun çok modlu ifadesi, çevre anlama, konuşma doğallığı ve kişiye özel öğrenme döngüsü tamamlanır.

## Değişiklik tipi
- [x] Hata düzeltmesi
- [x] Yeni özellik
- [x] Refactor
- [x] Dokümantasyon güncellemesi
- [x] Test güncellemesi

## Etkilenen modüller
`modules/common`, `modules/oled_faces`, `modules/neopixel`, `modules/piservo`, `modules/vlm_bridge`, `modules/agent_core`, `modules/autonomy`, `modules/speak`, `modules/arduino_serial`, `modules/social_db`, `modules/gateway`, `modules/interactions`, `arduino/firmware/xMain`

## Faz özeti (birleştirilen PR'lar)
- **#140** Phase 0 — Expression & perception foundation (procedural OLED, NeoPixel segments, VisionSampler)
- **#138** Phase 1 — Unified emotion model & expression director (anger axis, affective appraisal, canonical vocab)
- **#139** Phase 2 — Unified memory & context-aware RAG recall (TF-IDF, MemoryConsolidator, proactive recall)
- **#141** Phase 3 — Continuous environment perception (WorldState environment, scene narration)
- **#142** Phase 4 — Natural speech (Piper prosody, fillers, barge-in)
- **#143** Phase 5 — Firmware liveliness bridge (`liveliness` contract + firmware breathing)
- **#144** Phase 6 — Learning & adaptation (PreferenceLearner, trust_score, search_social_memory)

## Doğrulama
- [x] Lokal çalıştırma tamamlandı (PC mock/sim)
- [x] İlgili testler geçiyor (154+ pytest)
- [x] Gerekli doküman/konfig güncellemeleri yapıldı (`.sentrybot/context/architecture-summary.md`)

## Arduino Kontrat Kontrolü
- [x] `contract.py` dışında elle Arduino payload yazılmadı
- [x] Yeni `liveliness` komutu builder + validator + gateway test içeriyor
- [x] Kritik komutlar `/arduino/request` kullanıyor

## Risk ve geri alma
Orta-düşük risk; davranış değişiklikleri config ile kısıtlanabilir (`companion.learning`, `liveliness`, `naturalness`). Geri alma: bu PR revert veya `main`'e önceki release tag.

## İlgili issue
N/A — companion liveliness roadmap (7 faz)
