### PR TITLE
feat(vlm): remote vision availability and person emotion empathy

### DIFF
--- a/modules/autonomy/services/brain_parts/vision.py
+++ b/modules/autonomy/services/brain_parts/vision.py
@@ -27,6 +27,14 @@ class VisionMixin:
                 importance = float(ctx_data.get("importance_score", 0.0))
                 self.state["last_visual_importance"] = importance
                 self._track_scene_context(ctx_data, importance)
+                for person in ctx_data.get("people", []) or []:
+                    if isinstance(person, dict) and person.get("emotion"):
+                        self._mirror_person_emotion(
+                            {
+                                "name": person.get("name", "Unknown"),
+                                "emotion": person.get("emotion"),
+                            }
+                        )
                 if importance > 0.6:
                     self.mood.modify("curiosity", int(importance * 20))
                     self.mood.modify("energy", 10)
@@ -95,6 +103,44 @@ class VisionMixin:
             if importance >= 0.5:
                 self.mood.modify("curiosity", 6)
 
+    def _mirror_person_emotion(self, result: Dict[str, Any]) -> None:
+        empathy = self._vision_cfg.get("empathy", {}) if isinstance(self._vision_cfg.get("empathy"), dict) else {}
+        if not empathy.get("enabled", True):
+            return
+        raw = str(result.get("emotion", "") or "").strip().lower()
+        if not raw:
+            return
+        try:
+            from modules.common.emotion_vocab import get_vocab
+
+            canon = get_vocab().canonical(raw)
+        except Exception:
+            canon = raw
+        allowed = {str(x).strip().lower() for x in (empathy.get("mirror") or ["joy", "sadness", "fear"])}
+        if canon not in allowed:
+            return
+        now = time.time()
+        cooldown = float(empathy.get("cooldown_s", 28))
+        if now - float(self.state.get("last_empathy_mirror_ts", 0.0)) < cooldown:
+            return
+        self.state["last_empathy_mirror_ts"] = now
+        self.state["last_emotion"] = canon
+        try:
+            self.express(canon)
+            self.client.push_interaction_event(f"vision.person_emotion_{canon}")
+        except Exception:
+            pass
+        if empathy.get("speak_on_mirror", False):
+            replies = {
+                "joy": "Mutlu görünüyorsun, ben de mutlu oldum.",
+                "sadness": "Üzgün görünüyorsun. İyi misin?",
+                "fear": "Bir şey mi korkuttu seni?",
+                "worried": "Endişeli görünüyorsun.",
+            }
+            line = replies.get(canon)
+            if line:
+                self._speak_with_mood(line, emotion=canon)
+
     def _handle_vision_result(self, result: Dict[str, Any]) -> None:
         name = result.get("name") or result.get("label")
         if not name:
@@ -122,6 +168,7 @@ class VisionMixin:
         happiness_boost = 10 if name != "Unknown" else 4
         self.mood.modify("happiness", happiness_boost)
         self.mood.modify("curiosity", 5)
+        self._mirror_person_emotion(result)
         self.client.push_interaction_event("vision.person", {"name": name})
         self._focus_on_target(result)
         should_speak = name != "Unknown" or self._vision_cfg.get("speak_on_unknown", False)

