### PR TITLE
chore(release): merge dev into main — Pip OLED motor catalog sync

### DIFF
--- a/modules/autonomy/services/brain_parts/animations.py
+++ b/modules/autonomy/services/brain_parts/animations.py
@@ -79,9 +79,11 @@ class AnimationSupportMixin:
 
     def _perform_eye_saccade(self) -> None:
         """Briefly dart the eyes to a random gaze direction."""
-        gaze = random.choice(["look_left", "look_right", "look_up", "look_down"])
+        gaze = random.choice(
+            ["look_left", "look_right", "look_up", "look_down", "wink", "wink_left", "wink_right", "blink", "double_blink"]
+        )
         try:
-            self.client.oled_show(gaze)
+            self.client.push_interaction_event(f"gesture:{gaze}")
         except Exception:
             pass
 

--- a/modules/autonomy/tests/test_expression_director.py
+++ b/modules/autonomy/tests/test_expression_director.py
@@ -86,12 +86,24 @@ class _Mini(AnimationSupportMixin):
         self.mood = _StubMood()
 
 
-def test_eye_saccade_uses_gaze_bitmaps():
+def test_eye_saccade_emits_gesture_interaction_event():
     client = _RecordingClient()
     mini = _Mini(client)
     mini._perform_eye_saccade()
-    eyes = [c for c in client.calls if c[0] == "eyes"]
-    assert eyes and eyes[0][1] in {"look_left", "look_right", "look_up", "look_down"}
+    gestures = [c for c in client.calls if c[0] == "event" and c[1].startswith("gesture:")]
+    assert gestures
+    gaze = gestures[0][1].removeprefix("gesture:")
+    assert gaze in {
+        "look_left",
+        "look_right",
+        "look_up",
+        "look_down",
+        "wink",
+        "wink_left",
+        "wink_right",
+        "blink",
+        "double_blink",
+    }
 
 
 def test_ear_micromovement_emits_emotion_event():

--- a/modules/common/config/emotions.yml
+++ b/modules/common/config/emotions.yml
@@ -7,45 +7,60 @@
 # render hints below. This keeps eyes (OLED), LEDs (NeoPixel), ears (PiServo),
 # head body-language and TTS tone aligned for one emotion.
 
-# canonical -> alias labels that should map onto it
 aliases:
   neutral:    [calm, idle, default, normal]
+  joy:        [happy, happiness, glad, cheerful, amusement, optimism, mutlu, mutlu ol, sevin, neşeli, neseli]
+  sadness:    [sad, unhappy, down, grief, disappointment, remorse, uzul, üzül, mutsuz]
+  curiosity:  [curious, interested, intrigued, realization, merak, merakli]
+  tired:      [sleepy, drowsy, fatigued, exhausted, yoruldum, uyu, uykum var]
+  fear:       [scared, afraid, frightened, nervousness, kork, korkut, korkma]
   anger:      [angry, mad, annoyance, annoyed, sinirlen, sinirli, kizgin, kızgın, ofkeli, öfkeli, sinirlenme]
   furious:    [rage, enraged, livid, cok sinirli, çok sinirli, öfke, ofke]
   surprise:   [surprised, shocked, astonished, sasir, şaşır, saskin, şaşkın]
   excitement: [excited, thrilled, energetic, heyecanli, heyecanlı]
   love:       [affection, adoration, admiration, desire, gratitude, sev, seviyorum, askim, aşkım]
+  disgust:    [disgusted, repulsed, disapproval]
   confusion:  [confused, disoriented, puzzled, uncertain, kafan karisik, kafan karışık, anlamadim]
   worried:    [worry, anxious, concerned, endiseli, endişeli, kaygili]
   bored:      [boredom, dull, listless, sikildim, sıkıldım, sikinti]
-  joy:        [happy, happiness, glad, cheerful, amusement, optimism, mutlu, mutlu ol, sevin, neşeli, neseli]
-  sadness:    [sad, unhappy, down, grief, disappointment, remorse, uzul, üzül, mutsuz]
-  fear:       [scared, afraid, frightened, nervousness, nervous, kork, korkut, korkma]
-  tired:      [sleepy, drowsy, fatigued, exhausted, yoruldum, uyu, uykum var]
-  curiosity:  [curious, interested, intrigued, realization, merak, merakli]
+  suspicious: [suspicious, doubtful, side_eye, skeptical]
+  awe:        [awe, wonder, amazed, wow]
+  gloomy:     [gloomy, melancholy, rainy, overcast]
+  cool:       [cool, chill, sunglasses]
+  devil:      [devil, mischief, evil, naughty]
+  kawaii:     [kawaii, cute, blushing, adorable]
+  dead:       [dead, ko, knocked_out, defeated]
+  smoking:    [smoking, chill_smoke, relaxed_smoke]
+  wired:      [wired, caffeinated, hyper, jittery]
+  nervous:    [nervous, sweaty, anxious_face]
+  disoriented: [dizzy, woozy, vertigo]
 
-# Per-canonical render hints consumed across modules.
-#   oled    -> bitmap/animation name in oled_faces catalog
-#   palette -> neopixel emotion palette file (modules/neopixel/emotions/<palette>.yml)
-#   effect  -> neopixel animation effect
-#   ears    -> piservo emotion pose key
-#   tone    -> speak TTS tone preset
-#   rgb     -> direct fallback color when a palette is unavailable
 render:
