### PR TITLE
fix(graph-ui): correct GitHub Pages base URL

### DIFF
--- a/.github/workflows/deploy-graph-ui.yml
+++ b/.github/workflows/deploy-graph-ui.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          VITE_BASE: /Project-SentryBOT-V5/
+          VITE_BASE: /SentryBOT/
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/tools/graph-ui/vite.config.ts
+++ b/tools/graph-ui/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  base: process.env.VITE_BASE || "/Project-SentryBOT-V5/",
+  base: process.env.VITE_BASE || "/SentryBOT/",
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Özet
Repo `Project-SentryBOT-V5` → `SentryBOT` olarak yeniden adlandırıldığı için Pages base URL güncellenmedi. 3D grafik asset'leri 404 dönüyordu.

## Değişiklik tipi
- [x] Hata düzeltmesi