### PR TITLE
feat(agent_core): remote vision routing and emotion keyword tools

### DIFF
--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -113,7 +113,8 @@ vlm_bridge:
     host: 0.0.0.0
     port: 8101
   vision:
-    processing_mode: local
+    processing_mode: remote
+    hybrid_local_capture: false
     camera_source: "@gateway/camera/video"
     context_max_age_s: 45
     confidence_threshold: 0.5
@@ -122,7 +123,7 @@ vlm_bridge:
       min_good_matches: 5
       min_score: 0.08
     follow:
-      enabled: true
+      enabled: false
       track_interval_s: 0.12
       pan_gain_deg: 50
       tilt_gain_deg: 32
@@ -161,6 +162,12 @@ vlm_bridge:
   remote:
     auth_token: "changeme"
     accept_results: true
+  remote_multimodal:
+    enabled: false
+    endpoint: "http://192.168.1.100:8102/vision/analyze"
+    interval_s: 8.0
+    jpeg_quality: 75
+    auth_token: ""
   robot:
     host: "localhost"
   ollama:
@@ -384,3 +391,6 @@ safety:
   min_servo_angle: 0
   max_stepper_speed: 100
   laser_max_duration_s: 2.0
+
+camera:
+  enabled: false

--- a/modules/agent_core/config/config.yml
+++ b/modules/agent_core/config/config.yml
@@ -32,13 +32,19 @@ llm:
 tri_layer:
   enabled: true
   router:
-    max_subagents: 1
+    max_subagents: 2
     default_modules:
-      - vlm_bridge
+      - autonomy
+      - agent_core
   subagent:
     max_steps: 2
   persona:
     num_predict: 180
+    system_prompt: |
+      Sen SentryBOT companion robotusun. Kullanıcı duygu veya yüz/ışık ifadesi istediğinde
+      (ör. sinirlen, mutlu ol, kızgın konuş, yüzünü değiştir, kırmızı yan) uygun aracı kullan:
+      set_emotion (tam duygu), oled_face (yüz), set_lights (LED efekt+renk).
+      Duygusal cevap verirken tonunu duyguya uydur.
 
 safety:
   max_servo_angle: 180

--- a/modules/agent_core/services/agent.py
+++ b/modules/agent_core/services/agent.py
@@ -194,7 +194,7 @@ class AgentOrchestrator:
         default_modules = router_cfg.get("default_modules", ["autonomy", "agent_core"])
         if not isinstance(default_modules, list):
             default_modules = ["autonomy", "agent_core"]
-        if not self._camera_input_available():
+        if not self._vision_input_available():
             default_modules = [m for m in default_modules if str(m).strip().lower() != "vlm_bridge"]
 
         profile_overrides = tri_cfg.get("profiles") if isinstance(tri_cfg.get("profiles"), dict) else None
@@ -552,16 +552,19 @@ class AgentOrchestrator:
 
     def _camera_input_available(self) -> bool:
         try:
-            from modules.gateway.url import gateway_url, resolve_gateway_base_url
+            from modules.common.vision_availability import camera_live_available
+            from modules.gateway.url import resolve_gateway_base_url
 
-            base = resolve_gateway_base_url()
-            import requests
+            return camera_live_available(resolve_gateway_base_url(), timeout_s=0.35)
+        except Exception:
+            return False
 
-            resp = requests.get(gateway_url(base, "/camera/healthz"), timeout=0.35)
-            if resp.status_code != 200:
-                return False
-            data = resp.json() if resp.content else {}
-            return bool((data or {}).get("ok", False))
+    def _vision_input_available(self) -> bool:
+        try:
+            from modules.common.vision_availability import vision_input_available
+            from modules.gateway.url import resolve_gateway_base_url
+
+            return vision_input_available(resolve_gateway_base_url(), timeout_s=0.5)
         except Exception:
             return False
 