-  neutral:    { oled: normal,     palette: neutral,      effect: BREATHE,        ears: neutral,   tone: neutral,  rgb: [40, 60, 80] }
-  joy:        { oled: happy,      palette: joy,          effect: RAINBOW_CYCLE,  ears: joy,       tone: joy,      rgb: [0, 200, 60] }
-  sadness:    { oled: sad,        palette: sadness,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [40, 80, 160] }
-  curiosity:  { oled: focused,    palette: curiosity,    effect: COMET,          ears: curiosity, tone: neutral,  rgb: [0, 180, 200] }
-  tired:      { oled: tired,      palette: neutral,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [80, 40, 120] }
-  fear:       { oled: scared,     palette: fear,         effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 0, 120] }
-  anger:      { oled: angry,      palette: anger,        effect: PULSE,          ears: anger,     tone: excited,  rgb: [220, 40, 0] }
-  furious:    { oled: furious,    palette: anger,        effect: METEOR,         ears: anger,     tone: excited,  rgb: [255, 0, 0] }
-  surprise:   { oled: surprised,  palette: surprise,     effect: TWINKLE,        ears: surprise,  tone: excited,  rgb: [255, 200, 0] }
-  excitement: { oled: excited,    palette: excitement,   effect: RAINBOW_CYCLE,  ears: surprise,  tone: excited,  rgb: [255, 120, 0] }
-  love:       { oled: lovely,     palette: love,         effect: PULSE,          ears: joy,       tone: joy,      rgb: [255, 40, 100] }
-  disgust:    { oled: worried,    palette: disgust,      effect: BREATHE,        ears: sadness,   tone: neutral,  rgb: [120, 160, 0] }
-  confusion:  { oled: confused,   palette: confusion,    effect: TWINKLE,        ears: curiosity, tone: neutral,  rgb: [160, 0, 200] }
-  worried:    { oled: worried,    palette: nervousness,  effect: BREATHE,        ears: fear,      tone: sadness,  rgb: [180, 100, 0] }
-  bored:      { oled: bored,      palette: neutral,      effect: BREATHE,        ears: sadness,   tone: neutral,  rgb: [60, 60, 60] }
+  neutral:     { oled: neutral,     palette: neutral,      effect: BREATHE,        ears: neutral,   tone: neutral,  rgb: [40, 60, 80] }
+  joy:         { oled: happy,       palette: joy,          effect: RAINBOW_CYCLE,  ears: joy,       tone: joy,      rgb: [0, 200, 60] }
+  sadness:     { oled: sad,         palette: sadness,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [40, 80, 160] }
+  curiosity:   { oled: attentive,   palette: curiosity,    effect: COMET,          ears: curiosity, tone: neutral,  rgb: [0, 180, 200] }
+  tired:       { oled: tired,       palette: neutral,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [80, 40, 120] }
+  fear:        { oled: scared,      palette: fear,         effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 0, 120] }
+  anger:       { oled: angry,       palette: anger,        effect: PULSE,          ears: anger,     tone: excited,  rgb: [220, 40, 0] }
+  furious:     { oled: furious,     palette: anger,        effect: METEOR,         ears: anger,     tone: excited,  rgb: [255, 0, 0] }
+  surprise:    { oled: surprised,   palette: surprise,     effect: TWINKLE,        ears: surprise,  tone: excited,  rgb: [255, 200, 0] }
+  excitement:  { oled: wired,       palette: excitement,   effect: RAINBOW_CYCLE,  ears: surprise,  tone: excited,  rgb: [255, 120, 0] }
+  love:        { oled: lovely,      palette: love,         effect: PULSE,          ears: joy,       tone: joy,      rgb: [255, 40, 100] }
+  disgust:     { oled: gloomy,       palette: disgust,      effect: BREATHE,        ears: sadness,   tone: neutral,  rgb: [120, 160, 0] }
+  confusion:   { oled: disoriented,  palette: confusion,    effect: TWINKLE,        ears: curiosity, tone: neutral,  rgb: [160, 0, 200] }
+  worried:     { oled: nervous,      palette: nervousness,  effect: BREATHE,        ears: fear,      tone: sadness,  rgb: [180, 100, 0] }
+  bored:       { oled: bored,        palette: neutral,      effect: BREATHE,        ears: sadness,   tone: neutral,  rgb: [60, 60, 60] }
+  suspicious:  { oled: suspicious,   palette: neutral,      effect: BREATHE,        ears: curiosity, tone: neutral,  rgb: [90, 90, 70] }
+  awe:         { oled: awe,          palette: surprise,     effect: TWINKLE,        ears: surprise,  tone: excited,  rgb: [255, 220, 120] }
+  gloomy:      { oled: gloomy,        palette: sadness,      effect: BREATHE,        ears: sadness,   tone: sadness,  rgb: [50, 70, 110] }
+  cool:        { oled: cool,          palette: neutral,      effect: BREATHE,        ears: neutral,   tone: neutral,  rgb: [70, 90, 120] }
+  devil:       { oled: devil,         palette: anger,        effect: PULSE,          ears: anger,     tone: excited,  rgb: [200, 0, 60] }
+  kawaii:      { oled: kawaii,        palette: love,         effect: TWINKLE,        ears: joy,       tone: joy,      rgb: [255, 140, 180] }
+  dead:        { oled: dead,          palette: neutral,      effect: BREATHE,        ears: neutral,   tone: neutral,  rgb: [40, 40, 40] }
+  smoking:     { oled: smoking,       palette: neutral,      effect: BREATHE,        ears: neutral,   tone: neutral,  rgb: [80, 80, 80] }
+  wired:       { oled: wired,         palette: excitement,   effect: COMET,          ears: surprise,  tone: excited,  rgb: [255, 120, 0] }
+  nervous:     { oled: nervous,       palette: nervousness,  effect: PULSE,          ears: fear,      tone: sadness,  rgb: [200, 160, 0] }
+  disoriented: { oled: disoriented,   palette: confusion,    effect: TWINKLE,        ears: curiosity, tone: neutral,  rgb: [140, 80, 200] }
 
 default_canonical: neutral

--- a/modules/oled_faces/README.md
+++ b/modules/oled_faces/README.md
@@ -5,7 +5,7 @@ Robot durum/olay sinyallerini Raspberry Pi SSD1306 OLED ekranda **Pip tarzı pro
 ## Kaynaklar
 - Durum: `state_manager` (`operational`, `emotions`)
 - Olaylar: `interactions` event akışı