--- a/modules/autonomy/tests/test_vision_empathy.py
+++ b/modules/autonomy/tests/test_vision_empathy.py
@@ -1,0 +1,34 @@
+"""Tests for vision empathy mirroring."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from modules.autonomy.services.brain_parts.vision import VisionMixin
+
+
+class _Mini(VisionMixin):
+    def __init__(self):
+        self._vision_cfg = {
+            "empathy": {
+                "enabled": True,
+                "cooldown_s": 0.0,
+                "mirror": ["joy", "sadness"],
+            }
+        }
+        self.state = {}
+        self.client = MagicMock()
+        self.express = MagicMock(return_value="joy")
+        self._speak_with_mood = MagicMock()
+
+
+def test_mirror_person_emotion_happy():
+    mini = _Mini()
+    mini._mirror_person_emotion({"name": "Ali", "emotion": "happy"})
+    mini.express.assert_called_once_with("joy")
+    mini.client.push_interaction_event.assert_called_with("vision.person_emotion_joy")
+
+
+def test_mirror_skips_unknown_emotion():
+    mini = _Mini()
+    mini._mirror_person_emotion({"name": "Ali", "emotion": "disgust"})
+    mini.express.assert_not_called()

--- a/modules/common/tests/test_vision_availability.py
+++ b/modules/common/tests/test_vision_availability.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from modules.common.vision_availability import (
+    camera_live_available,
+    remote_vision_cache_available,
+    vision_input_available,
+)
+
+
+def test_vision_input_available_from_remote_cache():
+    base = "http://127.0.0.1:8080"
+
+    with patch("modules.common.vision_availability.camera_live_available", return_value=False):
+        with patch("modules.common.vision_availability.remote_vision_cache_available", return_value=True):
+            assert vision_input_available(base) is True
+
+
+def test_vision_input_unavailable_when_both_missing():
+    base = "http://127.0.0.1:8080"
+
+    with patch("modules.common.vision_availability.camera_live_available", return_value=False):
+        with patch("modules.common.vision_availability.remote_vision_cache_available", return_value=False):
+            assert vision_input_available(base) is False
+
+
+def test_remote_cache_from_results_latest():
+    base = "http://127.0.0.1:8080"
+    mock_resp_ctx = MagicMock(status_code=200, json=lambda: {"available": False})
+    mock_resp_results = MagicMock(status_code=200, json=lambda: {"results": [{"label": "person"}]})
+
+    with patch("requests.get", side_effect=[mock_resp_ctx, mock_resp_results]):
+        assert remote_vision_cache_available(base) is True
+
+
+def test_camera_live_requires_ok_not_gave_up():
+    mock_resp = MagicMock(status_code=200, json=lambda: {"ok": True, "gave_up": True})
+
+    with patch("requests.get", return_value=mock_resp):
+        assert camera_live_available("http://127.0.0.1:8080") is False

--- a/modules/common/vision_availability.py
+++ b/modules/common/vision_availability.py
@@ -1,0 +1,63 @@
+"""Shared helpers for live camera vs remote vision cache availability."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def _parse_json(resp) -> Dict[str, Any]:
+    try:
+        data = resp.json()
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def camera_live_available(base_url: str, *, timeout_s: float = 0.5) -> bool:
+    """True when gateway camera healthz reports a live frame."""
+    try:
+        import requests
+
+        from modules.gateway.url import gateway_url
+
+        resp = requests.get(gateway_url(base_url, "/camera/healthz"), timeout=timeout_s)
+        if resp.status_code != 200:
+            return False
+        data = _parse_json(resp)
+        return bool(data.get("ok")) and not bool(data.get("gave_up", False))
+    except Exception:
+        return False
+
+
+def remote_vision_cache_available(base_url: str, *, timeout_s: float = 0.6) -> bool:
+    """True when VLM bridge has remote-ingested context or detection cache."""
+    try:
+        import requests
+
+        from modules.gateway.url import gateway_url
+
+        ctx = requests.get(gateway_url(base_url, "/vlm/context/latest"), timeout=timeout_s)
+        if ctx.status_code == 200:
+            data = _parse_json(ctx)
+            if data.get("available"):
+                return True
+        results = requests.get(
+            gateway_url(base_url, "/vlm/results/latest"),
+            params={"limit": 1},
+            timeout=timeout_s,
+        )
+        if results.status_code == 200:
+            data = _parse_json(results)
+            items = data.get("results")
+            if isinstance(items, list) and items:
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def vision_input_available(base_url: str, *, timeout_s: float = 0.6) -> bool:
+    """Live camera OR remote vision cache is usable for agent/VLM tools."""
+    if camera_live_available(base_url, timeout_s=min(timeout_s, 0.5)):
+        return True
+    return remote_vision_cache_available(base_url, timeout_s=timeout_s)

--- a/modules/vlm_bridge/services/visual_context.py
+++ b/modules/vlm_bridge/services/visual_context.py
@@ -36,6 +36,7 @@ class PersonContext:
     last_seen: str = ""
     is_follow_target: bool = False
     appearance_notes: str = ""
+    emotion: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)


### PR DESCRIPTION
## Özet
Ortak `vision_availability` helper, VLM remote görsel bağlamında kişi duygusu, autonomy brain'de mirror empathy ve isteğe bağlı `speak_on_mirror` konuşması. Kamera kapalıyken remote VLM cache ile vision context.

## Değişiklik tipi
- [ ] Hata düzeltmesi
- [x] Yeni özellik
- [ ] Refactor
- [ ] Dokümantasyon güncellemesi
- [ ] Test güncellemesi

## Etkilenen modüller
`modules/common`, `modules/vlm_bridge`, `modules/autonomy`

## Doğrulama
- [ ] Lokal çalıştırma tamamlandı
- [x] İlgili testler geçiyor
- [x] Gerekli doküman/konfig güncellemeleri yapıldı

## Arduino Kontrat Kontrolü (uygunsa)
- [x] Uygulanmıyor

## Risk ve geri alma
Düşük-orta: remote VLM yoksa helper false döner, mevcut davranış korunur.

## İlgili issue
N/A

**Stack:** `fix/camera-disabled-safe-gating` → bu PR → hedef `dev`

Made with [Cursor](https://cursor.com)