--- a/modules/agent_core/services/progress.py
+++ b/modules/agent_core/services/progress.py
@@ -53,8 +53,8 @@ _ACK_TEMPLATES_EN = [
 ]
 
 _TOOL_START_TEMPLATES_TR: Dict[str, str] = {
-    "get_vision": "Kameradan görüntü alıyorum.",
-    "get_visual_context": "Çevreyi inceliyorum, kameradan son görüntüyü alıyorum.",
+    "get_vision": "Görüş verisini alıyorum.",
+    "get_visual_context": "Çevreyi inceliyorum, son görüntü önbelleğine bakıyorum.",
     "get_sensor_data": "Sensör verilerini okuyorum.",
     "search_memory": "Hafızamı tarıyorum.",
     "move_head": "Kafamı çeviriyorum.",
@@ -79,8 +79,8 @@ _VLM_PROCESSING_TEMPLATES_TR = [
 ]
 
 _TOOL_START_TEMPLATES_EN: Dict[str, str] = {
-    "get_vision": "Capturing an image from the camera.",
-    "get_visual_context": "Looking around and checking the latest view.",
+    "get_vision": "Fetching vision data.",
+    "get_visual_context": "Checking the latest vision cache.",
     "get_sensor_data": "Reading sensor data.",
     "search_memory": "Searching my memory.",
     "move_head": "Turning my head.",

--- a/modules/agent_core/services/tool_progress.py
+++ b/modules/agent_core/services/tool_progress.py
@@ -28,6 +28,7 @@ _FAILURE_MARKERS = (
 
 _VISION_SUCCESS_MARKERS = (
     "camera sees:",
+    "vision:",
     "scene:",
     "people:",
     "hazards:",

--- a/modules/agent_core/services/tools.py
+++ b/modules/agent_core/services/tools.py
@@ -60,20 +60,22 @@ class ToolRegistry:
 
     def _camera_input_available(self) -> bool:
         try:
-            import requests
+            from modules.common.vision_availability import camera_live_available
 
-            resp = requests.get(self._url("camera/healthz"), timeout=0.5)
-            if resp.status_code != 200:
-                return False
-            data = resp.json()
-            if not isinstance(data, dict):
-                return False
-            return bool(data.get("ok")) and not bool(data.get("gave_up", False))
+            return camera_live_available(self._gateway_base_url, timeout_s=0.5)
+        except Exception:
+            return False
+
+    def _vision_input_available(self) -> bool:
+        try:
+            from modules.common.vision_availability import vision_input_available
+
+            return vision_input_available(self._gateway_base_url, timeout_s=0.6)
         except Exception:
             return False
 
     def _vision_unavailable_message(self) -> str:
-        return "Kamera görüntüsü şu an kullanılamıyor; görme araçları devre dışı."
+        return "Görüş verisi şu an kullanılamıyor (kamera veya uzak VLM cache yok); görme araçları devre dışı."
 
     def _acquire_vision(self, tool_name: str) -> bool:
         if self.vision_arbiter is None or tool_name not in self._VLM_TOOL_NAMES:
@@ -113,7 +115,7 @@ class ToolRegistry:
                     })
                     return f"Error executing {tool_name}: resource busy"
                 acquired = True
-            if tool_name in self._VLM_TOOL_NAMES and not self._camera_input_available():
+            if tool_name in self._VLM_TOOL_NAMES and not self._vision_input_available():
                 self._emit_status({
                     "type": "tool_error",
                     "tool": tool_name,
@@ -261,14 +263,18 @@ class ToolRegistry:
             "type": "function",
             "function": {
                 "name": "set_emotion",
-                "description": "Set the robot's internal emotional state.",
+                "description": "Express a canonical emotion across OLED face, NeoPixel lights, and robot state.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "emotion": {
                             "type": "string",
-                            "enum": ["joy", "sadness", "anger", "fear", "trust", "disgust", "anticipation", "surprise", "tired", "neutral"],
-                            "description": "The dominant emotion to feel"
+                            "enum": [
+                                "neutral", "joy", "sadness", "anger", "furious", "fear",
+                                "surprise", "excitement", "love", "disgust", "confusion",
+                                "worried", "bored", "tired", "curiosity",
+                            ],
+                            "description": "Canonical emotion from the shared vocabulary",
                         }
                     },
                     "required": ["emotion"]
@@ -593,18 +599,37 @@ class ToolRegistry:
 
     def oled_face(self, expression: str) -> str:
         if not self.client: return "Error: Hardware client disconnected."
-        anim_list = ["ScanningEyes", "Winking", "scan", "blink", "emotive"]
-        if expression in anim_list:
-            resp = self.client.oled_anim(expression)
+        key = str(expression or "").strip().lower()
+        pip_activities = {
+            "listening", "thinking", "scanning", "searching", "working",
+            "processing", "connecting", "sleep", "alert",
+        }
+        legacy_anims = {"scan", "emotive", "blink", "wink", "all", "icons"}
+        if key in pip_activities or key in legacy_anims:
+            resp = self.client.oled_anim(key)
         else:
-            resp = self.client.oled_show(expression)
+            resp = self.client.oled_show(key)
         return f"OLED face updated to {expression}. Response: {resp}"
 
     def set_emotion(self, emotion: str) -> str:
-        if not self.client: return "Error: Hardware client disconnected."
-        self.client.update_emotions([emotion])
-        self.client.push_interaction_event(f"scene.emotion_{emotion}")
-        return f"Internal emotion set to: {emotion}"
+        if not self.client:
+            return "Error: Hardware client disconnected."
+        try:
+            from modules.common.emotion_vocab import emotion_render
+
+            render = emotion_render(emotion)
+            canon = render.canonical
+        except Exception:
+            canon = str(emotion or "neutral").strip().lower()
+            render = None
+        self.client.update_emotions([canon])
+        if render is not None:
+            self.client.set_neopixel(render.effect, emotions=[canon], color=list(render.rgb))
+            self.client.oled_show(render.oled)
+            self.client.push_interaction_event(f"emotion:{canon}")
+            return f"Expressed emotion: {canon}"
+        self.client.push_interaction_event(f"emotion:{canon}")
+        return f"Internal emotion set to: {canon}"
 
     def interaction_event(self, event: str) -> str:
         if not self.client: return "Error: Hardware client disconnected."
@@ -658,7 +683,7 @@ class ToolRegistry:
         results = self.client.get_latest_vision_results(limit=5)
         if not results:
             return "Vision results unavailable. Continue with text-only reasoning if needed."
-        return f"Camera sees: {results}"
+        return f"Vision: {results}"
 
     def get_sensor_data(self) -> str:
         bat = self.world_state.get_state().get("battery_percent", "unknown")

--- a/modules/agent_core/services/tri_layer.py
+++ b/modules/agent_core/services/tri_layer.py
@@ -51,7 +51,7 @@ def build_subagent_profiles(overrides: Dict[str, dict] | None = None) -> Dict[st
             role="Behavior specialist",
             goal="Decide autonomous behavior policy.",
             allowed_tools=("search_memory", "interaction_event", "set_emotion", "get_sensor_data"),
-            keywords=("autonomy", "idle", "bored", "follow", "behavior"),
+            keywords=("autonomy", "idle", "bored", "follow", "behavior", "sinirlen", "mutlu", "duygu", "ifade", "companion"),
         ),
         "calibration": SubAgentProfile(
             module="calibration",
@@ -100,7 +100,7 @@ def build_subagent_profiles(overrides: Dict[str, dict] | None = None) -> Dict[st
             role="Interaction specialist",
             goal="Trigger high-level interaction events.",
             allowed_tools=("interaction_event", "set_lights", "oled_face", "set_emotion"),
-            keywords=("interaction", "react", "event", "scene", "expression"),
+            keywords=("interaction", "react", "event", "scene", "expression", "sinirlen", "mutlu", "duygu", "ifade"),
         ),
         "logwrapper": SubAgentProfile(
             module="logwrapper",
@@ -315,6 +315,28 @@ class TriLayerRouter:
             scores["diagnostics"] = scores.get("diagnostics", 0.0) + 1.2
         if q_tokens & {"schedule", "timer", "later", "remind", "periodic"} and "scheduler" in self.profiles:
             scores["scheduler"] = scores.get("scheduler", 0.0) + 1.1
+
+        emotion_tokens = {
+            "sinirlen", "sinirli", "kizgin", "kızgın", "mutlu", "uzgun", "üzgün", "kork",
+            "emotion", "duygu", "ifade", "yuz", "yüz", "face", "angry", "happy", "sad",
+            "excited", "bored", "furious", "scared", "love", "worried", "confused",
+            "led", "light", "lights", "neopixel", "renk", "color", "oled", "eyes",
+        }
+        emotion_phrases = (
+            "mutlu ol", "sinirli ol", "kizgin ol", "kızgın ol", "uzgun ol", "üzgün ol",
+            "kirmizi yan", "kırmızı yan", "yuzunu degistir", "yüzünü değiştir",
+        )
+        if q_tokens & emotion_tokens or any(p in text for p in emotion_phrases):
+            if "interactions" in self.profiles:
+                scores["interactions"] = scores.get("interactions", 0.0) + 2.8
+            if "autonomy" in self.profiles:
+                scores["autonomy"] = scores.get("autonomy", 0.0) + 2.4
+            if "neopixel" in self.profiles:
+                scores["neopixel"] = scores.get("neopixel", 0.0) + 1.8
+            if "oled_faces" in self.profiles:
+                scores["oled_faces"] = scores.get("oled_faces", 0.0) + 1.6
+            if "speak" in self.profiles:
+                scores["speak"] = scores.get("speak", 0.0) + 1.0
 
         if not scores:
             return list(self.default_modules[: self.max_subagents])

--- a/modules/agent_core/tests/test_tool_progress.py
+++ b/modules/agent_core/tests/test_tool_progress.py
@@ -16,7 +16,7 @@ def test_tool_result_succeeded_rejects_unavailable_vision() -> None:
 
 
 def test_tool_result_succeeded_accepts_real_vision_payload() -> None:
-    assert tool_result_succeeded("get_vision", "Camera sees: person, chair")
+    assert tool_result_succeeded("get_vision", "Vision: person, chair")
     assert tool_result_succeeded("get_visual_context", "Scene: kitchen | People: Ali")
 
 
@@ -48,5 +48,5 @@ def test_progress_speaks_tool_done_after_success() -> None:
 
     pm = ProgressManager(speech_arbiter=_SpeechStub())
     token = pm.new_request(language="tr")
-    pm.emit_tool_done(token, "get_vision", "Camera sees: table")
+    pm.emit_tool_done(token, "get_vision", "Vision: table")
     assert spoken == ["Görüntüyü aldım."]


### PR DESCRIPTION
## Özet
Agent core VLM araçları remote vision cache varken kullanılabilir; duygu anahtar kelimeleri autonomy/interactions'a yönlendirilir. Tri-layer config senkronu, agent.yaml remote vision varsayılanları ve vision progress UX metinleri güncellendi.

## Değişiklik tipi
- [x] Hata düzeltmesi
- [x] Yeni özellik
- [ ] Refactor
- [ ] Dokümantasyon güncellemesi
- [ ] Test güncellemesi

## Etkilenen modüller
`modules/agent_core`, `config/agent.yaml`

## Doğrulama
- [ ] Lokal çalıştırma tamamlandı
- [x] İlgili testler geçiyor
- [x] Gerekli doküman/konfig güncellemeleri yapıldı

## Arduino Kontrat Kontrolü (uygunsa)
- [x] Uygulanmıyor

## Risk ve geri alma
Düşük: vision yoksa araçlar devre dışı kalır. Config revert yeterli.

## İlgili issue
N/A

**Stack:** `feat/vlm-remote-vision-empathy` → bu PR → hedef `dev`

Made with [Cursor](https://cursor.com)