-- Yüz motoru: `services/eyes/` (moods, gestures, activities — esp-bridge-mcp-robot Pip motoru)
+- Yüz motoru: `services/eyes/` (moods, gestures, activities — [esp-bridge-mcp-robot](https://github.com/WhoIsMrSentry/esp-bridge-mcp-robot) Pip motoru, senkron: `src/modules/espbridge/eyes/`)
 
 ## API
 - `GET /oled_faces/healthz`
@@ -16,3 +16,4 @@ Robot durum/olay sinyallerini Raspberry Pi SSD1306 OLED ekranda **Pip tarzı pro
 ## Not
 - OLED sürüşü Pi I2C üzerinden (`display` ayarları: `config/config.yml`).
 - Eski Irisoled bitmap/JSON varlıkları kaldırıldı; legacy isimler `services/legacy_map.py` ile Pip motoruna yönlendirilir.
+- `config_loader` açılışta `catalog_registry.expand_config()` ile **31 mood + 24 gesture + 8 activity** motor girdisini `event_map` ve `idle_ambient.pool` içine birleştirir (`use_full_catalog: true`).

--- a/modules/oled_faces/__init__.py
+++ b/modules/oled_faces/__init__.py
@@ -1,3 +1,17 @@
-from .xOledFacesService import xOledFacesService
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .xOledFacesService import xOledFacesService as xOledFacesService
+
+
+def __getattr__(name: str):
+    if name == "xOledFacesService":
+        from .xOledFacesService import xOledFacesService
+
+        return xOledFacesService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["xOledFacesService"]

--- a/modules/oled_faces/config/config.yml
+++ b/modules/oled_faces/config/config.yml
@@ -27,6 +27,9 @@ priority_map:
   emotion:fear: 88
   emotion:angry: 86
   emotion:furious: 90
+  gesture:smoke: 40
+  gesture:laugh: 38
+  activity:editing: 42
 
 display:
   enabled: true
@@ -35,6 +38,7 @@ display:
   width: 128
   height: 64
   contrast: 143 # 0x8F
+  brightness: 255
   fps: 24
   column_offset: 0
   seg_remap: true
@@ -49,44 +53,44 @@ fallback_unknown: normal
 
 idle_ambient:
   enabled: true
-  min_interval_s: 14
-  max_interval_s: 40
-  hold_s: 9
+  use_full_catalog: true
+  min_interval_s: 18
+  max_interval_s: 45
+  hold_s: 6
   priority: 32
-  pool:
-    - { mode: bitmap, name: smoking }
-    - { mode: animation, name: thinking }
-    - { mode: bitmap, name: bored }
-    - { mode: animation, name: searching }
-    - { mode: bitmap, name: lovely }
-    - { mode: animation, name: working }
-    - { mode: bitmap, name: skeptical }
-    - { mode: gesture, name: nod }
-    - { mode: bitmap, name: dumb }
-    - { mode: animation, name: processing }
-    - { mode: bitmap, name: tired }
-    - { mode: animation, name: connecting }
+  pool: []
 
 state_map:
   idle: { mode: bitmap, name: normal }
   boot: { mode: logo, name: logo }
   active: { mode: bitmap, name: attentive }
+  maintenance: { mode: bitmap, name: cool }
   listening: { mode: animation, name: listening }
   thinking: { mode: animation, name: thinking }
   speaking: { mode: animation, name: thinking }
   sleeping: { mode: animation, name: sleep }
   alert: { mode: animation, name: alert }
   low_battery: { mode: bitmap, name: battery_low }
-  charging: { mode: bitmap, name: battery }
+  charging: { mode: bitmap, name: standby }
   charged: { mode: bitmap, name: battery_full }
 
 event_map:
+  # --- speech / agent sessions ---
   wakeword.detected: { mode: animation, name: listening }
   speech.listen.start: { mode: animation, name: listening }
   speech.listen.end: { mode: bitmap, name: normal }
   speech.start: { mode: animation, name: thinking }
+  speech.end: { mode: bitmap, name: normal }
   agent.thinking: { mode: animation, name: thinking }
+  agent.editing: { mode: animation, name: editing }
+  agent.processing: { mode: animation, name: processing }
+  agent.connecting: { mode: animation, name: connecting }
+
+  # --- vision ---
   vision.person: { mode: animation, name: searching }
+  vision.focus: { mode: bitmap, name: focused }
+
+  # --- autonomy idle / body language ---
   autonomy.calm: { mode: bitmap, name: normal }
   autonomy.excited: { mode: gesture, name: excited }
   autonomy.angry: { mode: bitmap, name: furious }
@@ -98,32 +102,82 @@ event_map:
   autonomy.sleep: { mode: animation, name: sleep }
   autonomy.wake: { mode: bitmap, name: normal }
   autonomy.offline: { mode: animation, name: connecting }
-  vision.focus: { mode: bitmap, name: focused }
-  error: { mode: gesture, name: scan_sweep }
-  warning: { mode: bitmap, name: alert }
+  autonomy.nod: { mode: gesture, name: nod }
+  autonomy.refuse: { mode: gesture, name: refuse }
+  autonomy.laugh: { mode: gesture, name: laugh }
+  autonomy.smoke: { mode: gesture, name: smoke }
+  autonomy.shiver: { mode: gesture, name: shiver }
+  autonomy.squint: { mode: gesture, name: squint }
+  autonomy.pop: { mode: gesture, name: pop }
+  autonomy.roll: { mode: gesture, name: roll }
+  autonomy.cross_eyes: { mode: gesture, name: cross_eyes }
+
+  # --- owner / security ---
   owner.scan: { mode: gesture, name: look_left }
   owner.rfid: { mode: gesture, name: wink }
   owner.temp_granted: { mode: bitmap, name: happy }
-  owner.temp_revoked: { mode: bitmap, name: worried }
+  owner.temp_revoked: { mode: bitmap, name: nervous }
   owner.locked: { mode: bitmap, name: scared }
+
+  # --- system ---
+  error: { mode: gesture, name: scan_sweep }
+  warning: { mode: bitmap, name: alert }
+
+  # --- canonical emotions (autonomy mood / expression_director) ---
+  emotion:neutral: { mode: bitmap, name: neutral }
+  emotion:joy: { mode: bitmap, name: happy }
+  emotion:sadness: { mode: bitmap, name: sad }
+  emotion:curiosity: { mode: bitmap, name: attentive }
+  emotion:tired: { mode: bitmap, name: tired }
+  emotion:fear: { mode: bitmap, name: scared }
+  emotion:anger: { mode: bitmap, name: angry }
+  emotion:furious: { mode: bitmap, name: furious }
+  emotion:surprise: { mode: bitmap, name: surprised }
+  emotion:excitement: { mode: bitmap, name: wired }
+  emotion:love: { mode: bitmap, name: lovely }
+  emotion:disgust: { mode: bitmap, name: gloomy }
+  emotion:confusion: { mode: bitmap, name: disoriented }
+  emotion:worried: { mode: bitmap, name: nervous }
+  emotion:bored: { mode: bitmap, name: bored }
+  emotion:suspicious: { mode: bitmap, name: suspicious }
+  emotion:awe: { mode: bitmap, name: awe }
+  emotion:gloomy: { mode: bitmap, name: gloomy }
+  emotion:cool: { mode: bitmap, name: cool }
+  emotion:devil: { mode: bitmap, name: devil }
+  emotion:kawaii: { mode: bitmap, name: kawaii }
+  emotion:dead: { mode: bitmap, name: dead }
+  emotion:smoking: { mode: bitmap, name: smoking }
+  emotion:disoriented: { mode: bitmap, name: disoriented }
+  emotion:wired: { mode: bitmap, name: wired }
+  emotion:nervous: { mode: bitmap, name: nervous }
+
+  # --- legacy emotion event labels (backward compatible) ---
   emotion:happy: { mode: bitmap, name: happy }
   emotion:joy: { mode: bitmap, name: happy }
   emotion:sad: { mode: bitmap, name: sad }
   emotion:surprised: { mode: bitmap, name: surprised }
   emotion:sleepy: { mode: bitmap, name: sleepy }
-  emotion:confused: { mode: bitmap, name: confused }
+  emotion:confused: { mode: bitmap, name: disoriented }
   emotion:angry: { mode: bitmap, name: angry }
   emotion:anger: { mode: bitmap, name: angry }
   emotion:furious: { mode: bitmap, name: furious }
   emotion:bored: { mode: bitmap, name: bored }
-  emotion:despair: { mode: bitmap, name: despair }
-  emotion:worried: { mode: bitmap, name: worried }
   emotion:scared: { mode: bitmap, name: scared }
   emotion:focused: { mode: bitmap, name: focused }
-  emotion:excited: { mode: bitmap, name: excited }
+  emotion:excited: { mode: bitmap, name: wired }
   emotion:love: { mode: bitmap, name: lovely }
   emotion:curiosity: { mode: bitmap, name: attentive }
-  emotion:tired: { mode: bitmap, name: tired }
+  emotion:despair: { mode: bitmap, name: despair }
+  emotion:worried: { mode: bitmap, name: nervous }
+
+  # --- emotion scenes (autonomy config scenes) ---
+  scene.emotion_joy: { mode: bitmap, name: happy }
+  scene.emotion_curiosity: { mode: bitmap, name: attentive }
+  scene.emotion_fear: { mode: bitmap, name: scared }
+  scene.emotion_tired: { mode: bitmap, name: tired }
+  scene.emotion_sad: { mode: bitmap, name: sad }
+  scene.emotion_angry: { mode: bitmap, name: angry }
+  scene.emotion_furious: { mode: bitmap, name: furious }
 
 arduino_event_map:
   rfid: { mode: gesture, name: wink }

--- a/modules/oled_faces/config_loader.py
+++ b/modules/oled_faces/config_loader.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Optional
 
 import yaml
 
+from .services.catalog_registry import expand_config
+
 _DEFAULT_CFG_PATH = Path(__file__).parent / "config" / "config.yml"
 
 
@@ -16,4 +18,4 @@ def load_config(path: Optional[str] = None, overrides: Optional[Dict[str, Any]] 
         cfg: Dict[str, Any] = yaml.safe_load(f) or {}
     if overrides:
         cfg.update(overrides)
-    return cfg
+    return expand_config(cfg)

--- a/modules/oled_faces/services/catalog_registry.py
+++ b/modules/oled_faces/services/catalog_registry.py
@@ -1,0 +1,78 @@
+"""Motor catalog (moods / gestures / activities) and config expansion helpers."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from .eyes.activities import ACTIVITIES
+from .eyes.gestures import BLINKS, GESTURES_FN
+from .eyes.moods import MOODS
+from .mapper import OledAction
+
+# 31 moods, 24 gestures (7 blinks + 17 moves), 8 busy activities (+ idle)
+MOTOR_MOODS: Tuple[str, ...] = tuple(MOODS.keys())
+MOTOR_GESTURES: Tuple[str, ...] = tuple(BLINKS) + tuple(GESTURES_FN)
+MOTOR_ACTIVITIES: Tuple[str, ...] = tuple(a for a in ACTIVITIES if a != "idle")
+
+
+def build_catalog_pool() -> List[Dict[str, str]]:
+    """Flat playlist covering every motor entry (idle ambient round-robin)."""
+    items: List[Dict[str, str]] = []
+    for mood in MOTOR_MOODS:
+        items.append({"mode": "bitmap", "name": mood})
+    for gesture in MOTOR_GESTURES:
+        items.append({"mode": "gesture", "name": gesture})
+    for activity in MOTOR_ACTIVITIES:
+        items.append({"mode": "animation", "name": activity})
+    return items
+
+
+def build_motor_event_map() -> Dict[str, Dict[str, str]]:
+    """Default event_map entries so every motor name is addressable as an event."""
+    out: Dict[str, Dict[str, str]] = {}
+    for mood in MOTOR_MOODS:
+        out[f"emotion:{mood}"] = {"mode": "bitmap", "name": mood}
+    for gesture in MOTOR_GESTURES:
+        out[f"gesture:{gesture}"] = {"mode": "gesture", "name": gesture}
+    for activity in MOTOR_ACTIVITIES:
+        out[f"activity:{activity}"] = {"mode": "animation", "name": activity}
+    return out
+
+
+def expand_config(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge motor catalog into event_map and idle_ambient pool (config overrides win)."""
+    merged = dict(cfg)
+    motor_events = build_motor_event_map()
+    user_events = dict(merged.get("event_map") or {})
+    merged["event_map"] = {**motor_events, **user_events}
+
+    ambient = dict(merged.get("idle_ambient") or {})
+    if bool(ambient.get("use_full_catalog", True)):
+        user_pool = list(ambient.get("pool") or [])
+        seen = {(str(i.get("mode", "")).lower(), str(i.get("name", "")).lower()) for i in user_pool if isinstance(i, dict)}
+        pool = list(user_pool)
+        for item in build_catalog_pool():
+            key = (item["mode"], item["name"])
+            if key not in seen:
+                pool.append(item)
+                seen.add(key)
+        ambient["pool"] = pool
+    merged["idle_ambient"] = ambient
+    return merged
+
+
+def catalog_pool_actions() -> List[OledAction]:
+    return [
+        OledAction(mode=str(i["mode"]), name=str(i["name"]))
+        for i in build_catalog_pool()
+    ]
+
+
+__all__ = [
+    "MOTOR_MOODS",
+    "MOTOR_GESTURES",
+    "MOTOR_ACTIVITIES",
+    "build_catalog_pool",
+    "build_motor_event_map",
+    "expand_config",
+    "catalog_pool_actions",
+]

--- a/modules/oled_faces/services/eyes/activities.py
+++ b/modules/oled_faces/services/eyes/activities.py
@@ -7,10 +7,10 @@ import math
 from .primitives import draw_formula
 
 ACTIVITIES = ("idle", "thinking", "scanning", "searching", "working", "listening",
-              "processing", "connecting")
+              "processing", "connecting", "editing")
 # each busy activity wears a fitting face; listening just stays attentive (neutral)
 ACT_MOOD = {"thinking": "focused", "scanning": "neutral", "searching": "focused",
-            "working": "focused", "listening": "neutral",
+            "working": "focused", "listening": "neutral", "editing": "smoking",
             "processing": "focused", "connecting": "attentive"}
 
 
@@ -88,6 +88,23 @@ def _hammer(d, W, H, now):
             d.line([ax, ay - 1, ax + math.cos(a) * L, ay - 1 + math.sin(a) * L], fill=1, width=2)
 
 
+def _typing(d, W, H, now):
+    # two small chibi hands tap the keys -- "editing" (just hands, no arms)
+    base = H - 3                                          # key row the fingertips reach
+    for i, cx in enumerate((18, W - 18)):               # left & right hand, near the edges
+        tap = round((math.sin(now * 8 + i * math.pi) + 1) / 2 * 3)   # alternating peck
+        cy = base - 6 + tap                             # whole hand dips to press
+        thumb = cx + (7 if i == 0 else -7)              # thumb tucked toward the centre
+        d.ellipse([thumb - 2, cy - 3, thumb + 3, cy + 2], fill=1)    # thumb nub
+        d.rounded_rectangle([cx - 7, cy - 5, cx + 7, cy + 2], radius=3, fill=1)  # back of hand
+        for k in range(4):                              # four little fingertips on the keys
+            fx = cx - 5 + k * 4
+            d.ellipse([fx - 2, cy, fx + 2, cy + 5], fill=1)
+        for k in range(3):                              # notches between the fingers
+            nx = cx - 3 + k * 4
+            d.line([nx, cy + 1, nx, cy + 5], fill=0, width=1)
+
+
 def _arc_ring(d, W, H, now):
     # a sleek arc sweeps around a ring -- "processing / computing"
     cx, cy, rad = W // 2, H - 11, 8
@@ -108,4 +125,5 @@ def _link_dots(d, W, H, now):
 # act name -> overlay painter (activities without one just move the gaze)
 OVERLAYS = {"thinking": _think, "searching": _magnifier,
             "working": _hammer, "listening": _headphones,
-            "processing": _arc_ring, "connecting": _link_dots}
+            "processing": _arc_ring, "connecting": _link_dots,
+            "editing": _typing}

--- a/modules/oled_faces/services/eyes/engine.py
+++ b/modules/oled_faces/services/eyes/engine.py
@@ -16,7 +16,7 @@ import time
 from PIL import Image, ImageDraw
 
 from .activities import ACT_MOOD, ACTIVITIES, OVERLAYS, pose
-from .gestures import BLINKS, GESTURES_FN
+from .gestures import BLINKS, GESTURE_FACE, GESTURE_FX, GESTURES_FN
 from .moods import MOODS
 from .primitives import ease, rounded_rect
 
@@ -27,8 +27,11 @@ _MASK = ({"left", "right"}, 0.24, 1, 0.5)    # blink that hides a mood's lid swa
 
 class EyeEngine:
     def __init__(self, show, *, width=128, height=64, fps=30,
-                 eye_w=36, eye_h=36, radius=12, gap=10):
+                 eye_w=36, eye_h=36, radius=12, gap=10,
+                 set_brightness=None, bright=255):        # bright = general panel brightness, max by default
         self._show = show
