### PR TITLE
feat(autonomy): companion expression, Turkish emotions, and OLED listen faces

### DIFF
--- a/modules/autonomy/config/config.yml
+++ b/modules/autonomy/config/config.yml
@@ -3,6 +3,8 @@ defaults:
   boredom_threshold_s: 20
   mood:
     decay_rate: 0.5
+    anger_threshold: 38
+    furious_threshold: 75
     initial_happiness: 50
     initial_energy: 100
     max_happiness: 100
@@ -156,8 +158,13 @@ request_timeouts:
   ollama_warmup_s: 2.5
   speech_min_interval_s: 0.8
 
+speech_reactions:
+  excited_on_speech: false
+  excited_on_praise: true
+  excited_on_questions: false
+
 visual_state:
-  emotion_min_interval_s: 2.2
+  emotion_min_interval_s: 1.8
   default_lock_s: 2.4
   strong_lock_s: 4.8
   state_hold_s: 3.2
@@ -228,6 +235,19 @@ vision_hooks:
     far_distance_m: 3.0
     near_multiplier: 0.6
     far_multiplier: 1.3
+  empathy:
+    enabled: true
+    cooldown_s: 28
+    mirror:
+      - joy
+      - sadness
+      - fear
+      - worried
+    speak_on_mirror: true
+
+empathy:
+  enabled: true
+  cooldown_s: 28
 
 scenes:
   wakeword_reaction:
@@ -386,6 +406,66 @@ scenes:
       - { type: effect_burst, name: "PULSE", duration_ms: 120, count: 4, interval_ms: 60 }
       - { type: effect, name: "SOLID", color: "#FF0000" }
       - { type: event, name: "scene.emotion_furious.end" }
