### PR TITLE
docs: unified robot expression maps and Pip catalog tooling

### DIFF
--- a/docs/neopixel_event_mapping.csv
+++ b/docs/neopixel_event_mapping.csv
@@ -1,26 +1,26 @@
-source_event,neopixel_action,notes,reference
-wakeword.detected,TWINKLE;BREATHE,"TWINKLE on jewel segment; base BREATHE","modules/autonomy/config/config.yml: scenes.wakeword_reaction"
-speech.start,RAINBOW_CYCLE,"Interactions rule speech_start","modules/interactions/config/config.yml"
-speech.end,COMET,"Interactions rule speech_end","modules/interactions/config/config.yml"
-autonomy.excited,RAINBOW_CYCLE,,"modules/interactions/config/config.yml"
-autonomy.look_around,COMET or preset:curious_scan,"Idle LOOK_AROUND maps to COMET or preset","modules/autonomy/config/config.yml"
-autonomy.blink,RANDOM_BLINK,,"modules/interactions/config/config.yml"
-autonomy.stretch,WAVE,,"modules/interactions/config/config.yml"
-autonomy.bored,PULSE,,"modules/interactions/config/config.yml"
-autonomy.monologue,TWINKLE,,"modules/interactions/config/config.yml"
-vision.focus,COMET,"also triggers anim vision_focus","modules/autonomy/services/brain_parts/vision.py"
-vision.person,owner_welcome preset + COMET,"owner greeting visual","modules/autonomy/config/config.yml"
-owner.scan,owner_welcome preset,owner return visuals,"modules/autonomy/config/config.yml"
-owner.temp_granted,THEATER_CHASE or preset:temp_owner,temporary owner visual,"modules/autonomy/config/config.yml"
-owner.temp_revoked,PULSE,,"modules/interactions/config/config.yml"
-owner.locked,METEOR,,"modules/interactions/config/config.yml"
-error,METEOR,critical alert,"modules/interactions/config/config.yml"
-warning,PULSE,warning alert,"modules/interactions/config/config.yml"
-arduino_disconnected,THEATER_CHASE,magenta base,"modules/interactions/config/config.yml"
-net_burst,COMET or PULSE,network burst visual,"modules/interactions/config/config.yml"
-emotion_joy,preset:emotion_joy (RAINBOW_CYCLE + COMET),also anim look_around,"modules/autonomy/services/brain.py & modules/neopixel/config/config.yml"
-emotion_curiosity,preset:emotion_curiosity (TWINKLE),anim vision_focus,"modules/autonomy/services/brain.py & modules/neopixel/config/config.yml"
-emotion_fear,preset:emotion_fear (PULSE red),short head move,"modules/autonomy/services/brain.py & modules/neopixel/config/config.yml"
-emotion_tired,preset:emotion_tired (BREATHE dim),stretch anim + tilt,"modules/autonomy/services/brain.py & modules/neopixel/config/config.yml"
-emotion_sad,preset:emotion_sad (PULSE blue),downward tilt,"modules/autonomy/services/brain.py & modules/neopixel/config/config.yml"
-LLM/actions,dynamic (anim/effect),LLM returned actions processed by apply_llm_response,"modules/autonomy/services/brain.py"
+source_event,oled,neopixel_action,animate_servo,why,reference
+wakeword.detected,animation/listening,TWINKLE;BREATHE base,head pan/tilt,Dikkat + dinleme yüzü,modules/autonomy/config/config.yml scenes.wakeword_reaction
+speech.start,animation/thinking,PULSE,—,Konuşma başladı,modules/interactions/config/config.yml
+speech.end,bitmap/normal,COMET,—,Konuşma bitti,modules/interactions/config/config.yml
+autonomy.excited,gesture/excited,RAINBOW_CYCLE,—,Heyecan,modules/interactions/config/config.yml
+autonomy.look_around,animation/scanning,COMET,look_around,Çevre tarama,modules/autonomy/config/config.yml
+autonomy.blink,gesture/blink,RANDOM_BLINK,blink,Göz kırpma,modules/interactions/config/config.yml
+autonomy.stretch,gesture/look_up,WAVE,stretch,Esneme,modules/interactions/config/config.yml
+autonomy.bored,bitmap/bored,PULSE,—,Sıkıntı,modules/interactions/config/config.yml
+autonomy.monologue,animation/thinking,TWINKLE,—,Monolog,modules/interactions/config/config.yml
+vision.focus,bitmap/focused,COMET,vision_focus,Odaklanma,modules/autonomy/services/brain_parts/vision.py
+vision.person,animation/searching,owner_welcome+COMET,owner_scan,Kişi algılandı,modules/autonomy/config/config.yml
+owner.scan,gesture/look_left,COMET,owner_scan,Sahip tarama,modules/autonomy/config/config.yml
+owner.temp_granted,bitmap/happy,THEATER_CHASE,temp_owner,Geçici sahip,modules/interactions/config/config.yml
+owner.temp_revoked,bitmap/nervous,PULSE,—,Erişim iptal,modules/interactions/config/config.yml
+owner.locked,bitmap/scared,METEOR,—,Kilitli mod,modules/interactions/config/config.yml
+error,gesture/scan_sweep,METEOR,—,Kritik hata,modules/interactions/config/config.yml
+warning,bitmap/alert,PULSE,—,Uyarı,modules/interactions/config/config.yml
+arduino_disconnected,—,THEATER_CHASE magenta,—,Mega bağlantı koptu,modules/interactions/config/config.yml
+net_burst,—,COMET,—,Ağ patlaması,modules/interactions/config/config.yml
+emotion_joy,bitmap/happy,preset:emotion_joy,look_around,Mutluluk,modules/autonomy/config/config.yml scenes.emotion_joy
+emotion_curiosity,bitmap/attentive,preset:emotion_curiosity,vision_focus,Merak,modules/autonomy/config/config.yml scenes.emotion_curiosity
+emotion_fear,bitmap/scared,preset:emotion_fear,—,Korku,modules/autonomy/config/config.yml scenes.emotion_fear
+emotion_tired,bitmap/tired,preset:emotion_tired,stretch,Yorgunluk,modules/autonomy/config/config.yml scenes.emotion_tired
+emotion_sad,bitmap/sad,preset:emotion_sad,tilt down,Üzüntü,modules/autonomy/config/config.yml scenes.emotion_sad
+LLM/actions,dynamic,dynamic anim/effect,dynamic,LLM actions alanı,modules/autonomy/services/brain.py

