### PR TITLE
fix(neopixel): jewel/stick segment alias lookup order

### DIFF
--- a/modules/neopixel/services/runner.py
+++ b/modules/neopixel/services/runner.py
@@ -174,9 +174,14 @@ class NeoRunner:
         if not name:
             return None
         key = str(name).strip().lower()
-        aliases = {"jewel": "head", "stick": "body"}
-        key = aliases.get(key, key)
-        return self._segments.get(key)
+        bounds = self._segments.get(key)
+        if bounds is not None:
+            return bounds
+        aliases = {"jewel": "head", "stick": "body", "head": "jewel", "body": "stick"}
+        alt = aliases.get(key)
+        if alt:
+            return self._segments.get(alt)
+        return None
 
     def _drain_animate_queue(self) -> None:
         try:


### PR DESCRIPTION
## Özet
`_segment_bounds` jewel→head alias'ını doğrudan lookup'tan önce uyguluyordu; config'de `jewel`/`stick` segment adları varken `head` arandığı için `fill_segment` False dönüyor ve CI kırılıyordu.

## Değişiklik tipi
- [x] Hata düzeltmesi

## Etkilenen modüller
`modules/neopixel/services/runner.py`

## Doğrulama
- [x] `test_fill_segment_applies_only_target_range` kök nedeni giderildi

## Risk ve geri alma
Düşük — hem jewel/stick hem head/body config şemaları desteklenir.

Made with [Cursor](https://cursor.com)