### PR TITLE
fix(agent_core): repair vision arbiter pytest after vision_input rename

### DIFF
--- a/modules/agent_core/tests/test_arbiter_chain.py
+++ b/modules/agent_core/tests/test_arbiter_chain.py
@@ -36,7 +36,7 @@ def test_vision_arbiter_blocks_concurrent_vlm_tools():
     registry = _build_registry(arbiter)
 
     arbiter.acquire("external", ttl_s=10.0)
-    with patch.object(registry, "_camera_input_available", return_value=True):
+    with patch.object(registry, "_vision_input_available", return_value=True):
         result = registry.execute("describe_scene", {})
     assert "vision arbiter busy" in result
 


### PR DESCRIPTION
## Özet
`test_vision_arbiter_blocks_concurrent_vlm_tools` eski `_camera_input_available` mock'unu kullanıyordu; tool gating artık `_vision_input_available` ile yapıldığı için test vision-unavailable dalına düşüp CI'da kırılıyordu.

## Değişiklik tipi
- [x] Hata düzeltmesi
- [ ] Yeni özellik
- [ ] Refactor
- [ ] Dokümantasyon güncellemesi
- [x] Test güncellemesi

## Etkilenen modüller
`modules/agent_core/tests/test_arbiter_chain.py`

## Doğrulama
- [x] İlgili testler geçiyor (`test_arbiter_chain.py`)

## Arduino Kontrat Kontrolü (uygunsa)
- [x] Uygulanmıyor

## Risk ve geri alma
Yok — yalnızca test mock güncellemesi.

## İlgili issue
Fixes main CI failure after #154

Made with [Cursor](https://cursor.com)