--- a/docs/robot_expression_map.csv
+++ b/docs/robot_expression_map.csv
@@ -1,0 +1,65 @@
+event,source_module,oled,neopixel,animate_servo,piservo,why,reference
+wakeword.detected,wakeword,animation/listening,TWINKLE+jewel+BREATHE base,head pan/tilt,—,Dikkat çekici LED + dinleme yüzü; kullanıcı uyandı,modules/autonomy/config/config.yml scenes.wakeword_reaction + modules/oled_faces/config/config.yml
+speech.listen.start,speech,animation/listening,—,—,—,Aktif dinleme oturumu; OLED listening animasyonu,modules/oled_faces/config/config.yml
+speech.listen.end,speech,bitmap/normal,—,—,—,Dinleme bitti; nötr yüze dön,modules/oled_faces/config/config.yml
+speech.start,interactions,animation/thinking,PULSE,—,—,Konuşma başladı; düşünüyor yüzü + nabız LED,modules/interactions/config/config.yml + modules/oled_faces/config/config.yml
+speech.end,interactions,bitmap/normal,COMET,—,—,Konuşma bitti; kuyruk efekti + nötr yüz,modules/interactions/config/config.yml
+agent.thinking,agent_core,animation/thinking,—,—,—,LLM düşünüyor; thinking activity,modules/oled_faces/config/config.yml
+agent.editing,agent_core,animation/editing,—,—,—,Kod/düzenleme modu; editing activity (Pip),modules/oled_faces/config/config.yml
+agent.processing,agent_core,animation/processing,—,—,—,Arka plan işlem; processing activity,modules/oled_faces/config/config.yml
+agent.connecting,agent_core,animation/connecting,—,—,—,Bağlantı bekleniyor; connecting activity,modules/oled_faces/config/config.yml
+autonomy.blink,autonomy,gesture/blink,RANDOM_BLINK,blink.yml,—,Doğal göz kırpma; LED blink + servo blink anim,modules/interactions/config/config.yml
+autonomy.look_around,autonomy,animation/scanning,COMET,look_around.yml,—,Çevreyi tarama; scanning yüzü + comet LED,modules/autonomy/config/config.yml
+autonomy.stretch,autonomy,gesture/look_up,WAVE,stretch.yml,—,Uyanma/esneme; yukarı bakış + wave LED,modules/interactions/config/config.yml
+autonomy.bored,autonomy,bitmap/bored,PULSE,—,—,Sıkıntı; düşük enerji yüz + yavaş pulse,modules/interactions/config/config.yml
+autonomy.monologue,autonomy,animation/thinking,TWINKLE,—,—,Kendi kendine konuşma; thinking + twinkle,modules/interactions/config/config.yml
+autonomy.excited,autonomy,gesture/excited,RAINBOW_CYCLE,—,—,Heyecan; coşkulu jest + gökkuşağı LED,modules/interactions/config/config.yml
+autonomy.angry,autonomy,bitmap/furious,BREATHE red base,—,—,Öfke; kızgın yüz + kırmızı nefes LED,modules/interactions/config/config.yml
+autonomy.sleep,autonomy,animation/sleep,BREATHE dark base,—,tilt down,Uyku modu; sleepy yüz + koyu breathe,modules/interactions/config/config.yml
+autonomy.wake,autonomy,bitmap/normal,COMET,stretch.yml,—,Uyanış; comet + stretch anim (wake_entry scene),modules/autonomy/config/config.yml scenes.wake_entry
+autonomy.nod,autonomy,gesture/nod,—,—,—,Onay baş hareketi,modules/oled_faces/config/config.yml
+autonomy.refuse,autonomy,gesture/refuse,—,—,—,Red baş hareketi,modules/oled_faces/config/config.yml
+autonomy.laugh,autonomy,gesture/laugh,—,—,—,Gülme jesti,modules/oled_faces/config/config.yml
+autonomy.smoke,autonomy,gesture/smoke,—,—,—,Robot özel smoke jesti (Pip'te yok),modules/oled_faces/config/config.yml
+autonomy.shiver,autonomy,gesture/shiver,—,—,—,Ürperti jesti,modules/oled_faces/config/config.yml
+autonomy.squint,autonomy,gesture/squint,—,—,—,Kısık bakış,modules/oled_faces/config/config.yml
+autonomy.pop,autonomy,gesture/pop,—,—,—,Şaşırma pop jesti,modules/oled_faces/config/config.yml
+autonomy.roll,autonomy,gesture/roll,—,—,—,Göz devri,modules/oled_faces/config/config.yml
+autonomy.cross_eyes,autonomy,gesture/cross_eyes,—,—,—,Şaşkın çapraz bakış,modules/oled_faces/config/config.yml
+vision.focus,autonomy,bitmap/focused,COMET,vision_focus.yml,—,Hedefe odaklanma; focused yüz + comet + pan,modules/autonomy/services/brain_parts/vision.py
+vision.person,autonomy,animation/searching,COMET+owner_welcome preset,owner_scan.yml,—,Kişi algılandı; arama yüzü + karşılama LED/servo,modules/autonomy/config/config.yml scenes.vision_greeting_*
+owner.scan,autonomy,gesture/look_left,COMET,owner_scan.yml,—,Sahip tarama; sola bak + owner_scan anim,modules/autonomy/config/config.yml scenes.owner_return
+owner.rfid,autonomy/interactions,gesture/wink,RAINBOW_CYCLE,—,—,RFID tanıma; göz kırp + rainbow,modules/oled_faces/config/config.yml arduino_event_map
+owner.temp_granted,autonomy,bitmap/happy,THEATER_CHASE,temp_owner.yml,—,Geçici sahip onayı; mutlu yüz + chase LED,modules/interactions/config/config.yml
+owner.temp_revoked,autonomy,bitmap/nervous,PULSE,—,—,Geçici erişim iptal; gergin yüz,modules/interactions/config/config.yml
+owner.locked,autonomy,bitmap/scared,METEOR,—,—,Kilitli mod; korku yüzü + meteor uyarı,modules/interactions/config/config.yml
+error,interactions,gesture/scan_sweep,METEOR,—,—,Kritik hata; alarm yüzü + meteor LED,modules/interactions/config/config.yml
+warning,interactions,bitmap/alert,PULSE,—,—,Uyarı; alert mood + pulse,modules/interactions/config/config.yml
+arduino_disconnected,interactions,—,THEATER_CHASE magenta base,—,—,Mega bağlantısı koptu; magenta chase idle,modules/interactions/config/config.yml
+net_burst,interactions,—,COMET,—,—,Ağ trafiği patlaması görsel geri bildirimi,modules/interactions/config/config.yml
+cpu_hot,interactions,—,BREATHE red,—,—,CPU aşırı ısınma; kırmızı breathe,modules/interactions/config/config.yml
+emotion:joy,autonomy,bitmap/happy,preset emotion_joy+RAINBOW_CYCLE,look_around.yml,ears up,Mutluluk; happy yüz + joy preset + etrafa bak,modules/autonomy/config/config.yml scenes.emotion_joy
+emotion:curiosity,autonomy,bitmap/attentive,preset emotion_curiosity+TWINKLE,vision_focus.yml,ears forward,Merak; attentive yüz + twinkle + odak anim,modules/autonomy/config/config.yml scenes.emotion_curiosity
+emotion:fear,autonomy,bitmap/scared,preset emotion_fear+PULSE red,—,ears back,Korku; scared yüz + kırmızı pulse,modules/autonomy/config/config.yml scenes.emotion_fear
+emotion:tired,autonomy,bitmap/tired,preset emotion_tired+BREATHE dim,stretch.yml,ears down,Yorgunluk; tired yüz + dim breathe + esneme,modules/autonomy/config/config.yml scenes.emotion_tired
+emotion:sadness,autonomy,bitmap/sad,preset emotion_sad+PULSE blue,—,tilt down,Üzüntü; sad yüz + mavi pulse,modules/autonomy/config/config.yml scenes.emotion_sad
+emotion:anger,autonomy,bitmap/angry,preset emotion_angry,—,—,Öfke; angry mood (autonomy express),modules/oled_faces/config/config.yml
+emotion:smoking,autonomy,bitmap/smoking,—,—,—,Robot özel chill/smoke mood (SentryBOT only),modules/oled_faces/services/eyes/moods.py
+scene.emotion_joy,autonomy,bitmap/happy,preset emotion_joy,look_around.yml,—,Sahne tetikleyicisi: joy paketi,modules/oled_faces/config/config.yml
+scene.emotion_curiosity,autonomy,bitmap/attentive,preset emotion_curiosity,vision_focus.yml,—,Sahne tetikleyicisi: curiosity paketi,modules/oled_faces/config/config.yml
+state:listening,state_manager,animation/listening,—,—,—,Global state listening → OLED listening,modules/oled_faces/config/config.yml state_map
+state:thinking,state_manager,animation/thinking,—,—,—,Global state thinking,modules/oled_faces/config/config.yml state_map
+state:speaking,state_manager,animation/thinking,—,—,—,Konuşma sırasında thinking yüzü (TTS aktif),modules/oled_faces/config/config.yml state_map
+state:sleeping,state_manager,animation/sleep,BREATHE dark,—,—,Uyku state; sleep animasyon,modules/oled_faces/config/config.yml state_map
+state:low_battery,state_manager,bitmap/battery_low,PULSE orange,—,—,Düşük batarya uyarısı,modules/oled_faces/config/config.yml state_map
+agent.debugging,agent_core,animation/debugging,—,—,—,Hata ayıklama yüzü (Pip),modules/oled_faces/config/config.yml
+agent.building,agent_core,animation/building,—,—,—,Derleme/inşa animasyonu,modules/oled_faces/config/config.yml
+agent.testing,agent_core,animation/testing,—,—,—,Test tüpü animasyonu,modules/oled_faces/config/config.yml
+agent.deploying,agent_core,animation/deploying,—,—,—,Deploy balina animasyonu,modules/oled_faces/config/config.yml
+agent.glitch,agent_core,animation/glitch,—,—,—,Glitch corruption (kendi kendine biter),modules/oled_faces/config/config.yml
+agent.ping_pong,agent_core,animation/ping_pong,—,—,—,BLE/sonar ping-pong,modules/oled_faces/config/config.yml
+agent.waiting,agent_core,animation/waiting,—,—,—,Terminal bekleme cursor,modules/oled_faces/config/config.yml
+agent.chill,agent_core,bitmap/chill,—,—,—,Rahat mood (Pip),modules/oled_faces/config/config.yml
+activity:debugging,manual,animation/debugging,—,—,—,Katalog event tetikleyici,GET /oled_faces/catalog
+activity:deploying,manual,animation/deploying,—,—,—,Katalog event tetikleyici,POST /oled_faces/event
+emotion:chill,manual,bitmap/chill,—,—,—,Katalog mood tetikleyici,POST /oled_faces/manual

--- a/docs/robot_expression_map.md
+++ b/docs/robot_expression_map.md
@@ -1,0 +1,134 @@
+# SentryBOT — Robot İfade Haritası (Unified Expression Map)
+
+Tek referans: bir olay tetiklendiğinde **OLED yüz**, **NeoPixel LED**, **servo animasyon** ve **kulak (piservo)** nasıl davranır.
+
+Kaynak CSV: [`robot_expression_map.csv`](robot_expression_map.csv)  
+NeoPixel detay: [`neopixel_event_mapping.csv`](neopixel_event_mapping.csv)  
+Pip upstream: [`vendor/esp-bridge-mcp-robot`](../vendor/esp-bridge-mcp-robot) → `src/modules/espbridge/eyes/`
+
+## Mimari akış
+
+```mermaid
+flowchart LR
+    subgraph triggers [Tetikleyiciler]
+        WW[wakeword]
+        SP[speech]
+        AU[autonomy]
+        VI[vision]
+        OW[owner]
+    end
+    subgraph bus [Olay bus]
+        INT[interactions events]
+        SM[state_manager]
+    end
+    subgraph expression [İfade katmanları]
+        OLED[oled_faces Pip motor]
+        NEO[neopixel presets/effects]
+        ANI[animate YAML servos]
+        PS[piservo ears]
+        TTS[speak TTS]
+    end
+    WW --> INT
+    SP --> INT
+    AU --> INT
+    AU --> OLED
+    AU --> NEO
+    AU --> ANI
+    AU --> PS
+    AU --> TTS
+    INT --> NEO
+    VI --> AU
+    OW --> AU
+    SM --> OLED
+```
+
+## Katman sorumlulukları
+
+| Katman | Modül | Ne yapar |
+|--------|-------|----------|
+| OLED yüz | `oled_faces` | Pip motor: mood / gesture / activity (`services/eyes/`) |
+| LED | `neopixel` | Preset + effect (jewel + stick segmentler) |
+| Servo gövde | `animate` | YAML animasyonlar → Arduino `set_pose` |
+| Kulak | `piservo` | Duygu ile GPIO PWM kulak pozisyonu |
+| Ses | `speak` | TTS + liveliness LED senkronu |
+| Orkestrasyon | `autonomy` | Scene steps: event + preset + anim + speak |
+| Kural motoru | `interactions` | Event → NeoPixel HTTP kuralları |
+
+## Pip motor senkronu
+
+SentryBOT göz motoru upstream [esp-bridge-mcp-robot](https://github.com/WhoIsMrSentry/esp-bridge-mcp-robot) fork'udur.
+
+```bash
+python3 tools/sync_pip_eyes_catalog.py
+```
+
+| Katalog | SentryBOT | Upstream-only (port adayı) |
+|---------|-----------|----------------------------|
+| moods | 32 (+ `smoking` robot özel) | — (tam senkron) |
+| gestures | 24 (+ body language) | 12 ortak Pip blinks/gaze |
+| activities | 15 (upstream tam set) | — (tam senkron) |
+
+## Örnek olay paketleri
+
+### Wakeword
+- **OLED:** `listening` activity
+- **NeoPixel:** `TWINKLE` jewel + `BREATHE` base
+- **Servo:** head pan/tilt (autonomy scene)
+- **Neden:** Kullanıcı dikkatini çek; dinlemeye hazır ol
+
+### Konuşma
+- **speech.start:** OLED `thinking` + NeoPixel `PULSE`
+- **speech.end:** OLED `normal` + NeoPixel `COMET`
+- **speak liveliness:** konuşma süresince `interactions/effect` (ayrı kanal)
+
+### Autonomy body language
+| Olay | OLED | NeoPixel | Servo |
+|------|------|----------|-------|
+| `autonomy.blink` | gesture `blink` | `RANDOM_BLINK` | `blink` |
+| `autonomy.look_around` | activity `scanning` | `COMET` | `look_around` |
+| `autonomy.stretch` | gesture `look_up` | `WAVE` | `stretch` |
+| `autonomy.laugh` | gesture `laugh` | — | — |
+| `autonomy.smoke` | gesture `smoke` | — | — (robot özel) |
+
+### Duygu (emotion)
+| Duygu | OLED | NeoPixel | Servo |
+|-------|------|----------|-------|
+| joy | `happy` | preset `emotion_joy` | `look_around` |
+| curiosity | `attentive` | preset `emotion_curiosity` | `vision_focus` |
+| fear | `scared` | preset `emotion_fear` | — |
+| tired | `tired` | preset `emotion_tired` | `stretch` |
+| sadness | `sad` | preset `emotion_sad` | tilt down |
+
+Config: `modules/oled_faces/config/config.yml` (`emotion:*` keys) + `modules/autonomy/config/config.yml` (`scenes.emotion_*`)
+
+## ESP32 köprü vs Pip
+
+| Bileşen | `esp_link` + `arduino/firmware/esp_bridge` | Pip `esp-bridge-mcp-robot` |
+|---------|---------------------------------------------|----------------------------|
+| Rol | Mega UART köprüsü, `/esp/send` HTTP | BLE desk robot, MCP `face` tool |
+| OLED | — | ESP32 veya emülatör |
+| SentryBOT kullanımı | Pi → ESP → Mega NDJSON | Pi I2C OLED (`oled_faces`) |
+
+Bu iki sistem **farklı donanım** içindir; göz motoru kodu paylaşılır, iletişim katmanı paylaşılmaz.
+
+## Güncelleme prosedürü
+
+1. `cd vendor/esp-bridge-mcp-robot && git pull`
+2. `python3 tools/sync_pip_eyes_catalog.py`
+3. Gerekirse upstream-only mood/activity port et → `modules/oled_faces/services/eyes/`
+4. `docs/robot_expression_map.csv` satır ekle/güncelle
+5. `python3 .sentrybot/tools/generate_module_ai_assets.py`
+
+## Manuel tetikleme (otonomi gerekmez)
+
+Tüm motor girdileri `expand_config()` ile `event_map`'e otomatik kayıt olur:
+
+| Yol | Örnek |
+|-----|-------|
+| Event bus | `activity:debugging`, `gesture:nod`, `emotion:chill` |
+| HTTP event | `POST /oled_faces/event` → `{"type": "activity:deploying"}` |
+| HTTP manual | `POST /oled_faces/manual` → `{"mode": "animation", "name": "glitch"}` |
+| Agent hooks | `agent.debugging`, `agent.deploying`, `agent.chill` (config.yml) |
+| Katalog | `GET /oled_faces/catalog` — tüm isimler + event anahtarları |
+
+Legacy kısa adlar: `debug`, `deploy`, `build`, `test`, `ping`, `wait`, `glitch` → `resolve_animation()`.

--- a/modules/neopixel/event_mapping.md
+++ b/modules/neopixel/event_mapping.md
@@ -1,5 +1,8 @@
 # Neopixel Event → Animasyon Eşleme (Tam Liste)
 
+> **Birleşik harita (OLED + NeoPixel + servo):** [`docs/robot_expression_map.md`](../../docs/robot_expression_map.md)  
+> **CSV:** [`docs/robot_expression_map.csv`](../../docs/robot_expression_map.csv)
+
 Bu belge, repoda bulunan tetikleyici/event kaynaklarının hangi Neopixel animasyon/preset/effect çağrılarını tetiklediğini toplar. Dosya referansları workspace-relative linklerle verildi.
 
 ## Nasıl okunur

--- a/tools/sync_pip_eyes_catalog.py
+++ b/tools/sync_pip_eyes_catalog.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Compare SentryBOT oled_faces motor catalog vs vendor/esp-bridge-mcp-robot upstream."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VENDOR = ROOT / "vendor" / "esp-bridge-mcp-robot" / "src" / "modules" / "espbridge" / "eyes"
+
+
+def _order_from_init(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    text = path.read_text(encoding="utf-8")
+    if "_ORDER" not in text:
+        return []
+    tail = text.split("_ORDER", 1)[1]
+    return re.findall(r'"([a-z_]+)"', tail)
+
+
+def _local_catalog() -> dict[str, set[str]]:
+    sys.path.insert(0, str(ROOT))
+    from modules.oled_faces.services.catalog_registry import (  # noqa: WPS433
+        MOTOR_ACTIVITIES,
+        MOTOR_GESTURES,
+        MOTOR_MOODS,
+    )
+    return {
+        "moods": set(MOTOR_MOODS),
+        "gestures": set(MOTOR_GESTURES),
+        "activities": set(MOTOR_ACTIVITIES),
+    }
+
+
+def _upstream_catalog() -> dict[str, set[str]]:
+    if not VENDOR.exists():
+        print(f"Upstream not found: {VENDOR}")
+        print("Run: git clone --depth 1 https://github.com/WhoIsMrSentry/esp-bridge-mcp-robot.git vendor/esp-bridge-mcp-robot")
+        sys.exit(1)
+    return {
+        "moods": set(_order_from_init(VENDOR / "moods" / "__init__.py")),
+        "gestures": set(_order_from_init(VENDOR / "gestures" / "__init__.py")),
+        "activities": set(_order_from_init(VENDOR / "actions" / "__init__.py")),
+    }
+
+
+def _report(kind: str, local: set[str], upstream: set[str]) -> None:
+    only_local = sorted(local - upstream)
+    only_upstream = sorted(upstream - local)
+    shared = sorted(local & upstream)
+    print(f"\n## {kind}")
+    print(f"  shared: {len(shared)}  |  sentrybot-only: {len(only_local)}  |  upstream-only: {len(only_upstream)}")
+    if only_local:
+        print(f"  + SentryBOT: {', '.join(only_local)}")
+    if only_upstream:
+        print(f"  + upstream (port candidate): {', '.join(only_upstream)}")
+
+
+def main() -> None:
+    local = _local_catalog()
+    upstream = _upstream_catalog()
+    print("Pip eyes catalog diff")
+    print(f"Local:    modules/oled_faces/services/eyes/")
+    print(f"Upstream: vendor/esp-bridge-mcp-robot/src/modules/espbridge/eyes/")
+    for kind in ("moods", "gestures", "activities"):
+        _report(kind, local[kind], upstream[kind])
+    print("\nDone. Robot-specific extras are intentional; upstream-only items are port candidates.")
+
+
+if __name__ == "__main__":
+    main()

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,34 @@
+# Vendor — Harici Kaynaklar
+
+## esp-bridge-mcp-robot (Pip göz motoru)
+
+**Upstream:** [WhoIsMrSentry/esp-bridge-mcp-robot](https://github.com/WhoIsMrSentry/esp-bridge-mcp-robot)
+
+SentryBOT'ta Pip tarzı prosedürel OLED göz motoru `modules/oled_faces/services/eyes/` içinde çalışır.
+Upstream kaynak referansı: `vendor/esp-bridge-mcp-robot/src/modules/espbridge/eyes/`
+
+### Güncelleme
+
+```bash
+# İlk kurulum
+git clone --depth 1 https://github.com/WhoIsMrSentry/esp-bridge-mcp-robot.git vendor/esp-bridge-mcp-robot
+
+# Güncelleme
+cd vendor/esp-bridge-mcp-robot && git pull origin main && cd ../..
+
+# Katalog karşılaştırması (SentryBOT vs upstream)
+python3 tools/sync_pip_eyes_catalog.py
+```
+
+### SentryBOT vs Pip farkı
+
+| Alan | Pip (upstream) | SentryBOT |
+|------|----------------|-----------|
+| Donanım | ESP32 BLE + OLED | Pi I2C SSD1306 (`oled_faces`) |
+| Göz motoru | `espbridge/eyes/` | `modules/oled_faces/services/eyes/` |
+| Ekstra mood | — | `smoking` (robot özel) |
+| Ekstra gesture | `smoke`, `nod`, `laugh` … | sadece bakış/blink |
+| activities | 15 (upstream tam set) | robot idle + dev seti |
+| LED / servo | yok | `neopixel`, `animate`, `piservo` ile senkron |
+
+Birleşik ifade haritası: [`docs/robot_expression_map.md`](../docs/robot_expression_map.md)


### PR DESCRIPTION
## Summary
- Add `docs/robot_expression_map.md` + CSV — OLED + NeoPixel + servo unified map
- Update `docs/neopixel_event_mapping.csv` with OLED/servo columns (fix speech.start → PULSE)
- Cross-link `modules/neopixel/event_mapping.md`
- Add `tools/sync_pip_eyes_catalog.py` and `vendor/README.md` for upstream Pip diff

## Commits (Jun 19)
- `docs: add unified robot expression map across OLED, LED, and servo`
- `feat(tools): add Pip eyes catalog diff script and vendor README`

## Test plan
- [ ] `python3 tools/sync_pip_eyes_catalog.py` runs clean
- [ ] Review CSV rows against `modules/interactions/config/config.yml`

Made with [Cursor](https://cursor.com)