+        self._set_brightness, self._bright = set_brightness, bright
+        self._cur_bright = None                          # unset -> first frame pushes the general level
         self.W, self.H, self.fps = width, height, max(5, fps)
         self.eye_w, self.eye_h, self.radius, self.gap = eye_w, eye_h, radius, gap
         self.base_lx = (width - (2 * eye_w + gap)) // 2
@@ -44,6 +47,7 @@ class EyeEngine:
         self._pending = None                             # mood waiting for the layer to free
         self.look_x = self.look_y = 0.0                  # resting gaze target
         self._blink = self._gesture = self._activity = None
+        self._restore_mood = None                        # mood to return to after a face-swapping gesture
         self._next_blink = self._next_idle = 0.0
         self._stop = threading.Event()
         self._thread = None
@@ -63,6 +67,7 @@ class EyeEngine:
     def set_mood(self, mood):
         m = mood.lower() if mood and mood.lower() in MOODS else "neutral"
         with self._lock:
+            self._restore_mood = None                    # an explicit mood change cancels a pending gesture-restore
             if m == self.mood:
                 self._pending = None
             elif self._blink or self._gesture:           # busy -> apply (masked) once free
@@ -77,11 +82,16 @@ class EyeEngine:
         name = (name or "none").lower()
         now = time.monotonic()
         with self._lock:
+            if self._restore_mood is not None:           # a prior face-gesture is interrupted -> restore its mood first
+                self.mood, self._restore_mood = self._restore_mood, None
             if name in BLINKS:
                 self._begin_blink(now, BLINKS[name])
             elif name in GESTURES_FN:
                 self._blink = None
                 self._gesture = {"kind": name, "start": now, "dur": GESTURES_FN[name][0]}