+
+  emotion_sadness:
+    steps:
+      - { type: event, name: "scene.emotion_sadness.start" }
+      - { type: preset, name: "emotion_sadness" }
+      - { type: effect, name: "PULSE", duration_ms: 600 }
+      - { type: head, pan: 90, tilt: 100 }
+      - { type: event, name: "scene.emotion_sadness.end" }
+
+  emotion_love:
+    steps:
+      - { type: event, name: "scene.emotion_love.start" }
+      - { type: preset, name: "emotion_love" }
+      - { type: effect, name: "PULSE", duration_ms: 700, color: "#FF2864" }
+      - { type: event, name: "scene.emotion_love.end" }
+
+  emotion_surprise:
+    steps:
+      - { type: event, name: "scene.emotion_surprise.start" }
+      - { type: preset, name: "emotion_surprise" }
+      - { type: effect_burst, name: "TWINKLE", duration_ms: 150, count: 3, interval_ms: 70 }
+      - { type: event, name: "scene.emotion_surprise.end" }
+
+  emotion_excitement:
+    steps:
+      - { type: event, name: "scene.emotion_excitement.start" }
+      - { type: preset, name: "emotion_excitement" }
+      - { type: effect_burst, name: "RAINBOW_CYCLE", duration_ms: 200, count: 2, interval_ms: 80 }
+      - { type: event, name: "scene.emotion_excitement.end" }
+
+  emotion_bored:
+    steps:
+      - { type: event, name: "scene.emotion_bored.start" }
+      - { type: preset, name: "emotion_bored" }
+      - { type: head, pan: 88, tilt: 95 }
+      - { type: effect, name: "BREATHE", duration_ms: 900, color: "#3C3C3C" }
+      - { type: event, name: "scene.emotion_bored.end" }
+
+  emotion_worried:
+    steps:
+      - { type: event, name: "scene.emotion_worried.start" }
+      - { type: preset, name: "emotion_worried" }
+      - { type: effect, name: "BREATHE", duration_ms: 800, color: "#B46400" }
+      - { type: head, pan: 92, tilt: 98 }
+      - { type: event, name: "scene.emotion_worried.end" }
+
+  emotion_confusion:
+    steps:
+      - { type: event, name: "scene.emotion_confusion.start" }
+      - { type: preset, name: "emotion_confusion" }
+      - { type: effect, name: "TWINKLE", duration_ms: 500, color: "#A000C8" }
+      - { type: head, pan: 85, tilt: 92 }
+      - { type: event, name: "scene.emotion_confusion.end" }
+
+  emotion_neutral:
+    steps:
+      - { type: event, name: "scene.emotion_neutral.start" }
+      - { type: preset, name: "calm_idle" }
+      - { type: effect, name: "BREATHE", duration_ms: 600, color: "#283C50" }
+      - { type: event, name: "scene.emotion_neutral.end" }
 
 owner:
   enabled: true

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -282,7 +282,7 @@ class AutonomyBrain(
         self._apply_emotion_visual_state(target_emotion)
         # Try to run a matching scene for the dominant emotion (e.g. emotion_joy)
         try:
-            scene_name = f"emotion_{target_emotion}"
+            scene_name = self._emotion_scene_name(target_emotion)
             ran = self._run_scene(scene_name, context={"emotion": target_emotion})
             if ran:
                 # emit a scene-level interaction event for other subsystems
@@ -292,6 +292,16 @@ class AutonomyBrain(
                     pass
         except Exception:
             logger.debug("Failed to run emotion scene %s", scene_name, exc_info=True)
+
+    _EMOTION_SCENE_ALIASES = {
+        "sadness": "emotion_sad",
+        "anger": "emotion_angry",
+    }
+
+    @classmethod
+    def _emotion_scene_name(cls, emotion: str) -> str:
+        key = str(emotion or "neutral").strip().lower()
+        return cls._EMOTION_SCENE_ALIASES.get(key, f"emotion_{key}")
 
     def express(self, emotion: str, *, say: Optional[str] = None, language: Optional[str] = None) -> str:
         """Deliberately express an emotion across all modalities at once.
@@ -341,6 +351,115 @@ class AutonomyBrain(
         if any(tok in low for tok in praise):
             return "user_praise"
         return None
+
+    def _maybe_emit_speech_excited(self, text: str, sentiment_event: Optional[str]) -> None:
+        """Emit autonomy.excited only when configured — not on every utterance."""
+        cfg = self.config.get("speech_reactions", {}) if isinstance(self.config.get("speech_reactions"), dict) else {}
+        if sentiment_event == "user_praise" and cfg.get("excited_on_praise", True):
+            self.client.push_interaction_event("autonomy.excited")
+            return
+        if cfg.get("excited_on_speech", False):
+            self.client.push_interaction_event("autonomy.excited")
+            return
+        if cfg.get("excited_on_questions", False):
+            low = str(text or "").lower()
+            if "?" in text or any(w in low for w in ("nedir", "nasıl", "what", "who", "how")):
+                self.client.push_interaction_event("autonomy.excited")
+
+    _EMOTION_COMMAND_PHRASES = (
+        ("anger", ("sinirlen", "sinirli ol", "kizgin ol", "kızgın ol", "ofkeli ol", "öfkeli ol", "angry ol", "sinirli")),
+        ("furious", ("cok sinirli", "çok sinirli", "delir", "cildir", "öfke", "ofke")),
+        ("joy", ("mutlu ol", "sevin", "neselen", "neşelen", "gul", "gül")),
+        ("sadness", ("uzul", "üzül", "mutsuz ol", "uzgun ol", "üzgün ol")),
+        ("fear", ("kork", "korkut", "korkma")),
+        ("surprise", ("sasir", "şaşır", "saskin", "şaşkın")),
+        ("bored", ("sikil", "sıkıl", "sikildim", "sıkıldım")),
+        ("tired", ("yorul", "uyu", "uykum var")),
+        ("love", ("beni sev", "askim ol", "aşkım ol")),
+        ("excitement", ("heyecanlan", "heyecanli ol", "heyecanlı ol")),
+        ("confusion", ("kafan karisik", "kafan karışık", "anlamadim", "anlamadım")),
+        ("worried", ("endiselen", "endişelen", "kaygilan")),
+        ("curiosity", ("merak et", "merakli ol")),
+    )
+
+    @classmethod
+    def _emotion_command_for_text(cls, text: str) -> Optional[str]:
+        low = str(text or "").lower().strip()
+        if not low:
+            return None
+        for canon, phrases in cls._EMOTION_COMMAND_PHRASES:
+            if any(p in low for p in phrases):
+                return canon
+        try:
+            from modules.common.emotion_vocab import get_vocab
+
+            vocab = get_vocab()
+            for token in low.replace(",", " ").split():
+                key = token.strip("!.?")
+                if len(key) < 4:
+                    continue
+                canon = vocab.canonical(key)
+                if canon not in {"neutral", "curiosity"}:
+                    return canon
+        except Exception:
+            pass
+        return None
+
+    @staticmethod
+    def _emotion_command_reply(canon: str, lang: str) -> str:
+        tr_replies = {
+            "anger": "Tamam, sinirliyim! Ne istiyorsun?",
+            "furious": "Çok sinirliyim! Dikkat et!",
+            "joy": "Harika, mutluyum!",
+            "sadness": "Tamam... biraz üzgünüm.",
+            "fear": "Korkuyorum...",
+            "surprise": "Vay! Şaşırdım!",
+            "bored": "Sıkıldım galiba.",
+            "tired": "Yorgunum...",
+            "love": "Seni de seviyorum!",
+            "excitement": "Heyecanlandım!",
+            "confusion": "Kafam karıştı...",
+            "worried": "Biraz endişeliyim.",
+            "curiosity": "Merak ettim!",
+            "neutral": "Tamam.",
+        }
+        en_replies = {
+            "anger": "Fine, I'm angry! What do you want?",
+            "furious": "I'm furious! Watch out!",
+            "joy": "I'm happy!",
+            "neutral": "Okay.",
+        }
+        replies = tr_replies if str(lang or "tr").startswith("tr") else en_replies
+        return replies.get(str(canon or "neutral"), replies.get("neutral", "Okay."))
+
+    def _handle_emotion_command(self, text: str, lang: str) -> bool:
+        cmd = self._emotion_command_for_text(text)
+        if not cmd:
+            return False
+        mood_axis = {
+            "anger": "anger",
+            "furious": "anger",
+            "joy": "happiness",
+            "fear": "fear",
+            "sadness": "sadness",
+            "excitement": "happiness",
+            "love": "happiness",
+        }
+        axis = mood_axis.get(cmd)
+        if axis:
+            self.mood.modify(axis, 40)
+        reply = self._emotion_command_reply(cmd, lang)
+        canon = self.express(cmd, say=reply, language=lang)
+        self.state["last_emotion"] = canon
+        self.client.update_emotions([canon])
+        visual = self._normalize_emotion_name(canon)
+        try:
+            self._run_scene(f"emotion_{visual}", context={"emotion": canon})
+        except Exception:
+            pass
+        self.memory.add_event(f"User asked me to express: {cmd}")
+        logger.info("Emotion command handled: %s -> %s", text, canon)
+        return True
 
     def _think(self):
         now = time.time()
@@ -750,12 +869,6 @@ class AutonomyBrain(
 
         logger.info("Heard: %s", text)
         self.state["last_interaction"] = time.time()
-        self.mood.modify("happiness", 5)
-        sentiment_event = self._sentiment_event_for_text(text)
-        if sentiment_event:
-            self.appraise_event(sentiment_event)
-        self.memory.add_event(f"User said: {text}")
-        self._log_conversation(text)
         lang = str(source_lang or self.state.get("last_speech_language") or "tr")
         wake_only = len(strip_wakewords(low).split()) < 1 and contains_wakeword(low)
         if wake_only:
@@ -766,7 +879,23 @@ class AutonomyBrain(
                     self.client.start_speech_listening()
                 except Exception:
                     pass
+                with self._speech_req_lock:
+                    if self._active_speech_req_id == request_id:
+                        self._speech_busy = False
                 return
+
+        if self._handle_emotion_command(text, lang):
+            with self._speech_req_lock:
+                if self._active_speech_req_id == request_id:
+                    self._speech_busy = False
+            return
+
+        self.mood.modify("happiness", 5)
+        sentiment_event = self._sentiment_event_for_text(text)
+        if sentiment_event:
+            self.appraise_event(sentiment_event)
+        self.memory.add_event(f"User said: {text}")
+        self._log_conversation(text)
         speaker = self._guess_active_person()
         if speaker:
             self.state["last_speaker"] = speaker
@@ -775,7 +904,7 @@ class AutonomyBrain(
             if sentiment_event:
                 self._apply_interaction_feedback(sentiment_event, speaker, text)
 
-        self.client.push_interaction_event("autonomy.excited")
+        self._maybe_emit_speech_excited(text, sentiment_event)
 
         blocked_response = self._maybe_block_request(text)
         if blocked_response:
@@ -835,9 +964,11 @@ class AutonomyBrain(
                         logger.info("Agent Core handled speech with full pipeline.")
                         self.memory.add_event(f"Agent replied: {response_text}")
                         self._remember_person_chat(speaker, response_text, role="assistant")
-                        # Final TTS uses STT session language (not per-chunk text detection).
+                        tone = self._tone_profile(
+                            self.state.get("last_emotion") or self.mood.get_dominant_emotion()
+                        )
                         self.agent.speech_arbiter.enqueue_final(
-                            response_text, language=lang,
+                            response_text, language=lang, tone=tone,
                         )
                         return
                 except Exception as exc:

--- a/modules/autonomy/services/expression_director.py
+++ b/modules/autonomy/services/expression_director.py
@@ -37,6 +37,16 @@ class ExpressionDirector:
     def __init__(self, client: Any) -> None:
         self.client = client
 
+    def _render_leds(self, canon: str, effect: str, color: list[int]) -> bool:
+        """Prefer palette emote; fall back to effect+RGB animate."""
+        if hasattr(self.client, "emote_neopixel"):
+            if _safe("emote", lambda: self.client.emote_neopixel([canon], duration=0.25)):
+                return True
+        return _safe(
+            "leds",
+            lambda: self.client.set_neopixel(effect, emotions=[canon], color=color),
+        )
+
     def express(
         self,
         emotion: str,
@@ -58,11 +68,11 @@ class ExpressionDirector:
             effect, oled, color, tone = "BREATHE", "normal", [120, 120, 140], "neutral"
 
         modalities = []
-        if _safe("leds", lambda: self.client.set_neopixel(effect, emotions=[canon], color=color)):
+        if self._render_leds(canon, effect, color):
             modalities.append("leds")
         if _safe("eyes", lambda: self.client.oled_show(oled)):
             modalities.append("eyes")
-        # interaction event drives ears (piservo bridge) + any other subscribers
+        # interaction event drives ears (piservo bridge); LEDs handled above
         if _safe("ears", lambda: self.client.push_interaction_event(f"emotion:{canon}")):
             modalities.append("ears")
         if move_head is not None:

--- a/modules/autonomy/services/mood.py
+++ b/modules/autonomy/services/mood.py
@@ -72,12 +72,15 @@ class MoodManager:
     def get_dominant_emotion(self):
         # Determine the dominant emotion for LEDs / eyes / body language.
         # Order encodes priority: high-arousal negative states win first.
+        mood_cfg = self.config.get("defaults", {}).get("mood", {}) if isinstance(self.config.get("defaults"), dict) else {}
+        anger_thresh = float(mood_cfg.get("anger_threshold", 45))
+        furious_thresh = float(mood_cfg.get("furious_threshold", 75))
         anger = self.state.get("anger", 0)
-        if anger > 75:
+        if anger > furious_thresh:
             return "furious"
         if self.state["fear"] > 50:
             return "fear"
-        if anger > 45:
+        if anger > anger_thresh:
             return "anger"
         if self.state["happiness"] > 70:
             return "joy"

--- a/modules/autonomy/tests/test_emotion_commands.py
+++ b/modules/autonomy/tests/test_emotion_commands.py
@@ -1,0 +1,23 @@
+"""Tests for spoken emotion imperative commands."""
+from __future__ import annotations
+
+from modules.autonomy.services.brain import AutonomyBrain
+
+
+def test_sinirlen_maps_to_anger():
+    assert AutonomyBrain._emotion_command_for_text("sinirlen") == "anger"
+    assert AutonomyBrain._emotion_command_for_text("lütfen sinirli ol") == "anger"
+
+
+def test_mutlu_ol_maps_to_joy():
+    assert AutonomyBrain._emotion_command_for_text("mutlu ol") == "joy"
+
+
+def test_non_emotion_returns_none():
+    assert AutonomyBrain._emotion_command_for_text("bugun hava nasil") is None
+
+
+def test_emotion_scene_name_aliases():
+    assert AutonomyBrain._emotion_scene_name("sadness") == "emotion_sad"
+    assert AutonomyBrain._emotion_scene_name("anger") == "emotion_angry"
+    assert AutonomyBrain._emotion_scene_name("joy") == "emotion_joy"

--- a/modules/autonomy/tests/test_expression_director.py
+++ b/modules/autonomy/tests/test_expression_director.py
@@ -13,6 +13,10 @@ class _RecordingClient:
     def set_neopixel(self, effect, emotions=None, color=None, duration=None):
         self.calls.append(("leds", effect, tuple(emotions or []), tuple(color or ())))
 
+    def emote_neopixel(self, emotions, duration=0.25):
+        self.calls.append(("emote", tuple(emotions or ()), duration))
+        return {"ok": True}
+
     def oled_show(self, name):
         self.calls.append(("eyes", name))
 
@@ -35,10 +39,9 @@ def test_express_fires_all_modalities_with_canonical_label():
     canon = director.express("happy", say="merhaba", move_head=(100, 90))
     assert canon == "joy"
     kinds = client.kinds()
-    assert {"leds", "eyes", "event", "head", "voice"} <= set(kinds)
-    # LEDs and the ear-driving interaction event both use the canonical label
-    leds = next(c for c in client.calls if c[0] == "leds")
-    assert leds[2] == ("joy",)
+    assert {"emote", "eyes", "event", "head", "voice"} <= set(kinds)
+    emote = next(c for c in client.calls if c[0] == "emote")
+    assert emote[1] == ("joy",)
     assert ("event", "emotion:joy") in client.calls
     voice = next(c for c in client.calls if c[0] == "voice")
     assert voice[2] == "joy"  # TTS tone resolved from vocab
@@ -51,7 +54,7 @@ def test_express_without_speech_or_head_skips_those():
     kinds = set(client.kinds())
     assert "voice" not in kinds
     assert "head" not in kinds
-    assert {"leds", "eyes", "event"} <= kinds
+    assert {"emote", "eyes", "event"} <= kinds
 
 
 def test_failing_modality_does_not_block_others():
@@ -63,8 +66,8 @@ def test_failing_modality_does_not_block_others():
     director = ExpressionDirector(client)
     canon = director.express("surprise")
     assert canon == "surprise"
-    # eyes failed, but LEDs + ears still fired
-    assert "leds" in client.kinds()
+    # eyes failed, but emote + ears still fired
+    assert "emote" in client.kinds()
     assert ("event", "emotion:surprise") in client.calls
 
 

--- a/modules/autonomy/tests/test_speech_reactions.py
+++ b/modules/autonomy/tests/test_speech_reactions.py
@@ -1,0 +1,40 @@
+"""Tests for conditional speech-side interaction events."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from modules.autonomy.services.brain import AutonomyBrain
+
+
+def _brain(cfg: dict | None = None) -> AutonomyBrain:
+    config = {
+        "llm": {"enabled": False},
+        "speech_reactions": {
+            "excited_on_speech": False,
+            "excited_on_praise": True,
+            "excited_on_questions": False,
+        },
+    }
+    if cfg:
+        config.update(cfg)
+    brain = AutonomyBrain(config)
+    brain.client = MagicMock()
+    return brain
+
+
+def test_no_excited_on_plain_speech():
+    brain = _brain()
+    brain._maybe_emit_speech_excited("bugun hava nasil", None)
+    brain.client.push_interaction_event.assert_not_called()
+
+
+def test_excited_on_praise():
+    brain = _brain()
+    brain._maybe_emit_speech_excited("aferin cok iyisin", "user_praise")
+    brain.client.push_interaction_event.assert_called_once_with("autonomy.excited")
+
+
+def test_excited_on_question_when_enabled():
+    brain = _brain({"speech_reactions": {"excited_on_questions": True}})
+    brain._maybe_emit_speech_excited("bu nedir?", None)
+    brain.client.push_interaction_event.assert_called_once_with("autonomy.excited")

--- a/modules/common/config/emotions.yml
+++ b/modules/common/config/emotions.yml
@@ -10,20 +10,19 @@
 # canonical -> alias labels that should map onto it
 aliases:
   neutral:    [calm, idle, default, normal]
-  joy:        [happy, happiness, glad, cheerful, amusement, optimism]
-  sadness:    [sad, unhappy, down, grief, disappointment, remorse]
-  curiosity:  [curious, interested, intrigued, realization]
-  tired:      [sleepy, drowsy, fatigued, exhausted]
-  fear:       [scared, afraid, frightened, nervousness, nervous]
-  anger:      [angry, mad, annoyance, annoyed]
-  furious:    [rage, enraged, livid]
-  surprise:   [surprised, shocked, astonished]
-  excitement: [excited, thrilled, energetic]
-  love:       [affection, adoration, admiration, desire, gratitude]
-  disgust:    [disgusted, repulsed, disapproval]
-  confusion:  [confused, disoriented, puzzled, uncertain]
-  worried:    [worry, anxious, concerned]
-  bored:      [boredom, dull, listless]
+  anger:      [angry, mad, annoyance, annoyed, sinirlen, sinirli, kizgin, kızgın, ofkeli, öfkeli, sinirlenme]
+  furious:    [rage, enraged, livid, cok sinirli, çok sinirli, öfke, ofke]
+  surprise:   [surprised, shocked, astonished, sasir, şaşır, saskin, şaşkın]
+  excitement: [excited, thrilled, energetic, heyecanli, heyecanlı]
+  love:       [affection, adoration, admiration, desire, gratitude, sev, seviyorum, askim, aşkım]
+  confusion:  [confused, disoriented, puzzled, uncertain, kafan karisik, kafan karışık, anlamadim]
+  worried:    [worry, anxious, concerned, endiseli, endişeli, kaygili]
+  bored:      [boredom, dull, listless, sikildim, sıkıldım, sikinti]
+  joy:        [happy, happiness, glad, cheerful, amusement, optimism, mutlu, mutlu ol, sevin, neşeli, neseli]
+  sadness:    [sad, unhappy, down, grief, disappointment, remorse, uzul, üzül, mutsuz]
+  fear:       [scared, afraid, frightened, nervousness, nervous, kork, korkut, korkma]
+  tired:      [sleepy, drowsy, fatigued, exhausted, yoruldum, uyu, uykum var]
+  curiosity:  [curious, interested, intrigued, realization, merak, merakli]
 
 # Per-canonical render hints consumed across modules.
 #   oled    -> bitmap/animation name in oled_faces catalog

--- a/modules/oled_faces/config/config.yml
+++ b/modules/oled_faces/config/config.yml
@@ -107,11 +107,13 @@ event_map:
   owner.temp_revoked: { mode: bitmap, name: worried }
   owner.locked: { mode: bitmap, name: scared }
   emotion:happy: { mode: bitmap, name: happy }
+  emotion:joy: { mode: bitmap, name: happy }
   emotion:sad: { mode: bitmap, name: sad }
   emotion:surprised: { mode: bitmap, name: surprised }
   emotion:sleepy: { mode: bitmap, name: sleepy }
   emotion:confused: { mode: bitmap, name: confused }
   emotion:angry: { mode: bitmap, name: angry }
+  emotion:anger: { mode: bitmap, name: angry }
   emotion:furious: { mode: bitmap, name: furious }
   emotion:bored: { mode: bitmap, name: bored }
   emotion:despair: { mode: bitmap, name: despair }

--- a/modules/oled_faces/services/face_coordinator.py
+++ b/modules/oled_faces/services/face_coordinator.py
@@ -20,6 +20,8 @@ _PASSIVE_OPERATIONAL: Set[str] = {
 _LISTEN_START = {"wakeword.detected", "speech.listen.start"}
 _LISTEN_END = {"speech.listen.end"}
 
+_FORCE_EMOTION_LABELS = {"anger", "angry", "furious", "fear", "scared", "surprise", "surprised"}
+
 _SPEAK_START = {"speech.start"}
 _SPEAK_END = {"speech.end"}
 
@@ -75,11 +77,13 @@ class FaceCoordinator:
         if key.startswith("emotion:"):
             label = key.split(":", 1)[1]
             mood_action = self.mapper.from_emotions([label])
-            if self._listen_active(now) or self._speak_active(now):
+            force_emotion = label in _FORCE_EMOTION_LABELS
+            if (self._listen_active(now) or self._speak_active(now)) and not force_emotion:
                 return FaceDecision(action=mood_action, priority=priority, source="event", apply=False)
-            if not self._emotion_stable(mood_action.name, now):
+            if not force_emotion and not self._emotion_stable(mood_action.name, now):
                 return FaceDecision(action=mood_action, priority=priority, source="event", apply=False)
-            return FaceDecision(action=mood_action, priority=max(priority, 62), source="event")
+            boosted = 88 if force_emotion else max(priority, 62)
+            return FaceDecision(action=mood_action, priority=boosted, source="event")
 
         if key in {"autonomy.blink", "autonomy.look_around", "autonomy.stretch"}:
             return FaceDecision(action=action, priority=min(priority, 45), source="event")

--- a/modules/oled_faces/tests/test_face_coordinator.py
+++ b/modules/oled_faces/tests/test_face_coordinator.py
@@ -59,6 +59,14 @@ def test_listen_session_blocks_activity_clear():
     assert c.should_clear_activity(time.time(), 0.0) is False
 
 
+def test_anger_emotion_applies_during_listen_session():
+    c = _coord()
+    c.on_event("speech.listen.start", OledAction("animation", "listening"), 80)
+    d = c.on_event("emotion:anger", OledAction("bitmap", "angry"), 65)
+    assert d.apply is True
+    assert d.action.name == "angry"
+
+
 def test_speech_end_uses_baseline_not_forced_normal():
     c = _coord()
     baseline = OledAction("bitmap", "happy")

--- a/modules/oled_faces/xOledFacesService.py
+++ b/modules/oled_faces/xOledFacesService.py
@@ -102,17 +102,24 @@ class xOledFacesService:
             time.sleep(max(0.05, interval_s))
 
     def _enforce_session_activity(self) -> None:
+        now = time.time()
         if self.coordinator.listen_session_active():
             self.display.pin_activity("listening")
             want = OledAction(mode="animation", name="listening")
-            if self._last_sent != (want.mode, want.name):
-                self._apply(want, priority=80, force=True)
+            if self._last_sent == (want.mode, want.name):
+                return
+            if now < self._active_hold_until and self._active_priority > 78:
+                return
+            self._apply(want, priority=78, force=False)
             return
         if self.coordinator.speak_session_active():
             self.display.pin_activity("thinking")
             want = OledAction(mode="animation", name="thinking")
-            if self._last_sent != (want.mode, want.name):
-                self._apply(want, priority=74, force=True)
+            if self._last_sent == (want.mode, want.name):
+                return
+            if now < self._active_hold_until and self._active_priority > 74:
+                return
+            self._apply(want, priority=74, force=False)
             return
         self.display.pin_activity(None)
 


### PR DESCRIPTION
## Özet
Companion ifade katmanı: Türkçe duygu komutları, passive mood sahneleri, expression director emote önceliği, OLED listen sırasında güçlü duygular ve joy alias. Common emotions.yml Türkçe alias genişletmesi.

## Değişiklik tipi
- [x] Hata düzeltmesi
- [x] Yeni özellik
- [ ] Refactor
- [ ] Dokümantasyon güncellemesi
- [ ] Test güncellemesi

## Etkilenen modüller
`modules/autonomy`, `modules/common`, `modules/oled_faces`, `modules/interactions`

## Doğrulama
- [ ] Lokal çalıştırma tamamlandı
- [x] İlgili testler geçiyor
- [x] Gerekli doküman/konfig güncellemeleri yapıldı

## Arduino Kontrat Kontrolü (uygunsa)
- [x] `contract.py` dışında elle Arduino payload yazılmadı
- [x] Kritik komutlar gerektiğinde `/arduino/request` kullanıyor
- [ ] Yeni komut ailesi builder + validator + test içeriyor

## Risk ve geri alma
Orta-düşük: emotion LED çift tetikleme interactions config'den kaldırıldı. Revert veya interactions config geri yükleme.

## İlgili issue
N/A

**Stack:** `feat/neopixel-emotion-leds` → bu PR → hedef `dev`

Made with [Cursor](https://cursor.com)