+                if name in GESTURE_FACE:                  # wear another mood for the gesture, restore it when done
+                    self._restore_mood = self.mood
+                    self.mood, self._pending = GESTURE_FACE[name], None
 
     def set_activity(self, name):
         """Loop a status animation (thinking/scanning/...); 'idle' stops it. Each busy
@@ -123,6 +133,8 @@ class EyeEngine:
                 self._blink = None
             if self._gesture and now - self._gesture["start"] > self._gesture["dur"]:
                 self._gesture = None
+                if self._restore_mood is not None:        # face-swapping gesture finished -> restore the original mood
+                    self.mood, self._restore_mood = self._restore_mood, None
             free = not (self._blink or self._gesture)
             if free and self._pending:                       # masked deferred mood swap
                 self.mood, self._pending = self._pending, None
@@ -136,8 +148,17 @@ class EyeEngine:
                 self._next_idle = now + random.uniform(1.5, 5)
             mood, act, look = self.mood, self._activity, (self.look_x, self.look_y)
 
-        bw = self.eye_w + MOODS[mood].get("dw", 0)
-        bh = self.eye_h + MOODS[mood].get("dh", 0)
+        spec = MOODS[mood]
+        target = min(spec.get("bright", self._bright), self._bright)  # emote may dim, capped at the general max
+        if self._set_brightness and target != self._cur_bright:
+            try:
+                self._set_brightness(target)
+                self._cur_bright = target
+            except Exception:
+                pass                                      # BLE hiccup -- retry next frame
+
+        bw = self.eye_w + spec.get("dw", 0)
+        bh = self.eye_h + spec.get("dh", 0)
         if act:
             tx, ty, hmult = pose(act, now)
             bh *= hmult
@@ -165,9 +186,11 @@ class EyeEngine:
         dx = dy = conv = 0.0
         msw = msh = 1.0
         gbias = 0.0
+        gkind = gph = genv = None
         if g:
             ph = min(1.0, (now - g["start"]) / g["dur"])
-            ret = GESTURES_FN[g["kind"]][1](ph, math.sin(ph * math.pi))
+            gkind, gph, genv = g["kind"], ph, math.sin(ph * math.pi)
+            ret = GESTURES_FN[g["kind"]][1](ph, genv)
             dx, dy, conv, msw, msh = ret[:5]
             gbias = ret[5] if len(ret) > 5 else 0.0
 
@@ -178,7 +201,9 @@ class EyeEngine:
         d = self._draw
         d.rectangle([0, 0, self.W - 1, self.H - 1], fill=0)   # clear the reused buffer
         slot = self.base_lx + self.gx + dx                    # left eye's slot origin
-        for sx, openness, right in ((slot, ol, False), (slot + self.eye_w + self.gap, or_, True)):
+        eyes = () if spec.get("bare") else \
+            ((slot, ol, False), (slot + self.eye_w + self.gap, or_, True))  # 'bare' draws no eyes
+        for sx, openness, right in eyes:
             es = 1.0 + (bias if right else -bias)             # parallax: the near eye swells
             w = max(2.0, self.ew * msw * es)
             ho = max(2.0, self.eh * msh * es)                 # open height (before the blink)
@@ -194,4 +219,6 @@ class EyeEngine:
             spec["decor"](d, self.W, self.H, now, self.gx, self.gy)
         if act in OVERLAYS:
             OVERLAYS[act](d, self.W, self.H, now)
+        if gkind in GESTURE_FX:                           # gesture-time extras (e.g. a smoke cloud)
+            GESTURE_FX[gkind](d, self.W, self.H, gph, genv)
         return self._img

--- a/modules/oled_faces/services/eyes/gestures.py
+++ b/modules/oled_faces/services/eyes/gestures.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import math
 
+from .primitives import smoothstep
+
 _PI = math.pi
 
 # blink timeline: name -> (eyes, duration, closes, anchor)
@@ -29,7 +31,7 @@ def _look(dx, dy, bias=0.0):
             hold = (1.0 - p) / 0.20
         else:               # hold the look
             hold = 1.0
-        hold = hold * hold * (3 - 2 * hold)   # smoothstep the ramps
+        hold = smoothstep(hold)               # ease the ramps
         s = 1.0 - 0.12 * hold                 # mild foreshorten (parallax carries the turn)
         return dx * hold, dy * hold, 0.0, s, s, bias * hold
     return fn
@@ -38,8 +40,9 @@ def _look(dx, dy, bias=0.0):
 # one-shot motion: name -> (duration, fn(ph, env) -> (dx, dy, conv, scale_w, scale_h))
 # ph 0..1 is gesture progress; env = sin(ph*pi) fades the move in and out.
 GESTURES_FN = {
-    "nod":        (0.7, lambda p, e: (0.0, math.sin(p * _PI * 4) * 6 * e, 0.0, 1.0, 1.0)),
-    "refuse":     (0.6, lambda p, e: (math.sin(p * _PI * 6) * 9 * e, 0.0, 0.0, 1.0, 1.0)),
+    "smoke":      (3.8, lambda p, e: (0.0, 0.0, 0.0, 1.0, 1.0)),                              # slow drag -- the cigarette does the work
+    "nod":        (1.4, lambda p, e: (0.0, math.sin(p * _PI * 8) * 6 * e, 0.0, 1.0, 1.0)),    # two nods, same speed
+    "refuse":     (1.2, lambda p, e: (math.sin(p * _PI * 12) * 9 * e, 0.0, 0.0, 1.0, 1.0)),   # two shakes, same speed
     "laugh":      (1.4, lambda p, e: (0.0, -abs(math.sin(p * _PI * 4)) * 7 * e, 0.0, 1.0, 1.0 - 0.4 * e)),
     "excited":    (0.9, lambda p, e: (0.0, -abs(math.sin(p * _PI * 5)) * 8 * e, 0.0, 1.0 + 0.22 * e, 1.0 + 0.22 * e)),
     "roll":       (0.9, lambda p, e: (math.cos(p * _PI * 2) * 11 * e, math.sin(p * _PI * 2) * 7 * e, 0.0, 1.0, 1.0)),
@@ -53,9 +56,54 @@ GESTURES_FN = {
     "look_up":    (1.2, _look(0, -10)),
     "look_down":  (1.2, _look(0, 10)),
     "acknowledge": (0.45, lambda p, e: (0.0, e * 8, 0.0, 1.0, 1.0)),                       # one crisp dip -- "on it"
-    "boot_up":     (0.6, lambda p, e: (0.0, 0.0, 0.0, 0.15 + 0.85 * p, 0.15 + 0.85 * p)),  # iris in from nothing
-    "power_down":  (0.7, lambda p, e: (0.0, 0.0, 0.0, 1.0 - 0.85 * e, 1.0 - 0.92 * e)),    # collapse to a dot -- sign-off
     "scan_sweep":  (1.6, lambda p, e: (-math.sin(p * _PI * 2) * 15, 0.0, 0.0, 1.0, 1.0)),  # one smooth sensor sweep
 }
+
+def _smoking_act(d, W, H, p, e):
+    """Lift the cigarette to the lips with a thin curl of smoke (like the smoking mood);
+    on the slow inhale the wisp fades; on the exhale the cig pulls away and a thick plume pours out."""
+    mx, my = W * 0.5, H - 9                            # the mouth
+    lift = smoothstep(p / 0.12)                       # bring the cigarette up to the lips
+    away = smoothstep((p - 0.55) / 0.30) if p > 0.55 else 0.0   # then pull it away on the exhale
+    ax, ay = away * 10, away * 8
+    rfx, rfy = W * 0.55, H - 1                          # resting hold, low
+    # filter end at the lips; the body + ember reach out so the cigarette stays visible
+    fx, fy = rfx + (mx - 4 - rfx) * lift + ax, rfy + (my - rfy) * lift + ay
+    ex, ey = rfx + 18 + (mx + 16 - (rfx + 18)) * lift + ax, rfy - 3 + (my - 2 - (rfy - 3)) * lift + ay
+    d.line([fx, fy, ex, ey], fill=1, width=3)         # cigarette body
+    glow = 3 if 0.35 <= p < 0.55 else 2               # ember flares as the breath is drawn in
+    d.ellipse([ex - glow, ey - glow, ex + glow, ey + glow], fill=1)
+
+    thin = lift if p < 0.35 else max(0.0, 1.0 - smoothstep((p - 0.35) / 0.20))  # wisp fades on the inhale
+    if thin > 0.03:
+        pts = [(ex + math.sin(f * 4.5 - p * 9) * (f * f * 5), ey - 2 - f * 20 * thin)
+               for f in (i / 10 for i in range(11))]
+        d.line(pts, fill=1, width=1)                   # a single thin curl off the tip
+
+    if p <= 0.55:
+        return
+    eq = (p - 0.55) / 0.45                            # 0..1 across the exhale
+    rise = smoothstep(eq) * 1.7                       # the plume drifts slowly upward
+    fade = 1.0 if eq < 0.4 else smoothstep((1.0 - eq) / 0.6)   # then dissipates gently, over a long tail
+    for i in range(22):
+        f = i / 21.0
+        front = rise - f * 0.9
+        if front <= 0:
+            continue
+        cxl = mx + math.sin(f * 3.4 + p * 4) * (2 + f * 11)
+        spread = 3 + f * 16
+        base = (2.5 + f * 8) * min(1.0, front * 2.4) * fade   # fade shrinks every puff toward the end
+        for j in (-1, 0, 1):                          # a few puffs across the width -> a full, soft plume
+            bx, by = cxl + j * spread * 0.5, my - f * (my + 2) - rise * 3   # the whole plume drifts up as it fades
+            rad = base * (1.0 - 0.28 * abs(j))
+            if rad > 0.5:
+                d.ellipse([bx - rad, by - rad, bx + rad, by + rad], fill=1)
+
+
+# gesture-time painters: name -> fn(d, W, H, ph, env), drawn on top of the face
+GESTURE_FX = {"smoke": _smoking_act}
+
+# while a gesture plays, wear another mood's eye-look (name -> mood whose paint to borrow)
+GESTURE_FACE = {"smoke": "bored"}
 
 GESTURES = ("none",) + tuple(BLINKS) + tuple(GESTURES_FN)

--- a/modules/oled_faces/services/eyes/moods.py
+++ b/modules/oled_faces/services/eyes/moods.py
@@ -46,7 +46,6 @@ def _focused(d, x, y, w, h, r, ir):   _lids(d, x, y, w, h, 0.24, 0.76)      # de
 def _sleepy(d, x, y, w, h, r, ir):    _lids(d, x, y, w, h, 0.5, 0.82)       # droopy slits
 def _despair(d, x, y, w, h, r, ir):   _lids(d, x, y, w, h, 0.42, 0.62)      # drained slit
 def _attentive(d, x, y, w, h, r, ir): _lids(d, x, y, w, h, top=0.12)        # crisp top lid -- locked on
-def _standby(d, x, y, w, h, r, ir):   _lids(d, x, y, w, h, 0.34, 0.70)      # calm low-power band
 def _smoking(d, x, y, w, h, r, ir):   _lids(d, x, y, w, h, top=0.45)        # heavy-lidded, chilled out
 
 
@@ -74,6 +73,9 @@ def _dead(d, x, y, w, h, r, ir):  # KO -- an X carved across the eye
     d.line([x + w - 4, y + 3, x + 3, y + h - 4], fill=0, width=lw)
 
 
+def _suspicious(d, x, y, w, h, r, ir): _lids(d, x, y, w, h, 0.40, 0.88)      # heavy slit + pinched bottom -- side-eye
+
+
 def _decor_lovely(d, W, H, now, ox=0.0, oy=0.0):  # little hearts & sparkles scattered around -- smitten
     spots = ((0.50, 0.07), (0.24, 0.14), (0.76, 0.12), (0.05, 0.40), (0.95, 0.42),
              (0.07, 0.74), (0.93, 0.72), (0.28, 0.90), (0.72, 0.88))
@@ -93,15 +95,102 @@ def _decor_smoke(d, W, H, now, ox=0.0, oy=0.0):  # a lit cigarette, slightly rig
     d.line(pts, fill=1, width=2, joint="curve")      # a single slow, flowing smoke line
 
 
-# spec keys: dw/dh size delta, tilt per-eye y offset, bias per-eye size skew,
-# paint lid carver, decor face extras. Everything is optional.
+def _decor_coffee(d, W, H, now, ox=0.0, oy=0.0):  # a steaming mug, bottom-right -- "wired / caffeinated"
+    cx, cy = W - 20, H - 11
+    d.rounded_rectangle([cx, cy, cx + 12, cy + 9], radius=2, fill=1)              # cup body
+    d.arc([cx + 11, cy + 1, cx + 17, cy + 8], start=-80, end=80, fill=1, width=2)  # handle
+    for i in range(2):                                                            # two rising steam curls
+        sx = cx + 3 + i * 6
+        pts = [(sx + math.sin(f * 5 - now * 3) * 2.5, cy - 1 - f * 9) for f in (j / 6 for j in range(7))]
+        d.line(pts, fill=1, width=1, joint="curve")
+
+
+def _decor_sweat(d, W, H, now, ox=0.0, oy=0.0):  # a nervous bead wells up by the brow then slides -- "nervous"
+    t = (now * 0.8) % 1.0
+    x, y, s = W - 16 + int(ox), 8 + t * 11, 3
+    d.ellipse([x - s * 0.7, y - s * 0.3, x + s * 0.7, y + s], fill=1)             # rounded body
+    d.polygon([(x, y - s - 3), (x - s * 0.6, y - s * 0.2), (x + s * 0.6, y - s * 0.2)], fill=1)  # pointed top
+
+
+def _decor_cloud(d, W, H, now, ox=0.0, oy=0.0):  # a little rain cloud drizzles overhead -- "gloomy"
+    cx, cy = W // 2 + int(ox), 7
+    for dx, r in ((-7, 4), (0, 5), (7, 4)):                                       # three lumps + flat base
+        d.ellipse([cx + dx - r, cy - r, cx + dx + r, cy + r], fill=1)
+    d.rectangle([cx - 11, cy, cx + 11, cy + 3], fill=1)
+    for i in range(4):                                                            # falling rain streaks
+        t = (now * 1.5 + i / 4) % 1.0
+        rx, ry = cx - 9 + i * 6, cy + 5 + t * 12
+        d.line([rx, ry, rx - 1, ry + 3], fill=1, width=1)
+
+
+def _decor_vein(d, W, H, now, ox=0.0, oy=0.0):  # a cross-shaped popping anger vein throbs by the brow -- furious
+    cx, cy = 16 + int(ox), 8
+    s = 5 + (math.sin(now * 9) + 1)                                               # throb 5..7
+    for a in (45, 135, 225, 315):                                                # four inward chevrons (the 💢 cross)
+        ax, ay = math.cos(math.radians(a)), math.sin(math.radians(a))
+        ex, ey = cx + ax * s, cy + ay * s
+        d.line([ex, ey, ex - ax * 3 - ay * 2, ey - ay * 3 + ax * 2], fill=1, width=1)
+        d.line([ex, ey, ex - ax * 3 + ay * 2, ey - ay * 3 - ax * 2], fill=1, width=1)
+
+
+def _decor_sleep(d, W, H, now, ox=0.0, oy=0.0):  # "z z Z" drift up and grow -- sleepy
+    for i in range(3):
+        t = (now * 0.5 + i / 3) % 1.0
+        x, y = W // 2 + 16 + i * 6 + int(ox), H // 2 - 2 - t * 22
+        d.text((x, y), "Z" if i == 2 else "z", fill=1)
+
+
+# pixel-art "deal-with-it" shades: connected top frame, two lenses stepping down-inward.
+# '#' = dark lens block; gaps inside a lens are the white gleam ("one-way" glow).
+_SHADES_ART = (
+    "################################",   # connected top bar
+    "###############  ###############",   # center bridge notch
+    " ## # ########    ## # ######## ",   # gleam streaks, lower-left of each lens
+    "  ## # #######     ## # ######  ",
+    "   ## # #####       ## # ####   ",
+    "    ########         #######    ",   # angled lens bottoms
+)
+_SHADES_BLOCKS = [(c, r) for r, row in enumerate(_SHADES_ART)  # block (col, row) coords, scanned once
+                  for c, ch in enumerate(row) if ch == "#"]
+
+
+def _decor_cool(d, W, H, now, ox=0.0, oy=0.0):  # pixel-art shades, no eyes -- wanders side to side like eyes
+    u = 3                                                      # pixel-block size (96x48 -> leaves room to wander)
+    sway = round(math.sin(now * 0.7) * 9 + math.sin(now * 1.7) * 4)   # organic side-to-side wander
+    x0 = (W - len(_SHADES_ART[0]) * u) // 2 + sway
+    y0 = (H - len(_SHADES_ART) * u) // 2 + round(math.sin(now * 0.9) * 2)  # a small vertical bob
+    for c, r in _SHADES_BLOCKS:
+        px, py = x0 + c * u, y0 + r * u
+        d.rectangle([px, py, px + u - 1, py + u - 1], fill=1)
+
+
+def _decor_devil(d, W, H, now, ox=0.0, oy=0.0):  # two sharply-angled horns + a clean swaying tail -- "devil"
+    d.polygon([(30, 21), (41, 18), (18, 2)], fill=1)          # left horn, angled up-left
+    d.polygon([(W - 30, 21), (W - 41, 18), (W - 18, 2)], fill=1)  # right horn, angled up-right
+    bx, by = W - 6, H - 1                                      # tail from the bottom-right corner
+    tx, ty = W - 13 + math.sin(now * 2.2) * 3, H - 23          # tip sways gently
+    d.line([(bx, by), (W - 16, H - 12), (tx, ty)], fill=1, width=2, joint="curve")
+    d.polygon([(tx - 3, ty + 2), (tx + 3, ty + 2), (tx, ty - 5)], fill=1)  # spade barb
+
+
+def _decor_kawaii(d, W, H, now, ox=0.0, oy=0.0):  # rosy blush hatch + twinkles -- "kawaii"
+    for cx in (14, W - 24):                                    # a blush patch under each eye -- tracks the gaze
+        for i in range(3):
+            d.line([cx + i * 4 + ox, H - 12 + oy, cx + 3 + i * 4 + ox, H - 7 + oy], fill=1, width=1)
+    for fx, fy, s in ((0.07, 0.16, 4), (0.93, 0.18, 4), (0.5, 0.06, 3)):
+        sparkle(d, fx * W, fy * H, s)                          # ambient twinkles stay put
+
+
+# spec keys: dw/dh size delta, tilt per-eye y offset, bias per-eye size skew, paint lid
+# carver, decor face extras, bright panel brightness 0..255, bare draw no eyes. All optional.
 MOODS = {
     "neutral":     {},
+    "smoking":     {"dh": -4, "paint": _smoking, "decor": _decor_smoke},  # chilled, thin smoke curling up
     "happy":       {"paint": _happy},
     "sad":         {"dw": -4, "dh": -6, "paint": _sad},   # small + downcast
     "angry":       {"paint": _angry},
     "tired":       {"paint": _tired},
-    "sleepy":      {"dh": -20, "paint": _sleepy},
+    "sleepy":      {"dh": -20, "paint": _sleepy, "decor": _decor_sleep},  # droopy slits + drifting Zzz
     "surprised":   {"dw": -4, "dh": 10},
     "lovely":      {"dw": 2, "dh": 2, "decor": _decor_lovely},
     "skeptical":   {"paint": _skeptical},
@@ -112,12 +201,19 @@ MOODS = {
     "scared":      {"dw": -10, "dh": -4},
     "dead":        {"paint": _dead},
     "alert":       {"dw": -18},                            # two upright bars
-    "furious":     {"dw": 2, "dh": 2, "paint": _furious},
+    "furious":     {"dw": 2, "dh": 2, "paint": _furious, "decor": _decor_vein},  # rage + popping vein
     "worried":     {"dh": 2, "paint": _worried},           # open eyes + concerned brow
     "despair":     {"dw": -8, "dh": -6, "paint": _despair},
     "disoriented": {"tilt": 4, "bias": 0.3},               # mismatched sizes + tilt -- woozy
     "attentive":   {"dw": 2, "dh": 2, "paint": _attentive},  # leaned in, locked on -- "go ahead"
-    "standby":     {"dw": -6, "dh": -6, "paint": _standby},  # dim low-power idle -- ready, not off
-    "smoking":     {"dh": -4, "paint": _smoking, "decor": _decor_smoke},  # chilled, thin smoke curling up
+    "standby":     {"dw": -2, "dh": -24, "bright": 1},      # low dashes + dimmed panel -- low-power sleep
+    "suspicious":  {"dw": -2, "paint": _suspicious},                      # narrow slit eyes -- side-eye
+    "awe":         {"dw": 4, "dh": 14},                                   # huge open eyes -- pure wonder
+    "wired":       {"dw": 2, "dh": 2, "decor": _decor_coffee},            # caffeinated -- steaming mug
+    "nervous":     {"dw": -2, "paint": _worried, "decor": _decor_sweat},  # anxious brow + sweat bead
+    "gloomy":      {"dw": -2, "dh": -4, "paint": _sad, "decor": _decor_cloud},  # downcast + little rain cloud
+    "cool":        {"bare": True, "decor": _decor_cool},                  # just the aviators -- no eyes drawn
+    "devil":       {"paint": _angry, "decor": _decor_devil},              # evil glare + horns & tail
+    "kawaii":      {"dw": 2, "dh": 0, "decor": _decor_kawaii},            # round eyes + blush below + twinkles
 }
 EMOTIONS = tuple(MOODS)

--- a/modules/oled_faces/services/eyes/primitives.py
+++ b/modules/oled_faces/services/eyes/primitives.py
@@ -11,6 +11,12 @@ def ease(cur, tgt, dt, tau):
     return tgt + (cur - tgt) * math.exp(-dt / tau)
 
 
+def smoothstep(k):
+    """Hermite ease 0..1 with flat ends; clamps out-of-range input."""
+    k = max(0.0, min(1.0, k))
+    return k * k * (3 - 2 * k)
+
+
 def rounded_rect(d, x, y, w, h, r, fill):
     """rounded_rectangle with clamped radius (thin/blinking eyes never raise)."""
     if w <= 0 or h <= 0:

--- a/modules/oled_faces/services/face_renderer.py
+++ b/modules/oled_faces/services/face_renderer.py
@@ -25,6 +25,8 @@ class FaceRenderer:
             width=self._driver.width,
             height=self._driver.height,
             fps=self._fps,
+            set_brightness=self._driver.set_brightness,
+            bright=int(display_cfg.get("brightness", 255)),
         )
         self._engine.start()
         return True

--- a/modules/oled_faces/services/legacy_map.py
+++ b/modules/oled_faces/services/legacy_map.py
@@ -11,7 +11,15 @@ from .eyes.moods import MOODS
 # Legacy bitmap labels still emitted by emotion_vocab / config.
 _MOOD_ALIASES: Dict[str, str] = {
     "normal": "neutral",
-    "excited": "happy",
+    "excited": "wired",
+    "nervous": "nervous",
+    "wired": "wired",
+    "gloomy": "gloomy",
+    "kawaii": "kawaii",
+    "cool": "cool",
+    "devil": "devil",
+    "suspicious": "suspicious",
+    "awe": "awe",
     "look_down": "neutral",
     "look_left": "neutral",
     "look_right": "neutral",
@@ -114,4 +122,4 @@ def resolve_animation(name: str) -> FaceCommand:
 
 
 def resolve_logo() -> FaceCommand:
-    return FaceCommand(mood="attentive", gesture="boot_up")
+    return FaceCommand(mood="attentive", gesture="acknowledge")

--- a/modules/oled_faces/services/mapper.py
+++ b/modules/oled_faces/services/mapper.py
@@ -64,6 +64,12 @@ class FaceMapper:
         if key.startswith("emotion:"):
             label = key.split(":", 1)[1]
             return self.from_emotions([label])
+        if key.startswith("gesture:"):
+            name = key.split(":", 1)[1]
+            return OledAction(mode="gesture", name=name)
+        if key.startswith("activity:"):
+            name = key.split(":", 1)[1]
+            return OledAction(mode="animation", name=name)
         mapped = self.event_map.get(key)
         if isinstance(mapped, dict):
             return OledAction(mode=str(mapped.get("mode", "bitmap")), name=str(mapped.get("name", self.fallback_unknown)))

--- a/modules/oled_faces/services/pi_ssd1306_driver.py
+++ b/modules/oled_faces/services/pi_ssd1306_driver.py
@@ -119,6 +119,17 @@ class PiSsd1306Driver:
             end = start + self.width
             self._data(self._buffer[start:end])
 
+    def set_brightness(self, value: int) -> None:
+        """SSD1306 contrast 0..255; used by standby and mood-driven dimming."""
+        if not self._ok or self._bus is None:
+            return
+        level = max(0, min(255, int(value)))
+        if level == self.contrast:
+            return
+        self.contrast = level
+        self._cmd(0x81)
+        self._cmd(level)
+
     def _pil_to_buffer(self, image: Any) -> None:
         img = image.convert("1")
         if img.size != (self.width, self.height):

--- a/modules/oled_faces/tests/test_catalog_coverage.py
+++ b/modules/oled_faces/tests/test_catalog_coverage.py
@@ -1,0 +1,57 @@
+"""Ensure every Pip motor entry is wired through config expansion."""
+from __future__ import annotations
+
+from modules.oled_faces.config_loader import load_config
+from modules.oled_faces.services.catalog_registry import (
+    MOTOR_ACTIVITIES,
+    MOTOR_GESTURES,
+    MOTOR_MOODS,
+    build_catalog_pool,
+    build_motor_event_map,
+)
+
+
+def test_motor_catalog_sizes():
+    assert len(MOTOR_MOODS) == 31
+    assert len(MOTOR_GESTURES) == 24
+    assert len(MOTOR_ACTIVITIES) == 8
+
+
+def test_full_catalog_pool_covers_motor():
+    pool = build_catalog_pool()
+    modes = {(i["mode"], i["name"]) for i in pool}
+    for mood in MOTOR_MOODS:
+        assert ("bitmap", mood) in modes
+    for gesture in MOTOR_GESTURES:
+        assert ("gesture", gesture) in modes
+    for activity in MOTOR_ACTIVITIES:
+        assert ("animation", activity) in modes
+    assert len(pool) == 31 + 24 + 8
+
+
+def test_expand_config_registers_every_motor_event():
+    cfg = load_config()
+    events = cfg.get("event_map") or {}
+    for mood in MOTOR_MOODS:
+        assert f"emotion:{mood}" in events
+    for gesture in MOTOR_GESTURES:
+        assert f"gesture:{gesture}" in events
+    for activity in MOTOR_ACTIVITIES:
+        assert f"activity:{activity}" in events
+
+
+def test_idle_ambient_pool_includes_full_catalog():
+    cfg = load_config()
+    pool = (cfg.get("idle_ambient") or {}).get("pool") or []
+    modes = {(str(i.get("mode", "")).lower(), str(i.get("name", "")).lower()) for i in pool if isinstance(i, dict)}
+    assert len(modes) >= 31 + 24 + 8
+
+
+def test_semantic_event_overrides_motor_defaults():
+    raw_events = build_motor_event_map()
+    cfg = load_config()
+    events = cfg.get("event_map") or {}
+    assert events["autonomy.excited"]["mode"] == "gesture"
+    assert events["emotion:excitement"]["name"] == "wired"
+    assert events["emotion:confusion"]["name"] == "disoriented"
+    assert raw_events["emotion:neutral"]["name"] == "neutral"

--- a/modules/oled_faces/tests/test_eyes.py
+++ b/modules/oled_faces/tests/test_eyes.py
@@ -45,3 +45,18 @@ def test_legacy_emotive_maps_to_listening_activity():
 def test_legacy_bitmap_look_left_plays_gesture():
     cmd = resolve_bitmap("look_left")
     assert cmd.gesture == "look_left"
+
+
+def test_upstream_mood_catalog_size():
+    assert len(MOODS) >= 31
+
+
+def test_smoke_gesture_exists():
+    from modules.oled_faces.services.eyes.gestures import GESTURES_FN
+    assert "smoke" in GESTURES_FN
+    assert "acknowledge" in GESTURES_FN
+
+
+def test_editing_activity_available():
+    from modules.oled_faces.services.eyes.activities import ACTIVITIES
+    assert "editing" in ACTIVITIES

--- a/modules/oled_faces/tests/test_smoke.py
+++ b/modules/oled_faces/tests/test_smoke.py
@@ -2,10 +2,15 @@ from modules.oled_faces.services.mapper import FaceMapper
 
 
 def test_mapper_has_full_catalog():
-    mapper = FaceMapper({})
-    assert len(mapper.catalog_bitmaps) >= 20
+    from modules.oled_faces.config_loader import load_config
+
+    mapper = FaceMapper(load_config())
+    assert len(mapper.catalog_bitmaps) >= 31
     assert "normal" in mapper.catalog_bitmaps
+    assert "cool" in mapper.catalog_bitmaps
     assert "scan" in mapper.catalog_animations
+    assert "editing" in mapper.catalog_animations
+    assert "smoke" in mapper.catalog_animations
 
 
 def test_canonical_emotion_resolves_to_face():
@@ -16,5 +21,5 @@ def test_canonical_emotion_resolves_to_face():
 
 
 def test_explicit_event_map_override_wins():
-    mapper = FaceMapper({"event_map": {"emotion:happy": {"mode": "bitmap", "name": "excited"}}})
-    assert mapper.from_emotions(["happy"]).name == "excited"
+    mapper = FaceMapper({"event_map": {"emotion:happy": {"mode": "bitmap", "name": "kawaii"}}})
+    assert mapper.from_emotions(["happy"]).name == "kawaii"


### PR DESCRIPTION
## Özet
`dev` dalındaki Pip göz motoru senkronizasyonunu `main`'e taşır: esp-bridge-mcp-robot'tan 31 mood / 24 gesture / 8 activity motoru, tam OLED katalog kaydı, SSD1306 brightness dimming, genişletilmiş emotion vocabulary ve autonomy saccade'lerinin gesture interaction event'leri üzerinden yönlendirilmesi.

## Değişiklik tipi
- [ ] Hata düzeltmesi
- [x] Yeni özellik
- [ ] Refactor
- [ ] Dokümantasyon güncellemesi
- [x] Test güncellemesi

## Etkilenen modüller
`modules/oled_faces`, `modules/common`, `modules/autonomy`

## Doğrulama
- [ ] Lokal çalıştırma tamamlandı (`python run_robot.py` veya hedef modül çalıştırma)
- [x] İlgili testler geçiyor (`test_catalog_coverage`, smoke tests, autonomy saccade test)
- [x] Gerekli doküman/konfig güncellemeleri yapıldı

## Arduino Kontrat Kontrolü (uygunsa)
- [x] Uygulanmıyor (OLED / emotion config değişikliği)

## Risk ve geri alma
Düşük-orta: `idle_ambient.use_full_catalog: true` idle yüz değişim sıklığını artırır; `use_full_catalog: false` ile eski davranışa dönülür. PR revert yeterli.

## Birleştirilen PR'lar
- #158 feat/oled_faces-pip-catalog-sync

## Commits (7)
1. `feat(oled_faces): sync Pip eyes motor from esp-bridge-mcp-robot`
2. `feat(oled_faces): add SSD1306 brightness control for standby moods`
3. `feat(oled_faces): wire full Pip motor catalog into config and events`
4. `feat(common): extend emotion vocabulary for Pip mood catalog`
5. `feat(autonomy): route eye saccades through gesture interaction events`
6. `test(oled_faces): add catalog coverage and motor sync smoke tests`
7. `test(autonomy): update saccade test for gesture interaction events`

## İlgili issue
N/A

Made with [Cursor](https://cursor.com)