### PR TITLE
feat: companion runtime upgrade with voice-native agent and NeoPixel feedback

### DIFF
--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -286,12 +286,44 @@ speak:
       chars_per_second: 16
       force: false
 
+wakeword:
+  audio:
+    device: plughw:0,0
+    samplerate: 16000
+    channels: 2
+    dtype: int16
+    frame_ms: 30
+  wakeword:
+    engine: openwakeword
+    words:
+      - "hey mycroft"
+      - "mycroft"
+    trigger_on_partial: true
+    min_confidence: 0.0
+    cooldown_sec: 3.0
+  openwakeword:
+    pretrained_models:
+      - hey_mycroft
+    inference_framework: onnx
+    threshold: 0.25
+    smooth_window: 3
+    input_gain: 3.0
+    input_channels: 2
+    auto_calibration:
+      enabled: true
+      duration_sec: 12.0
+      min_samples: 120
+      percentile: 99.5
+      margin: 0.0007
+      min_threshold: 0.20
+      max_threshold: 0.40
+
 speech:
   server:
     host: 0.0.0.0
     port: 8082
   audio:
-    device: null
+    device: plughw:0,0
     samplerate: 16000
     channels: 2
     dtype: int16
@@ -303,6 +335,7 @@ speech:
     auto_language: true
     auto_switch_model: true
     dual_decode_margin: 0.35
+    dual_decode_languages: [tr, en]
     utterance_buffer_sec: 20
     model_path: null
     language_models:

--- a/modules/neopixel/api/router.py
+++ b/modules/neopixel/api/router.py
@@ -46,7 +46,7 @@ class EmotionsResponse(BaseModel):
 
 
 class CompanionModeRequest(BaseModel):
-    mode: str = Field(..., description="off | vu | listen | thinking | eye")
+    mode: str = Field(..., description="off | vu | listen | thinking | eye | wake_chase")
     eye_color: Optional[str] = Field(None, description='Optional "#RRGGBB" for center eye')
 
 

--- a/modules/neopixel/config/config.yml
+++ b/modules/neopixel/config/config.yml
@@ -28,6 +28,11 @@ companion:
     eye_default: "#30E3CA"
     vu_bar: "#00AAFF"
     vu_bg: "#051018"
+    # VU gradient: green (quiet) -> yellow (mid) -> red (loud)
+    vu_gradient:
+      - "#00FF00"
+      - "#FFFF00"
+      - "#FF0000"
   thinking:
     step_ms: 120
   eye:
@@ -35,6 +40,10 @@ companion:
   vu:
     smoothing: 0.35
     min_level: 0.04
+  wake_chase:
+    speed_ms: 80
+    direction_cw: true
+    pair_gap: 1
 
 # Pi5-specific driver hint
 pi5neo:

--- a/modules/neopixel/services/companion_leds.py
+++ b/modules/neopixel/services/companion_leds.py
@@ -1,4 +1,4 @@
-"""Companion LED modes: VU-meter strip, jewel thinking ring, center eye.
+"""Companion LED modes: VU-meter strip, jewel thinking ring, center eye, wake chase.
 
 Layout (config-driven, default): indices 0-6 = NeoPixel Jewel (0 = center eye),
 indices 7+ = straight strip for audio level display.
@@ -10,7 +10,7 @@ import logging
 import math
 import threading
 import time
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("neopixel.companion")
 
@@ -29,6 +29,34 @@ def _parse_hex_color(raw: Any, default: Color) -> Color:
             except ValueError:
                 return default
     return default
+
+
+def _lerp_color(c1: Color, c2: Color, t: float) -> Color:
+    """Linear interpolation between two colors."""
+    return (
+        int(c1[0] + (c2[0] - c1[0]) * t),
+        int(c1[1] + (c2[1] - c1[1]) * t),
+        int(c1[2] + (c2[2] - c1[2]) * t),
+    )
+
+
+def _interpolate_gradient(gradient: List[Color], pos: float) -> Color:
+    """Interpolate color from gradient at position pos (0.0 to 1.0)."""
+    if not gradient:
+        return (255, 255, 255)
+    if pos <= 0.0:
+        return gradient[0]
+    if pos >= 1.0:
+        return gradient[-1]
+    n = len(gradient)
+    if n == 1:
+        return gradient[0]
+    segment = pos * (n - 1)
+    idx = int(segment)
+    t = segment - idx
+    if idx >= n - 1:
+        return gradient[-1]
+    return _lerp_color(gradient[idx], gradient[idx + 1], t)
 
 
 class CompanionLedController:
@@ -50,6 +78,13 @@ class CompanionLedController:
         self._vu_bar = _parse_hex_color(colors.get("vu_bar", "#00AAFF"), (0, 170, 255))
         self._vu_bg = _parse_hex_color(colors.get("vu_bg", "#051018"), (5, 16, 24))
 
+        # VU gradient colors (green -> yellow -> red)
+        vu_gradient_raw = colors.get("vu_gradient")
+        if isinstance(vu_gradient_raw, list) and vu_gradient_raw:
+            self._vu_gradient = [_parse_hex_color(c, (255, 255, 255)) for c in vu_gradient_raw]
+        else:
+            self._vu_gradient = [(0, 255, 0), (255, 255, 0), (255, 0, 0)]
+
         thinking = self._cfg.get("thinking", {}) if isinstance(self._cfg.get("thinking"), dict) else {}
         self._think_step_ms = float(thinking.get("step_ms", 120))
         eye = self._cfg.get("eye", {}) if isinstance(self._cfg.get("eye"), dict) else {}
@@ -59,6 +94,12 @@ class CompanionLedController:
         self._vu_min = float(vu.get("min_level", 0.04))
         self._tick_ms = float(self._cfg.get("tick_ms", 50))
 
+        # Wake chase config
+        wake_chase = self._cfg.get("wake_chase", {}) if isinstance(self._cfg.get("wake_chase"), dict) else {}
+        self._wake_chase_speed_ms = float(wake_chase.get("speed_ms", 80))
+        self._wake_chase_direction_cw = bool(wake_chase.get("direction_cw", True))
+        self._wake_chase_pair_gap = int(wake_chase.get("pair_gap", 1))
+
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
@@ -67,6 +108,11 @@ class CompanionLedController:
         self._vu_target = 0.0
         self._think_phase = 0
         self._eye_phase = 0.0
+        
+        # Wake chase state
+        self._wake_chase_phase = 0
+        self._wake_chase_direction = 1  # 1 for CW, -1 for CCW
+        self._wake_chase_tick = 0
 
     @property
     def mode(self) -> str:
@@ -85,6 +131,8 @@ class CompanionLedController:
             self._mode = mode
             self._think_phase = 0
             self._eye_phase = 0.0
+            self._wake_chase_phase = 0
+            self._wake_chase_tick = 0
             if mode == "off":
                 self._vu_level = 0.0
                 self._vu_target = 0.0
@@ -128,6 +176,8 @@ class CompanionLedController:
                     self._render_thinking_frame()
                 elif mode == "eye":
                     self._render_eye_frame()
+                elif mode == "wake_chase":
+                    self._render_wake_chase_frame()
             except Exception as exc:
                 logger.debug("companion frame failed: %s", exc)
             time.sleep(interval)
@@ -138,13 +188,36 @@ class CompanionLedController:
             self._driver.set(i, 0, 0, 0)
         self._driver.show()
 
+    def _lerp_color(self, c1: Color, c2: Color, t: float) -> Color:
+        return (
+            int(c1[0] + (c2[0] - c1[0]) * t),
+            int(c1[1] + (c2[1] - c1[1]) * t),
+            int(c1[2] + (c2[2] - c1[2]) * t),
+        )
+
+    def _get_gradient_color(self, position: float) -> Color:
+        """Get color from vu_gradient based on position (0.0 - 1.0)."""
+        with self._lock:
+            gradient_colors = getattr(self, '_vu_gradient', None)
+            if not gradient_colors or len(gradient_colors) < 2:
+                return self._vu_bar
+        
+        # Find which segment of the gradient we're in
+        num_segments = len(gradient_colors) - 1
+        segment = min(int(position * num_segments), num_segments - 1)
+        segment_t = (position * num_segments) - segment
+        
+        c1 = gradient_colors[segment]
+        c2 = gradient_colors[segment + 1]
+        return self._lerp_color(c1, c2, segment_t)
+
     def _render_vu_frame(self) -> None:
         with self._lock:
             self._vu_level += (self._vu_target - self._vu_level) * self._vu_smoothing
             level = self._vu_level
             eye = self._eye_color
 
-        # Stick VU meter
+        # Stick VU meter with gradient colors
         lit = int(round(level * self._stick_count))
         lit = max(0, min(self._stick_count, lit))
         for i in range(self._stick_count):
@@ -152,7 +225,13 @@ class CompanionLedController:
             if idx >= self._driver.num_leds:
                 break
             if i < lit:
-                self._driver.set(idx, *self._vu_bar)
+                # Use gradient color based on position in the lit portion
+                if lit > 0:
+                    pos = i / max(1, lit - 1) if lit > 1 else 0.5
+                else:
+                    pos = 0.0
+                color = self._get_gradient_color(pos)
+                self._driver.set(idx, *color)
             else:
                 self._driver.set(idx, *self._vu_bg)
 
@@ -227,4 +306,75 @@ class CompanionLedController:
             else:
                 dim = tuple(int(c * 0.12) for c in eye)
                 self._driver.set(idx, *dim)
+        self._driver.show()
+
+    def _render_wake_chase_frame(self) -> None:
+        """Wake word chase animation on jewel ring (indices 1-6).
+        
+        Ring has 6 LEDs (1-6): 3 top (1,2,3) and 3 bottom (4,5,6).
+        Opposite pairs: (1,4), (2,5), (3,6) chase each other.
+        Direction alternates CW/CCB based on config.
+        Center (index 0) pulses subtly.
+        """
+        with self._lock:
+            eye = self._eye_color
+            chase_color = eye  # Use eye color for chase
+            speed_ms = self._wake_chase_speed_ms
+            direction_cw = self._wake_chase_direction_cw
+            pair_gap = self._wake_chase_pair_gap
+
+        # Determine direction (can be toggled externally if needed)
+        self._wake_chase_tick += 1
+        
+        # Update phase based on speed
+        if self._wake_chase_tick >= max(1, int(speed_ms / self._tick_ms)):
+            self._wake_chase_tick = 0
+            self._wake_chase_phase = (self._wake_chase_phase + (1 if direction_cw else -1)) % 6
+
+        # Ring LED indices (relative to jewel_start): 1,2,3,4,5,6
+        # Opposite pairs: (1,4), (2,5), (3,6)
+        pairs = [(1, 4), (2, 5), (3, 6)]
+        
+        # Center eye pulse
+        self._eye_phase += self._tick_ms / max(200.0, self._eye_breathe_ms)
+        pulse = 0.3 + 0.4 * (0.5 + 0.5 * math.sin(self._eye_phase * 2 * math.pi))
+        center_idx = self._jewel_start + self._center_rel
+        if center_idx < self._driver.num_leds:
+            self._driver.set(center_idx, 
+                           int(eye[0] * pulse), 
+                           int(eye[1] * pulse), 
+                           int(eye[2] * pulse))
+
+        # Chase animation on pairs
+        for pair_idx, (top, bottom) in enumerate(pairs):
+            # Each pair activates in sequence with a gap
+            active_pair = (self._wake_chase_phase // (pair_gap + 1)) % len(pairs)
+            is_active = (pair_idx == active_pair)
+            
+            if is_active:
+                # Active pair: both LEDs on (bright)
+                for rel in (top, bottom):
+                    idx = self._jewel_start + rel
+                    if idx < self._driver.num_leds:
+                        self._driver.set(idx, *chase_color)
+            else:
+                # Inactive: dim
+                for rel in (top, bottom):
+                    idx = self._jewel_start + rel
+                    if idx < self._driver.num_leds:
+                        dim = tuple(int(c * 0.1) for c in chase_color)
+                        self._driver.set(idx, *dim)
+
+        # Stick: subtle ambient glow
+        for i in range(self._stick_count):
+            idx = self._stick_start + i
+            if idx >= self._driver.num_leds:
+                break
+            # Gentle wave along stick
+            wave = 0.05 + 0.05 * math.sin((self._wake_chase_phase + i * 0.5) * math.pi / 3)
+            self._driver.set(idx, 
+                           int(chase_color[0] * wave),
+                           int(chase_color[1] * wave),
+                           int(chase_color[2] * wave))
+        
         self._driver.show()

--- a/modules/neopixel/tests/test_companion_leds.py
+++ b/modules/neopixel/tests/test_companion_leds.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from modules.neopixel.services.companion_leds import CompanionLedController
+from modules.neopixel.services.companion_leds import CompanionLedController, _interpolate_gradient
 
 
 class _FakeDriver:
@@ -43,3 +43,102 @@ def test_companion_thinking_alternates_ring():
     ring = driver.buf[1:7]
     assert any(c != (0, 0, 0) for c in ring)
     assert driver.buf[0] != (0, 0, 0)
+
+
+def test_gradient_interpolation():
+    """Test gradient color interpolation between green -> yellow -> red."""
+    gradient = [(0, 255, 0), (255, 255, 0), (255, 0, 0)]
+    # At 0.0 should be green
+    c = _interpolate_gradient(gradient, 0.0)
+    assert c == (0, 255, 0)
+    # At 1.0 should be red
+    c = _interpolate_gradient(gradient, 1.0)
+    assert c == (255, 0, 0)
+    # At 0.5 should be yellow-ish
+    c = _interpolate_gradient(gradient, 0.5)
+    assert c[1] > 0  # has green component
+    assert c[0] > 0  # has red component
+
+
+def test_companion_vu_gradient_colors():
+    """Test VU meter uses gradient colors (green->yellow->red)."""
+    driver = _FakeDriver(23)
+    ctrl = CompanionLedController(
+        driver,
+        {
+            "layout": {"jewel_start": 0, "jewel_count": 7, "jewel_center_index": 0, "stick_start": 7, "stick_count": 16},
+            "tick_ms": 10,
+            "vu": {"smoothing": 1.0, "min_level": 0.0},
+            "colors": {
+                "vu_gradient": ["#00FF00", "#FFFF00", "#FF0000"],
+                "vu_bg": "#051018",
+            },
+        },
+    )
+    ctrl.set_mode("vu")
+    ctrl.set_vu_level(1.0)  # Full level
+    ctrl._render_vu_frame()
+    
+    # Bottom of stick (index 7) should be green-ish
+    bottom = driver.buf[7]
+    assert bottom[1] > bottom[0] and bottom[1] > bottom[2]  # Green dominant
+    
+    # Top of stick (index 22) should be red-ish
+    top = driver.buf[22]
+    assert top[0] > top[1] and top[0] > top[2]  # Red dominant
+
+
+def test_companion_wake_chase_mode():
+    """Test wake_chase mode animates jewel ring with opposite pairs."""
+    driver = _FakeDriver(23)
+    ctrl = CompanionLedController(
+        driver,
+        {
+            "layout": {"jewel_start": 0, "jewel_count": 7, "jewel_center_index": 0, "stick_start": 7, "stick_count": 16},
+            "tick_ms": 10,
+            "wake_chase": {"speed_ms": 50, "direction_cw": True, "pair_gap": 1},
+            "colors": {"eye_default": "#30E3CA"},
+        },
+    )
+    ctrl.set_mode("wake_chase")
+    # Render a few frames
+    for _ in range(3):
+        ctrl._render_wake_chase_frame()
+    
+    # Center eye should be lit
+    assert driver.buf[0] != (0, 0, 0)
+    # Ring should have some activity (chase animation)
+    ring_leds = [driver.buf[i] for i in range(1, 7)]
+    assert any(c != (0, 0, 0) for c in ring_leds)
+
+
+def test_companion_wake_chase_opposite_pairs():
+    """Test that wake_chase lights opposite pairs (1,4), (2,5), (3,6)."""
+    driver = _FakeDriver(23)
+    ctrl = CompanionLedController(
+        driver,
+        {
+            "layout": {"jewel_start": 0, "jewel_count": 7, "jewel_center_index": 0, "stick_start": 7, "stick_count": 16},
+            "tick_ms": 10,
+            "wake_chase": {"speed_ms": 50, "direction_cw": True, "pair_gap": 0},
+            "colors": {"eye_default": "#FF0000"},
+        },
+    )
+    ctrl.set_mode("wake_chase")
+    ctrl._render_wake_chase_frame()
+    
+    # Check that opposite pairs are treated together
+    # At phase 0, pair (1,4) should be active
+    # We can't easily test the exact phase without knowing internal state,
+    # but we can verify the structure by checking multiple frames
+    seen_pairs = set()
+    for _ in range(10):
+        ctrl._render_wake_chase_frame()
+        # Check which ring LEDs are brightly lit
+        for i in range(1, 7):
+            c = driver.buf[i]
+            if c[0] > 50 or c[1] > 50 or c[2] > 50:  # bright
+                seen_pairs.add(i)
+    
+    # Should have activity on the ring
+    assert len(seen_pairs) > 0

--- a/modules/speech/services/audio_capture.py
+++ b/modules/speech/services/audio_capture.py
@@ -3,8 +3,14 @@ import logging
 import queue
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass
 from typing import Dict, Iterable, Optional, Any
+
+try:
+    import audioop
+except Exception:
+    audioop = None
 
 try:
     import sounddevice as sd
@@ -20,6 +26,10 @@ logger = logging.getLogger("speech.audio")
 # GLOBAL SINGLETON for all audio capture to ensure zero contention
 _SINGLE_CAPTURE_INSTANCE: Optional["AudioCapture"] = None
 _INSTANCE_LOCK = threading.Lock()
+
+# RMS sliding window settings
+_RMS_WINDOW_MS = 100
+_RMS_MAX_SAMPLES = 1000
 
 
 def _is_alsa_device_name(device: Any) -> bool:
@@ -83,6 +93,10 @@ class AudioCapture:
         self._alsa_thread = None
         self._pcm = None
 
+        # RMS level tracking (sliding window)
+        self._rms_window: deque[int] = deque(maxlen=_RMS_MAX_SAMPLES)
+        self._rms_lock = threading.Lock()
+
     def merge_config(self, cfg: Dict) -> None:
         """Apply non-default audio fields from a later module (e.g. wakeword plughw)."""
         if not isinstance(cfg, dict):
@@ -103,10 +117,51 @@ class AudioCapture:
         if audio.get("channels") is not None:
             self.cfg.channels = int(audio.get("channels", self.cfg.channels))
 
-    def _callback(self, indata, frames, time, status):
+    def _compute_rms(self, data: bytes) -> int:
+        """Compute RMS level from raw PCM int16 data. Returns 0-32767."""
+        if not data:
+            return 0
+        try:
+            if audioop is not None:
+                # audioop.rms expects bytes, width=2 for int16
+                return audioop.rms(data, 2)
+            # Fallback: simple RMS calculation without audioop
+            # Convert bytes to int16 samples
+            import struct
+            samples = struct.unpack(f"<{len(data)//2}h", data)
+            if not samples:
+                return 0
+            sum_sq = sum(s * s for s in samples)
+            return int((sum_sq / len(samples)) ** 0.5)
+        except Exception:
+            return 0
+
+    def _update_rms(self, data: bytes) -> None:
+        rms = self._compute_rms(data)
+        with self._rms_lock:
+            self._rms_window.append(rms)
+
+    def get_rms_level(self) -> float:
+        """Get normalized RMS level (0.0 - 1.0) over the sliding window."""
+        with self._rms_lock:
+            if not self._rms_window:
+                return 0.0
+            # Use max of recent window for VU meter responsiveness
+            max_rms = max(self._rms_window)
+            return min(1.0, max_rms / 32767.0)
+
+    def get_rms_raw(self) -> int:
+        """Get raw max RMS value (0-32767) over the sliding window."""
+        with self._rms_lock:
+            if not self._rms_window:
+                return 0
+            return max(self._rms_window)
+
+    def _callback(self, indata, frames, time_info, status):
         if status:
             logger.warning("Audio status: %s", status)
         data = bytes(indata)
+        self._update_rms(data)
         with self._lock:
             for q in self._subscribers:
                 try:
@@ -137,6 +192,7 @@ class AudioCapture:
                         length, data = self._pcm.read()
                         if length > 0 and data:
                             b_data = bytes(data)
+                            self._update_rms(b_data)
                             with self._lock:
                                 for q in self._subscribers:
                                     try:

--- a/modules/speech/services/audio_capture.py
+++ b/modules/speech/services/audio_capture.py
@@ -69,7 +69,8 @@ class AudioCapture:
         if not isinstance(audio, dict):
             return
         dev = audio.get("device")
-        if dev is not None and str(dev).strip():
+        # YAML `null` or empty string must not wipe a device set by wakeword bootstrap.
+        if dev is not None and str(dev).strip().lower() not in {"", "null", "none"}:
             self.cfg.device = dev
         if audio.get("samplerate") is not None:
             self.cfg.samplerate = int(audio.get("samplerate", self.cfg.samplerate))

--- a/modules/speech/services/audio_capture.py
+++ b/modules/speech/services/audio_capture.py
@@ -21,6 +21,28 @@ logger = logging.getLogger("speech.audio")
 _SINGLE_CAPTURE_INSTANCE: Optional["AudioCapture"] = None
 _INSTANCE_LOCK = threading.Lock()
 
+
+def _is_alsa_device_name(device: Any) -> bool:
+    if device is None:
+        return False
+    text = str(device).strip().lower()
+    if not text or text in {"null", "none", "default"}:
+        return False
+    if text.isdigit():
+        return False
+    return text.startswith(("plughw:", "hw:", "alsa:", "surround")) or "," in text
+
+
+def _portaudio_device(device: Any) -> Any:
+    if device is None:
+        return None
+    if isinstance(device, int):
+        return device
+    text = str(device).strip()
+    if text.isdigit():
+        return int(text)
+    return device
+
 def get_shared_capture(cfg: Dict) -> "AudioCapture":
     """Shared mic for wakeword + speech. Later callers may upgrade device/rate if unset."""
     global _SINGLE_CAPTURE_INSTANCE
@@ -71,7 +93,11 @@ class AudioCapture:
         dev = audio.get("device")
         # YAML `null` or empty string must not wipe a device set by wakeword bootstrap.
         if dev is not None and str(dev).strip().lower() not in {"", "null", "none"}:
-            self.cfg.device = dev
+            new_dev = dev
+            if new_dev != self.cfg.device and (self._stream is not None or self._alsa_thread is not None):
+                logger.info("audio device changed %s -> %s; restarting capture", self.cfg.device, new_dev)
+                self.stop()
+            self.cfg.device = new_dev
         if audio.get("samplerate") is not None:
             self.cfg.samplerate = int(audio.get("samplerate", self.cfg.samplerate))
         if audio.get("channels") is not None:
@@ -88,76 +114,101 @@ class AudioCapture:
                 except queue.Full:
                     pass
 
+    def _start_alsa(self, blocksize: int) -> bool:
+        if alsaaudio is None:
+            return False
+        try:
+            fmt = alsaaudio.PCM_FORMAT_S16_LE if self.cfg.dtype == "int16" else alsaaudio.PCM_FORMAT_S32_LE
+            dev_name = str(self.cfg.device) if self.cfg.device is not None else "default"
+
+            self._pcm = alsaaudio.PCM(
+                type=alsaaudio.PCM_CAPTURE,
+                device=dev_name,
+                channels=self.cfg.channels,
+                rate=self.cfg.samplerate,
+                format=fmt,
+                periodsize=max(64, blocksize),
+            )
+
+            def _alsa_reader():
+                self._stopped = False
+                try:
+                    while not self._stopped:
+                        length, data = self._pcm.read()
+                        if length > 0 and data:
+                            b_data = bytes(data)
+                            with self._lock:
+                                for q in self._subscribers:
+                                    try:
+                                        q.put_nowait(b_data)
+                                    except queue.Full:
+                                        pass
+                finally:
+                    if self._pcm:
+                        self._pcm.close()
+                        self._pcm = None
+
+            self._alsa_thread = threading.Thread(target=_alsa_reader, daemon=True)
+            self._alsa_thread.start()
+            logger.info(
+                "Audio capture started (ALSA): %s @ %d Hz, %d ch",
+                dev_name,
+                self.cfg.samplerate,
+                self.cfg.channels,
+            )
+            return True
+        except Exception as exc:
+            logger.warning("ALSA capture failed for device %s: %s", self.cfg.device, exc)
+            self._pcm = None
+            self._alsa_thread = None
+            return False
+
+    def _start_portaudio(self, blocksize: int) -> bool:
+        if sd is None:
+            return False
+        devs_to_try = [_portaudio_device(self.cfg.device)]
+        if self.cfg.device is not None:
+            devs_to_try.append(None)
+        for dev in devs_to_try:
+            try:
+                self._stream = sd.InputStream(
+                    device=dev,
+                    channels=self.cfg.channels,
+                    samplerate=self.cfg.samplerate,
+                    dtype=self.cfg.dtype,
+                    callback=self._callback,
+                    blocksize=blocksize,
+                )
+                self._stream.start()
+                self._stopped = False
+                logger.info(
+                    "Audio capture started (portaudio): %s @ %d Hz, %d ch",
+                    dev if dev is not None else "default",
+                    self.cfg.samplerate,
+                    self.cfg.channels,
+                )
+                return True
+            except Exception as exc:
+                logger.warning("sounddevice attempt failed for device %s: %s", dev, exc)
+                self._stream = None
+        return False
+
     def start(self):
         with self._lock:
             if self._stream is not None or self._alsa_thread is not None:
                 return
 
+            self._stopped = False
             blocksize = int(self.cfg.samplerate * self.cfg.frame_ms / 1000)
-            
-            # Try sounddevice (PortAudio)
-            if sd is not None:
-                # 1. Try explicit device
-                devs_to_try = [self.cfg.device, None] # Try configured, then default
-                for dev in devs_to_try:
-                    try:
-                        # Convert numeric string to int
-                        actual_dev = dev
-                        if isinstance(dev, str) and dev.isdigit():
-                            actual_dev = int(dev)
-                        
-                        self._stream = sd.InputStream(
-                            device=actual_dev,
-                            channels=self.cfg.channels,
-                            samplerate=self.cfg.samplerate,
-                            dtype=self.cfg.dtype,
-                            callback=self._callback,
-                            blocksize=blocksize,
-                        )
-                        self._stream.start()
-                        self._stopped = False
-                        logger.info("Audio capture started (portaudio): %s @ %d Hz", actual_dev if actual_dev is not None else "default", self.cfg.samplerate)
-                        return
-                    except Exception as exc:
-                        logger.warning("sounddevice attempt failed for device %s: %s", dev, exc)
 
-            # Fallback: pyalsaaudio
-            if alsaaudio is not None:
-                try:
-                    fmt = alsaaudio.PCM_FORMAT_S16_LE if self.cfg.dtype == 'int16' else alsaaudio.PCM_FORMAT_S32_LE
-                    dev_name = str(self.cfg.device) if self.cfg.device is not None else "default"
-                    
-                    self._pcm = alsaaudio.PCM(
-                        type=alsaaudio.PCM_CAPTURE,
-                        device=dev_name,
-                        channels=self.cfg.channels,
-                        rate=self.cfg.samplerate,
-                        format=fmt,
-                        periodsize=max(64, blocksize)
-                    )
-
-                    def _alsa_reader():
-                        self._stopped = False
-                        try:
-                            while not self._stopped:
-                                length, data = self._pcm.read()
-                                if length > 0 and data:
-                                    b_data = bytes(data)
-                                    with self._lock:
-                                        for q in self._subscribers:
-                                            try: q.put_nowait(b_data)
-                                            except: pass
-                        finally:
-                            if self._pcm:
-                                self._pcm.close()
-                                self._pcm = None
-
-                    self._alsa_thread = threading.Thread(target=_alsa_reader, daemon=True)
-                    self._alsa_thread.start()
-                    logger.info("Audio capture started (ALSA fallback): %s @ %d Hz", dev_name, self.cfg.samplerate)
+            # ALSA device strings (plughw:0,0) are invalid for PortAudio; use ALSA directly.
+            if _is_alsa_device_name(self.cfg.device):
+                if self._start_alsa(blocksize):
                     return
-                except Exception as exc:
-                    logger.warning("ALSA fallback failed: %s", exc)
+            elif self._start_portaudio(blocksize):
+                return
+            elif self._start_alsa(blocksize):
+                return
 
             raise RuntimeError("No working audio backend could be started.")
 

--- a/modules/speech/services/recognizer.py
+++ b/modules/speech/services/recognizer.py
@@ -99,11 +99,15 @@ class Recognizer:
                 try:
                     import webrtcvad as _webrtcvad  # type: ignore
                 except Exception as exc:
-                    raise RuntimeError(
-                        "VAD enabled but 'webrtcvad' is not installed. Install with 'pip install webrtcvad'."
-                    ) from exc
-                webrtcvad = _webrtcvad
-            if self._vad is None:
+                    logger.warning(
+                        "webrtcvad unavailable; continuing without VAD (%s). "
+                        "Install with 'pip install webrtcvad' for VAD filtering.",
+                        exc,
+                    )
+                    self.cfg.vad_enabled = False
+                else:
+                    webrtcvad = _webrtcvad
+            if self.cfg.vad_enabled and webrtcvad is not None and self._vad is None:
                 self._vad = webrtcvad.Vad(self.cfg.vad_aggressiveness)
 
     def run(self, stream: Iterable[bytes]) -> Iterator[RecognitionResult]:

--- a/modules/speech/services/wake_phrase.py
+++ b/modules/speech/services/wake_phrase.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-WAKE_PHRASES = ("hey sentrybot", "hey sentry", "sentrybot", "sentry")
+WAKE_PHRASES = ("hey mycroft", "mycroft", "hey sentrybot", "hey sentry", "sentrybot", "sentry")
 
 
 def contains_wakeword(text: str) -> bool:

--- a/modules/speech/tests/test_audio_capture.py
+++ b/modules/speech/tests/test_audio_capture.py
@@ -1,0 +1,13 @@
+from modules.speech.services.audio_capture import AudioCapture
+
+
+def test_merge_config_keeps_device_when_override_is_null() -> None:
+    capture = AudioCapture({"device": "plughw:0,0", "samplerate": 16000, "channels": 2})
+    capture.merge_config({"device": None, "samplerate": 16000})
+    assert capture.cfg.device == "plughw:0,0"
+
+
+def test_merge_config_applies_explicit_device() -> None:
+    capture = AudioCapture({"device": "default", "samplerate": 16000, "channels": 1})
+    capture.merge_config({"device": "plughw:1,0"})
+    assert capture.cfg.device == "plughw:1,0"

--- a/modules/speech/tests/test_audio_capture.py
+++ b/modules/speech/tests/test_audio_capture.py
@@ -11,3 +11,12 @@ def test_merge_config_applies_explicit_device() -> None:
     capture = AudioCapture({"device": "default", "samplerate": 16000, "channels": 1})
     capture.merge_config({"device": "plughw:1,0"})
     assert capture.cfg.device == "plughw:1,0"
+
+
+def test_is_alsa_device_name() -> None:
+    from modules.speech.services.audio_capture import _is_alsa_device_name
+
+    assert _is_alsa_device_name("plughw:0,0")
+    assert _is_alsa_device_name("hw:1,0")
+    assert not _is_alsa_device_name("0")
+    assert not _is_alsa_device_name(None)

--- a/modules/speech/tests/test_wake_phrase.py
+++ b/modules/speech/tests/test_wake_phrase.py
@@ -4,11 +4,13 @@ from modules.speech.services.wake_phrase import contains_wakeword, strip_wakewor
 
 
 def test_contains_wakeword() -> None:
+    assert contains_wakeword("hey mycroft")
     assert contains_wakeword("hey sentrybot")
     assert contains_wakeword("Hey Sentry, what is up")
     assert not contains_wakeword("merhaba nasılsın")
 
 
 def test_strip_wakewords() -> None:
+    assert strip_wakewords("hey mycroft please help") == "please help"
     assert strip_wakewords("hey sentrybot please help") == "please help"
     assert strip_wakewords("hey sentrybot") == ""

--- a/modules/wakeword/config/config.yml
+++ b/modules/wakeword/config/config.yml
@@ -10,9 +10,9 @@ audio:
   frame_ms: 30
 
 recognition:
-  language: tr
-  # point to speech module's model to reuse existing download
-  model_path: ../speech/models/vosk-tr
+  language: en
+  # Vosk fallback path when openWakeWord is unavailable (hey mycroft is English).
+  model_path: ../speech/models/vosk-en
   language_models:
     tr: models/vosk-tr
     en: models/vosk-en

--- a/modules/wakeword/config/config.yml
+++ b/modules/wakeword/config/config.yml
@@ -20,7 +20,7 @@ recognition:
   samplerate: 16000
   max_alternatives: 0
   vad:
-    enabled: true
+    enabled: false
     aggressiveness: 2
     hangover_ms: 300
 

--- a/modules/wakeword/config/config.yml
+++ b/modules/wakeword/config/config.yml
@@ -27,16 +27,16 @@ recognition:
 wakeword:
   engine: "openwakeword"  # openwakeword | vosk
   words:
-    - "hey sentry"
-    - "sentry"
+    - "hey mycroft"
+    - "mycroft"
   trigger_on_partial: true
   min_confidence: 0.0
   cooldown_sec: 3.0
 
 openwakeword:
-  # model_paths can be a list or a map: {label: path}
-  model_paths:
-    - models/hey_sentribot.onnx
+  # Built-in openWakeWord catalog model (auto-downloaded on first run).
+  pretrained_models:
+    - hey_mycroft
   inference_framework: onnx
   threshold: 0.25
   smooth_window: 3

--- a/modules/wakeword/config/config.yml
+++ b/modules/wakeword/config/config.yml
@@ -62,6 +62,7 @@ actions:
   agent_interrupt_url: "@gateway/agent/speech/interrupt"
   speech_last_url: "@gateway/speech/last"
   interactions_event_url: "@gateway/interactions/event"
+  neopixel_url: "@gateway/neopixel"
   listen_window_sec: 8.0
   min_listen_before_final_sec: 1.0   # shorter when VAD filters wakeword echo
   min_listen_before_final_sec_vad: 0.75

--- a/modules/wakeword/config_loader.py
+++ b/modules/wakeword/config_loader.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import Any, Dict
+
 import yaml
+
+from modules.config_center.agent_yaml_loader import deep_merge, load_agent_config
 
 _DEF_CFG_PATH = Path(__file__).parent / "config" / "config.yml"
 
 
 def load_config(override_path: str | os.PathLike | None = None) -> Dict[str, Any]:
-    """Load YAML config for the wakeword module.
+    """Load wakeword config.
 
-    Priority: override_path > WAKEWORD_CONFIG env > default config.yml
+    Priority:
+    1) override_path / WAKEWORD_CONFIG env -> local config.yml
+    2) deep-merge config/agent.yaml `wakeword` section (when present)
+    3) sync `speech.audio` device from agent.yaml if wakeword audio device unset
     """
     cfg_env = os.getenv("WAKEWORD_CONFIG")
     cfg_path = Path(override_path or cfg_env) if (override_path or cfg_env) else _DEF_CFG_PATH
@@ -18,4 +25,21 @@ def load_config(override_path: str | os.PathLike | None = None) -> Dict[str, Any
         raise FileNotFoundError(f"Config file not found: {cfg_path}")
     with open(cfg_path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
+
+    try:
+        agent_cfg = load_agent_config()
+        section = agent_cfg.get("wakeword")
+        if isinstance(section, dict):
+            data = deep_merge(data, section)
+        speech_audio = (agent_cfg.get("speech") or {}).get("audio")
+        if isinstance(speech_audio, dict):
+            audio = data.setdefault("audio", {})
+            if isinstance(audio, dict):
+                dev = audio.get("device")
+                speech_dev = speech_audio.get("device")
+                if (not dev or str(dev).strip().lower() in {"", "null", "none"}) and speech_dev:
+                    audio["device"] = speech_dev
+    except Exception:
+        pass
+
     return data

--- a/modules/wakeword/requirements.txt
+++ b/modules/wakeword/requirements.txt
@@ -1,0 +1,3 @@
+openwakeword>=0.6.0
+numpy>=1.24.0
+onnxruntime>=1.16.0

--- a/modules/wakeword/services/openwakeword_runner.py
+++ b/modules/wakeword/services/openwakeword_runner.py
@@ -23,6 +23,33 @@ try:
 except Exception:
     pass
 
+_OWW_RELEASE = "v0.5.1"
+_OWW_BASE = f"https://github.com/dscripka/openWakeWord/releases/download/{_OWW_RELEASE}"
+
+# Fallback when installed openwakeword wheel omits MODELS (seen on some Pi builds).
+BUILTIN_FEATURE_MODELS: Dict[str, dict] = {
+    "melspectrogram": {
+        "download_url": f"{_OWW_BASE}/melspectrogram.tflite",
+        "filename": "melspectrogram.tflite",
+    },
+    "embedding": {
+        "download_url": f"{_OWW_BASE}/embedding_model.tflite",
+        "filename": "embedding_model.tflite",
+    },
+}
+BUILTIN_VAD_MODELS: Dict[str, dict] = {
+    "silero_vad": {
+        "download_url": f"{_OWW_BASE}/silero_vad.onnx",
+        "filename": "silero_vad.onnx",
+    },
+}
+BUILTIN_WAKE_MODELS: Dict[str, dict] = {
+    "hey_mycroft": {
+        "download_url": f"{_OWW_BASE}/hey_mycroft_v0.1.tflite",
+        "filename": "hey_mycroft_v0.1.tflite",
+    },
+}
+
 
 def _as_float(value) -> Optional[float]:
     try:
@@ -48,6 +75,47 @@ def _score_value(value) -> Optional[float]:
     except Exception:
         pass
     return _as_float(value)
+
+
+def _module_models_dir() -> Path:
+    return Path(__file__).resolve().parents[1] / "models"
+
+
+def _openwakeword_catalog() -> dict:
+    try:
+        import openwakeword  # type: ignore
+
+        catalog = getattr(openwakeword, "MODELS", {}) or {}
+        if catalog:
+            return dict(catalog)
+    except Exception:
+        pass
+    module_dir = _module_models_dir()
+    return {
+        key: {
+            "model_path": str(module_dir / str(meta["filename"])),
+            "download_url": str(meta["download_url"]),
+        }
+        for key, meta in BUILTIN_WAKE_MODELS.items()
+    }
+
+
+def _feature_model_groups() -> list[dict]:
+    try:
+        import openwakeword  # type: ignore
+    except Exception:
+        openwakeword = None  # type: ignore
+    groups: list[dict] = []
+    if openwakeword is not None:
+        feat = getattr(openwakeword, "FEATURE_MODELS", {}) or {}
+        vad = getattr(openwakeword, "VAD_MODELS", {}) or {}
+        if feat:
+            groups.append(dict(feat))
+        if vad:
+            groups.append(dict(vad))
+    if not groups:
+        groups = [BUILTIN_FEATURE_MODELS, BUILTIN_VAD_MODELS]
+    return groups
 
 
 def _openwakeword_pkg_dir() -> Path:
@@ -110,25 +178,25 @@ def _try_utils_download_models(model_names: list[str]) -> bool:
 
 
 def _ensure_openwakeword_assets(model_names: list[str], use_onnx: bool) -> None:
-    import openwakeword  # type: ignore
-
     if _try_utils_download_models(model_names):
         return
 
-    target = _openwakeword_models_dir()
-    for group in (
-        getattr(openwakeword, "FEATURE_MODELS", {}) or {},
-        getattr(openwakeword, "VAD_MODELS", {}) or {},
-    ):
+    targets = [_openwakeword_models_dir(), _module_models_dir()]
+    for target in targets:
+        target.mkdir(parents=True, exist_ok=True)
+
+    for group in _feature_model_groups():
         for entry in group.values():
             if isinstance(entry, dict) and entry.get("download_url"):
-                _download_asset_pair(str(entry["download_url"]), target)
+                for target in targets:
+                    _download_asset_pair(str(entry["download_url"]), target)
 
-    catalog = getattr(openwakeword, "MODELS", {}) or {}
+    catalog = _openwakeword_catalog()
     for name in model_names:
         entry = catalog.get(name)
         if isinstance(entry, dict) and entry.get("download_url"):
-            _download_asset_pair(str(entry["download_url"]), target)
+            for target in targets:
+                _download_asset_pair(str(entry["download_url"]), target)
 
 
 def _normalize_pretrained_names(model_names: list, catalog: dict) -> list[str]:
@@ -156,13 +224,13 @@ def _resolve_pretrained_models(
 ) -> tuple[Dict[str, str], list[str]]:
     """Resolve built-in openWakeWord models (e.g. hey_mycroft) and ensure assets exist."""
     try:
-        import openwakeword  # type: ignore
+        import openwakeword  # type: ignore  # noqa: F401
     except Exception as exc:
         raise RuntimeError(f"openwakeword is required for pretrained models: {exc}") from exc
 
-    catalog = getattr(openwakeword, "MODELS", {}) or {}
+    catalog = _openwakeword_catalog()
     if not catalog:
-        raise RuntimeError("openwakeword.MODELS catalog is empty")
+        raise RuntimeError("openwakeword model catalog is empty")
 
     normalized = _normalize_pretrained_names(model_names, catalog)
     use_onnx = str(inference_framework or "onnx").strip().lower() == "onnx"
@@ -170,13 +238,22 @@ def _resolve_pretrained_models(
 
     resolved: Dict[str, str] = {}
     for key in normalized:
-        base_path = Path(str(catalog[key]["model_path"]))
-        candidate = base_path.with_suffix(".onnx" if use_onnx else ".tflite")
-        if not candidate.exists() and base_path.exists():
-            candidate = base_path
-        if not candidate.exists():
-            raise FileNotFoundError(f"openwakeword model missing after download: {candidate}")
-        resolved[key] = str(candidate.resolve())
+        entry = catalog[key]
+        candidates: list[Path] = []
+        base_path = Path(str(entry.get("model_path", "")))
+        if base_path.name:
+            candidates.append(base_path)
+            candidates.append(base_path.with_suffix(".onnx" if use_onnx else ".tflite"))
+        fname = BUILTIN_WAKE_MODELS.get(key, {}).get("filename")
+        if fname:
+            stem = Path(str(fname)).stem
+            for root in (_openwakeword_models_dir(), _module_models_dir()):
+                candidates.append(root / f"{stem}.onnx" if use_onnx else root / str(fname))
+                candidates.append(root / str(fname))
+        chosen = next((p for p in candidates if p.exists()), None)
+        if chosen is None:
+            raise FileNotFoundError(f"openwakeword model missing after download: {key}")
+        resolved[key] = str(chosen.resolve())
     return resolved, normalized
 
 
@@ -217,10 +294,13 @@ class OpenWakewordRunner:
             ow_pkg = importlib.import_module("openwakeword")
             pkg_dir = Path(getattr(ow_pkg, "__file__", "")).resolve().parent
             _ensure_openwakeword_assets([], True)
-            required = pkg_dir / "resources" / "models" / "melspectrogram.onnx"
-            if not required.exists():
+            mel_candidates = [
+                pkg_dir / "resources" / "models" / "melspectrogram.onnx",
+                _module_models_dir() / "melspectrogram.onnx",
+            ]
+            if not any(path.exists() for path in mel_candidates):
                 raise RuntimeError(
-                    f"openwakeword runtime resource missing: {required}. "
+                    "openwakeword runtime resource missing: melspectrogram.onnx. "
                     "Reinstall openwakeword or use wakeword.engine=vosk."
                 )
         except RuntimeError:

--- a/modules/wakeword/services/openwakeword_runner.py
+++ b/modules/wakeword/services/openwakeword_runner.py
@@ -27,7 +27,17 @@ _OWW_RELEASE = "v0.5.1"
 _OWW_BASE = f"https://github.com/dscripka/openWakeWord/releases/download/{_OWW_RELEASE}"
 
 # Fallback when installed openwakeword wheel omits MODELS (seen on some Pi builds).
-BUILTIN_FEATURE_MODELS: Dict[str, dict] = {
+BUILTIN_FEATURE_MODELS_ONNX: Dict[str, dict] = {
+    "melspectrogram": {
+        "download_url": f"{_OWW_BASE}/melspectrogram.onnx",
+        "filename": "melspectrogram.onnx",
+    },
+    "embedding": {
+        "download_url": f"{_OWW_BASE}/embedding_model.onnx",
+        "filename": "embedding_model.onnx",
+    },
+}
+BUILTIN_FEATURE_MODELS_TFLITE: Dict[str, dict] = {
     "melspectrogram": {
         "download_url": f"{_OWW_BASE}/melspectrogram.tflite",
         "filename": "melspectrogram.tflite",
@@ -43,12 +53,20 @@ BUILTIN_VAD_MODELS: Dict[str, dict] = {
         "filename": "silero_vad.onnx",
     },
 }
-BUILTIN_WAKE_MODELS: Dict[str, dict] = {
+BUILTIN_WAKE_MODELS_ONNX: Dict[str, dict] = {
+    "hey_mycroft": {
+        "download_url": f"{_OWW_BASE}/hey_mycroft_v0.1.onnx",
+        "filename": "hey_mycroft_v0.1.onnx",
+    },
+}
+BUILTIN_WAKE_MODELS_TFLITE: Dict[str, dict] = {
     "hey_mycroft": {
         "download_url": f"{_OWW_BASE}/hey_mycroft_v0.1.tflite",
         "filename": "hey_mycroft_v0.1.tflite",
     },
 }
+# Backward-compatible alias used in tests.
+BUILTIN_WAKE_MODELS = BUILTIN_WAKE_MODELS_ONNX
 
 
 def _as_float(value) -> Optional[float]:
@@ -81,7 +99,11 @@ def _module_models_dir() -> Path:
     return Path(__file__).resolve().parents[1] / "models"
 
 
-def _openwakeword_catalog() -> dict:
+def _builtin_wake_models(use_onnx: bool) -> Dict[str, dict]:
+    return BUILTIN_WAKE_MODELS_ONNX if use_onnx else BUILTIN_WAKE_MODELS_TFLITE
+
+
+def _openwakeword_catalog(use_onnx: bool = True) -> dict:
     try:
         import openwakeword  # type: ignore
 
@@ -96,11 +118,11 @@ def _openwakeword_catalog() -> dict:
             "model_path": str(module_dir / str(meta["filename"])),
             "download_url": str(meta["download_url"]),
         }
-        for key, meta in BUILTIN_WAKE_MODELS.items()
+        for key, meta in _builtin_wake_models(use_onnx).items()
     }
 
 
-def _feature_model_groups() -> list[dict]:
+def _feature_model_groups(use_onnx: bool = True) -> list[dict]:
     try:
         import openwakeword  # type: ignore
     except Exception:
@@ -114,7 +136,8 @@ def _feature_model_groups() -> list[dict]:
         if vad:
             groups.append(dict(vad))
     if not groups:
-        groups = [BUILTIN_FEATURE_MODELS, BUILTIN_VAD_MODELS]
+        feat_builtin = BUILTIN_FEATURE_MODELS_ONNX if use_onnx else BUILTIN_FEATURE_MODELS_TFLITE
+        groups = [feat_builtin, BUILTIN_VAD_MODELS]
     return groups
 
 
@@ -127,21 +150,38 @@ def _openwakeword_models_dir() -> Path:
     return _openwakeword_pkg_dir() / "resources" / "models"
 
 
-def _download_url(url: str, dest: Path) -> None:
-    if dest.exists():
+def _download_url(url: str, dest: Path, min_bytes: int = 1024) -> None:
+    if dest.exists() and dest.stat().st_size >= min_bytes:
         return
+    if dest.exists():
+        try:
+            dest.unlink()
+        except Exception:
+            pass
     dest.parent.mkdir(parents=True, exist_ok=True)
     import urllib.request
 
     logger.info("downloading openwakeword asset: %s", dest.name)
     urllib.request.urlretrieve(url, dest)
+    if not dest.exists() or dest.stat().st_size < min_bytes:
+        raise RuntimeError(f"openwakeword download incomplete: {dest.name}")
 
 
-def _download_asset_pair(url: str, target_dir: Path) -> None:
+def _framework_asset_url(url: str, use_onnx: bool) -> tuple[str, str]:
     fname = url.rsplit("/", 1)[-1]
-    _download_url(url, target_dir / fname)
-    if fname.endswith(".tflite"):
-        _download_url(url.replace(".tflite", ".onnx"), target_dir / fname.replace(".tflite", ".onnx"))
+    if use_onnx:
+        if fname.endswith(".tflite"):
+            fname = fname[:-7] + ".onnx"
+            url = url.replace(".tflite", ".onnx")
+    elif fname.endswith(".onnx"):
+        fname = fname[:-5] + ".tflite"
+        url = url.replace(".onnx", ".tflite")
+    return url, fname
+
+
+def _download_framework_asset(url: str, target_dir: Path, use_onnx: bool) -> None:
+    asset_url, fname = _framework_asset_url(url, use_onnx)
+    _download_url(asset_url, target_dir / fname)
 
 
 def _try_utils_download_models(model_names: list[str]) -> bool:
@@ -185,18 +225,18 @@ def _ensure_openwakeword_assets(model_names: list[str], use_onnx: bool) -> None:
     for target in targets:
         target.mkdir(parents=True, exist_ok=True)
 
-    for group in _feature_model_groups():
+    for group in _feature_model_groups(use_onnx):
         for entry in group.values():
             if isinstance(entry, dict) and entry.get("download_url"):
                 for target in targets:
-                    _download_asset_pair(str(entry["download_url"]), target)
+                    _download_framework_asset(str(entry["download_url"]), target, use_onnx)
 
-    catalog = _openwakeword_catalog()
+    catalog = _openwakeword_catalog(use_onnx)
     for name in model_names:
         entry = catalog.get(name)
         if isinstance(entry, dict) and entry.get("download_url"):
             for target in targets:
-                _download_asset_pair(str(entry["download_url"]), target)
+                _download_framework_asset(str(entry["download_url"]), target, use_onnx)
 
 
 def _normalize_pretrained_names(model_names: list, catalog: dict) -> list[str]:
@@ -228,31 +268,34 @@ def _resolve_pretrained_models(
     except Exception as exc:
         raise RuntimeError(f"openwakeword is required for pretrained models: {exc}") from exc
 
-    catalog = _openwakeword_catalog()
+    use_onnx = str(inference_framework or "onnx").strip().lower() == "onnx"
+    catalog = _openwakeword_catalog(use_onnx)
     if not catalog:
         raise RuntimeError("openwakeword model catalog is empty")
 
     normalized = _normalize_pretrained_names(model_names, catalog)
-    use_onnx = str(inference_framework or "onnx").strip().lower() == "onnx"
     _ensure_openwakeword_assets(normalized, use_onnx)
 
     resolved: Dict[str, str] = {}
+    ext = ".onnx" if use_onnx else ".tflite"
     for key in normalized:
         entry = catalog[key]
         candidates: list[Path] = []
+        builtin_fname = _builtin_wake_models(use_onnx).get(key, {}).get("filename")
+        if builtin_fname:
+            stem = Path(str(builtin_fname)).stem
+            for root in (_openwakeword_models_dir(), _module_models_dir()):
+                candidates.append(root / f"{stem}{ext}")
         base_path = Path(str(entry.get("model_path", "")))
         if base_path.name:
-            candidates.append(base_path)
-            candidates.append(base_path.with_suffix(".onnx" if use_onnx else ".tflite"))
-        fname = BUILTIN_WAKE_MODELS.get(key, {}).get("filename")
-        if fname:
-            stem = Path(str(fname)).stem
-            for root in (_openwakeword_models_dir(), _module_models_dir()):
-                candidates.append(root / f"{stem}.onnx" if use_onnx else root / str(fname))
-                candidates.append(root / str(fname))
-        chosen = next((p for p in candidates if p.exists()), None)
+            candidates.append(base_path.with_suffix(ext))
+            if base_path.suffix != ext:
+                candidates.append(base_path)
+        chosen = next((p for p in candidates if p.exists() and p.stat().st_size >= 1024), None)
         if chosen is None:
             raise FileNotFoundError(f"openwakeword model missing after download: {key}")
+        if use_onnx and chosen.suffix.lower() != ".onnx":
+            raise FileNotFoundError(f"openwakeword onnx model missing (found {chosen.name}): {key}")
         resolved[key] = str(chosen.resolve())
     return resolved, normalized
 

--- a/modules/wakeword/services/openwakeword_runner.py
+++ b/modules/wakeword/services/openwakeword_runner.py
@@ -50,18 +50,88 @@ def _score_value(value) -> Optional[float]:
     return _as_float(value)
 
 
-def _resolve_pretrained_models(model_names: list, inference_framework: str = "onnx") -> Dict[str, str]:
-    """Resolve built-in openWakeWord models (e.g. hey_mycroft) and ensure they are downloaded."""
+def _openwakeword_pkg_dir() -> Path:
+    ow_pkg = importlib.import_module("openwakeword")
+    return Path(getattr(ow_pkg, "__file__", "")).resolve().parent
+
+
+def _openwakeword_models_dir() -> Path:
+    return _openwakeword_pkg_dir() / "resources" / "models"
+
+
+def _download_url(url: str, dest: Path) -> None:
+    if dest.exists():
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    import urllib.request
+
+    logger.info("downloading openwakeword asset: %s", dest.name)
+    urllib.request.urlretrieve(url, dest)
+
+
+def _download_asset_pair(url: str, target_dir: Path) -> None:
+    fname = url.rsplit("/", 1)[-1]
+    _download_url(url, target_dir / fname)
+    if fname.endswith(".tflite"):
+        _download_url(url.replace(".tflite", ".onnx"), target_dir / fname.replace(".tflite", ".onnx"))
+
+
+def _try_utils_download_models(model_names: list[str]) -> bool:
+    """Call openWakeWord's download helper when available (API differs across versions)."""
     try:
         import openwakeword  # type: ignore
-        from openwakeword.utils import download_models  # type: ignore
-    except Exception as exc:
-        raise RuntimeError(f"openwakeword is required for pretrained models: {exc}") from exc
+    except Exception:
+        return False
+
+    utils_mod = getattr(openwakeword, "utils", None)
+    download_fn = getattr(utils_mod, "download_models", None) if utils_mod is not None else None
+    if download_fn is None:
+        try:
+            from openwakeword.utils import download_models as download_fn  # type: ignore
+        except Exception:
+            download_fn = None
+    if download_fn is None:
+        return False
+
+    for args, kwargs in (
+        ((), {"model_names": model_names}),
+        ((model_names,), {}),
+        ((), {}),
+    ):
+        try:
+            download_fn(*args, **kwargs)
+            return True
+        except TypeError:
+            continue
+        except Exception as exc:
+            logger.debug("openwakeword.utils.download_models failed: %s", exc)
+            return False
+    return False
+
+
+def _ensure_openwakeword_assets(model_names: list[str], use_onnx: bool) -> None:
+    import openwakeword  # type: ignore
+
+    if _try_utils_download_models(model_names):
+        return
+
+    target = _openwakeword_models_dir()
+    for group in (
+        getattr(openwakeword, "FEATURE_MODELS", {}) or {},
+        getattr(openwakeword, "VAD_MODELS", {}) or {},
+    ):
+        for entry in group.values():
+            if isinstance(entry, dict) and entry.get("download_url"):
+                _download_asset_pair(str(entry["download_url"]), target)
 
     catalog = getattr(openwakeword, "MODELS", {}) or {}
-    if not catalog:
-        raise RuntimeError("openwakeword.MODELS catalog is empty")
+    for name in model_names:
+        entry = catalog.get(name)
+        if isinstance(entry, dict) and entry.get("download_url"):
+            _download_asset_pair(str(entry["download_url"]), target)
 
+
+def _normalize_pretrained_names(model_names: list, catalog: dict) -> list[str]:
     normalized: list[str] = []
     for raw in model_names:
         key = str(raw or "").strip().lower().replace(" ", "_").replace("-", "_")
@@ -75,12 +145,29 @@ def _resolve_pretrained_models(model_names: list, inference_framework: str = "on
             else:
                 raise ValueError(f"unknown openwakeword pretrained model: {raw}")
         normalized.append(key)
-
     if not normalized:
         raise ValueError("pretrained_models is empty")
+    return normalized
 
-    download_models(model_names=normalized)
+
+def _resolve_pretrained_models(
+    model_names: list,
+    inference_framework: str = "onnx",
+) -> tuple[Dict[str, str], list[str]]:
+    """Resolve built-in openWakeWord models (e.g. hey_mycroft) and ensure assets exist."""
+    try:
+        import openwakeword  # type: ignore
+    except Exception as exc:
+        raise RuntimeError(f"openwakeword is required for pretrained models: {exc}") from exc
+
+    catalog = getattr(openwakeword, "MODELS", {}) or {}
+    if not catalog:
+        raise RuntimeError("openwakeword.MODELS catalog is empty")
+
+    normalized = _normalize_pretrained_names(model_names, catalog)
     use_onnx = str(inference_framework or "onnx").strip().lower() == "onnx"
+    _ensure_openwakeword_assets(normalized, use_onnx)
+
     resolved: Dict[str, str] = {}
     for key in normalized:
         base_path = Path(str(catalog[key]["model_path"]))
@@ -90,7 +177,7 @@ def _resolve_pretrained_models(model_names: list, inference_framework: str = "on
         if not candidate.exists():
             raise FileNotFoundError(f"openwakeword model missing after download: {candidate}")
         resolved[key] = str(candidate.resolve())
-    return resolved
+    return resolved, normalized
 
 
 def _resolve_model_paths(model_paths) -> Dict[str, str]:
@@ -129,6 +216,7 @@ class OpenWakewordRunner:
         try:
             ow_pkg = importlib.import_module("openwakeword")
             pkg_dir = Path(getattr(ow_pkg, "__file__", "")).resolve().parent
+            _ensure_openwakeword_assets([], True)
             required = pkg_dir / "resources" / "models" / "melspectrogram.onnx"
             if not required.exists():
                 raise RuntimeError(
@@ -145,16 +233,14 @@ class OpenWakewordRunner:
             pretrained = cfg.get("pretrained_model")
         if isinstance(pretrained, str) and pretrained.strip():
             pretrained = [pretrained.strip()]
+        pretrained_names: list[str] = []
         if isinstance(pretrained, list) and pretrained:
-            model_paths = _resolve_pretrained_models(pretrained, inference_framework)
+            model_paths, pretrained_names = _resolve_pretrained_models(pretrained, inference_framework)
         else:
             model_paths = _resolve_model_paths(cfg.get("model_paths"))
         if not model_paths:
             raise ValueError("openwakeword.pretrained_models or openwakeword.model_paths is required")
         self._labels = list(model_paths.keys())
-        # Instantiate model in a backward/forward-compatible way.
-        # Prefer kwargs so inference_framework maps correctly even when
-        # upstream uses a permissive (*args, **kwargs) constructor.
         paths_list = list(model_paths.values())
         model_ctor = OpenWakeWordModel
 
@@ -171,6 +257,7 @@ class OpenWakewordRunner:
         tried = []
         last_exc = None
         candidates = [
+            {'kwargs': {'wakeword_models': pretrained_names or paths_list, 'inference_framework': inference_framework}},
             {'kwargs': {'wakeword_models': paths_list, 'inference_framework': inference_framework}},
             {'kwargs': {'model_paths': paths_list, 'inference_framework': inference_framework}},
             {'kwargs': {'models': paths_list, 'inference_framework': inference_framework}},

--- a/modules/wakeword/services/openwakeword_runner.py
+++ b/modules/wakeword/services/openwakeword_runner.py
@@ -50,6 +50,49 @@ def _score_value(value) -> Optional[float]:
     return _as_float(value)
 
 
+def _resolve_pretrained_models(model_names: list, inference_framework: str = "onnx") -> Dict[str, str]:
+    """Resolve built-in openWakeWord models (e.g. hey_mycroft) and ensure they are downloaded."""
+    try:
+        import openwakeword  # type: ignore
+        from openwakeword.utils import download_models  # type: ignore
+    except Exception as exc:
+        raise RuntimeError(f"openwakeword is required for pretrained models: {exc}") from exc
+
+    catalog = getattr(openwakeword, "MODELS", {}) or {}
+    if not catalog:
+        raise RuntimeError("openwakeword.MODELS catalog is empty")
+
+    normalized: list[str] = []
+    for raw in model_names:
+        key = str(raw or "").strip().lower().replace(" ", "_").replace("-", "_")
+        if not key:
+            continue
+        if key not in catalog:
+            aliases = {name.replace("_", ""): name for name in catalog}
+            compact = key.replace("_", "")
+            if compact in aliases:
+                key = aliases[compact]
+            else:
+                raise ValueError(f"unknown openwakeword pretrained model: {raw}")
+        normalized.append(key)
+
+    if not normalized:
+        raise ValueError("pretrained_models is empty")
+
+    download_models(model_names=normalized)
+    use_onnx = str(inference_framework or "onnx").strip().lower() == "onnx"
+    resolved: Dict[str, str] = {}
+    for key in normalized:
+        base_path = Path(str(catalog[key]["model_path"]))
+        candidate = base_path.with_suffix(".onnx" if use_onnx else ".tflite")
+        if not candidate.exists() and base_path.exists():
+            candidate = base_path
+        if not candidate.exists():
+            raise FileNotFoundError(f"openwakeword model missing after download: {candidate}")
+        resolved[key] = str(candidate.resolve())
+    return resolved
+
+
 def _resolve_model_paths(model_paths) -> Dict[str, str]:
     module_root = Path(__file__).resolve().parents[1]
 
@@ -96,11 +139,19 @@ class OpenWakewordRunner:
             raise
         except Exception as exc:
             raise RuntimeError(f"openwakeword preflight failed: {exc}")
-        model_paths = _resolve_model_paths(cfg.get("model_paths"))
-        if not model_paths:
-            raise ValueError("openwakeword.model_paths is required")
-        self._labels = list(model_paths.keys())
         inference_framework = str(cfg.get("inference_framework", "onnx")).strip().lower() or "onnx"
+        pretrained = cfg.get("pretrained_models")
+        if pretrained is None:
+            pretrained = cfg.get("pretrained_model")
+        if isinstance(pretrained, str) and pretrained.strip():
+            pretrained = [pretrained.strip()]
+        if isinstance(pretrained, list) and pretrained:
+            model_paths = _resolve_pretrained_models(pretrained, inference_framework)
+        else:
+            model_paths = _resolve_model_paths(cfg.get("model_paths"))
+        if not model_paths:
+            raise ValueError("openwakeword.pretrained_models or openwakeword.model_paths is required")
+        self._labels = list(model_paths.keys())
         # Instantiate model in a backward/forward-compatible way.
         # Prefer kwargs so inference_framework maps correctly even when
         # upstream uses a permissive (*args, **kwargs) constructor.

--- a/modules/wakeword/tests/test_config_loader.py
+++ b/modules/wakeword/tests/test_config_loader.py
@@ -1,0 +1,10 @@
+from modules.wakeword.config_loader import load_config
+
+
+def test_wakeword_config_loads_audio_device() -> None:
+    cfg = load_config()
+    audio = cfg.get("audio", {})
+    assert audio.get("device")
+    assert "wakeword" in cfg
+    ow = cfg.get("openwakeword", {})
+    assert ow.get("pretrained_models") == ["hey_mycroft"]

--- a/modules/wakeword/tests/test_config_loader.py
+++ b/modules/wakeword/tests/test_config_loader.py
@@ -8,3 +8,4 @@ def test_wakeword_config_loads_audio_device() -> None:
     assert "wakeword" in cfg
     ow = cfg.get("openwakeword", {})
     assert ow.get("pretrained_models") == ["hey_mycroft"]
+    assert cfg.get("recognition", {}).get("vad", {}).get("enabled") is False

--- a/modules/wakeword/tests/test_openwakeword_pretrained.py
+++ b/modules/wakeword/tests/test_openwakeword_pretrained.py
@@ -14,15 +14,18 @@ def test_resolve_pretrained_models_hey_mycroft(tmp_path) -> None:
             "download_url": "https://example/hey_mycroft_v0.1.tflite",
         }
     }
-    mock_utils = MagicMock()
     mock_ow = MagicMock()
     mock_ow.MODELS = fake_models
+    mock_ow.FEATURE_MODELS = {}
+    mock_ow.VAD_MODELS = {}
 
-    with patch.dict(
-        sys.modules,
-        {"openwakeword": mock_ow, "openwakeword.utils": mock_utils},
+    with patch.dict(sys.modules, {"openwakeword": mock_ow}), patch(
+        "modules.wakeword.services.openwakeword_runner._try_utils_download_models",
+        return_value=False,
+    ), patch(
+        "modules.wakeword.services.openwakeword_runner._download_asset_pair",
     ):
-        resolved = _resolve_pretrained_models(["hey_mycroft"], "onnx")
+        resolved, names = _resolve_pretrained_models(["hey_mycroft"], "onnx")
 
-    mock_utils.download_models.assert_called_once_with(model_names=["hey_mycroft"])
+    assert names == ["hey_mycroft"]
     assert resolved["hey_mycroft"] == str(onnx_path.resolve())

--- a/modules/wakeword/tests/test_openwakeword_pretrained.py
+++ b/modules/wakeword/tests/test_openwakeword_pretrained.py
@@ -12,19 +12,22 @@ def test_openwakeword_catalog_fallback_when_package_empty() -> None:
     mock_ow = MagicMock()
     mock_ow.MODELS = {}
     with patch.dict(sys.modules, {"openwakeword": mock_ow}):
-        catalog = _openwakeword_catalog()
+        catalog = _openwakeword_catalog(use_onnx=True)
     assert "hey_mycroft" in catalog
     assert catalog["hey_mycroft"]["download_url"] == BUILTIN_WAKE_MODELS["hey_mycroft"]["download_url"]
+    assert catalog["hey_mycroft"]["download_url"].endswith(".onnx")
 
 
 def test_resolve_pretrained_models_hey_mycroft(tmp_path) -> None:
     onnx_path = tmp_path / "hey_mycroft_v0.1.onnx"
-    onnx_path.write_bytes(b"model")
+    onnx_path.write_bytes(b"x" * 2048)
+    tflite_path = tmp_path / "hey_mycroft_v0.1.tflite"
+    tflite_path.write_bytes(b"y" * 2048)
 
     fake_models = {
         "hey_mycroft": {
-            "model_path": str(tmp_path / "hey_mycroft_v0.1.tflite"),
-            "download_url": "https://example/hey_mycroft_v0.1.tflite",
+            "model_path": str(tflite_path),
+            "download_url": "https://example/hey_mycroft_v0.1.onnx",
         }
     }
     mock_ow = MagicMock()
@@ -36,7 +39,13 @@ def test_resolve_pretrained_models_hey_mycroft(tmp_path) -> None:
         "modules.wakeword.services.openwakeword_runner._try_utils_download_models",
         return_value=False,
     ), patch(
-        "modules.wakeword.services.openwakeword_runner._download_asset_pair",
+        "modules.wakeword.services.openwakeword_runner._openwakeword_models_dir",
+        return_value=tmp_path,
+    ), patch(
+        "modules.wakeword.services.openwakeword_runner._module_models_dir",
+        return_value=tmp_path,
+    ), patch(
+        "modules.wakeword.services.openwakeword_runner._download_framework_asset",
     ):
         resolved, names = _resolve_pretrained_models(["hey_mycroft"], "onnx")
 

--- a/modules/wakeword/tests/test_openwakeword_pretrained.py
+++ b/modules/wakeword/tests/test_openwakeword_pretrained.py
@@ -1,7 +1,20 @@
 import sys
 from unittest.mock import MagicMock, patch
 
-from modules.wakeword.services.openwakeword_runner import _resolve_pretrained_models
+from modules.wakeword.services.openwakeword_runner import (
+    BUILTIN_WAKE_MODELS,
+    _openwakeword_catalog,
+    _resolve_pretrained_models,
+)
+
+
+def test_openwakeword_catalog_fallback_when_package_empty() -> None:
+    mock_ow = MagicMock()
+    mock_ow.MODELS = {}
+    with patch.dict(sys.modules, {"openwakeword": mock_ow}):
+        catalog = _openwakeword_catalog()
+    assert "hey_mycroft" in catalog
+    assert catalog["hey_mycroft"]["download_url"] == BUILTIN_WAKE_MODELS["hey_mycroft"]["download_url"]
 
 
 def test_resolve_pretrained_models_hey_mycroft(tmp_path) -> None:

--- a/modules/wakeword/tests/test_openwakeword_pretrained.py
+++ b/modules/wakeword/tests/test_openwakeword_pretrained.py
@@ -1,0 +1,28 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+from modules.wakeword.services.openwakeword_runner import _resolve_pretrained_models
+
+
+def test_resolve_pretrained_models_hey_mycroft(tmp_path) -> None:
+    onnx_path = tmp_path / "hey_mycroft_v0.1.onnx"
+    onnx_path.write_bytes(b"model")
+
+    fake_models = {
+        "hey_mycroft": {
+            "model_path": str(tmp_path / "hey_mycroft_v0.1.tflite"),
+            "download_url": "https://example/hey_mycroft_v0.1.tflite",
+        }
+    }
+    mock_utils = MagicMock()
+    mock_ow = MagicMock()
+    mock_ow.MODELS = fake_models
+
+    with patch.dict(
+        sys.modules,
+        {"openwakeword": mock_ow, "openwakeword.utils": mock_utils},
+    ):
+        resolved = _resolve_pretrained_models(["hey_mycroft"], "onnx")
+
+    mock_utils.download_models.assert_called_once_with(model_names=["hey_mycroft"])
+    assert resolved["hey_mycroft"] == str(onnx_path.resolve())

--- a/modules/wakeword/xWakewordService.py
+++ b/modules/wakeword/xWakewordService.py
@@ -97,6 +97,7 @@ class WakewordActions:
         self.speech_stop_url = str(cfg.get("speech_stop_url", ""))
         self.speech_last_url = str(cfg.get("speech_last_url", ""))
         self.interactions_event_url = str(cfg.get("interactions_event_url", ""))
+        self.neopixel_url = str(cfg.get("neopixel_url", ""))
         self.listen_window_sec = float(cfg.get("listen_window_sec", 8.0))
         self.min_listen_before_final_sec = float(cfg.get("min_listen_before_final_sec", 1.5))
         self.min_listen_before_final_sec_vad = float(
@@ -143,6 +144,24 @@ class WakewordActions:
         if _is_wakeword_only(text, wakeword):
             return False
         return True
+
+    def _neopixel_post(self, endpoint: str, payload: dict | None = None) -> None:
+        """POST to neopixel API endpoint."""
+        if not self.neopixel_url or requests is None:
+            return
+        try:
+            url = f"{self.neopixel_url.rstrip('/')}/{endpoint.lstrip('/')}"
+            requests.post(url, json=payload or {}, timeout=0.2)
+        except Exception as exc:
+            logger.debug("neopixel http post failed: %s", exc)
+
+    def neopixel_set_mode(self, mode: str) -> None:
+        """Set neopixel companion mode."""
+        self._neopixel_post("companion/mode", {"mode": mode})
+
+    def neopixel_set_vu_level(self, level: float) -> None:
+        """Set VU meter level (0.0 - 1.0)."""
+        self._neopixel_post("companion/vu", {"level": max(0.0, min(1.0, float(level)))})
 
 
 class WakewordService:
@@ -286,6 +305,8 @@ class WakewordService:
             self._last_trigger_ts = now
             self._active_window = True
         self.actions.interrupt_robot_speech()
+        # Trigger wake_chase mode on NeoPixel
+        self.actions.neopixel_set_mode("wake_chase")
         logger.info("wakeword candidate: %s at %f (barge-in)", wakeword, now)
         threading.Thread(target=self._command_window, args=(wakeword,), daemon=True).start()
 
@@ -303,7 +324,13 @@ class WakewordService:
                 else self.actions.min_listen_before_final_sec
             )
             grace_until = window_started_ts + max(0.0, min_listen)
+            
+            # During listening window, feed VU level from audio capture
             while _now() < deadline:
+                # Get audio level from shared capture
+                rms_level = self.capture.get_rms_level()
+                self.actions.neopixel_set_vu_level(rms_level)
+                
                 if (
                     _now() >= grace_until
                     and self.actions.stop_on_final
@@ -312,6 +339,8 @@ class WakewordService:
                     break
                 time.sleep(max(0.05, self.actions.poll_interval_ms / 1000.0))
             self.actions.stop_speech()
+            # Return to eye mode after listening window
+            self.actions.neopixel_set_mode("eye")
         finally:
             with self._lock:
                 self._active_window = False

--- a/modules/wakeword/xWakewordService.py
+++ b/modules/wakeword/xWakewordService.py
@@ -199,6 +199,11 @@ class WakewordService:
                 self._degraded_reason = self._degraded_reason or "no wakeword engine available"
                 return
             stream = self.capture.stream()
+            logger.info(
+                "wakeword listening started (engine=%s device=%s)",
+                self.engine,
+                getattr(self.capture.cfg, "device", None),
+            )
             logger.debug("wakeword listening using engine=%s; capture cfg=%s", self.engine, getattr(self.capture, 'cfg', None))
             if self.engine == "openwakeword" and self._openwakeword is not None:
                 for label in self._openwakeword.run(stream):


### PR DESCRIPTION
## Özet
`dev` dalındaki companion runtime yükseltmesini `main`'e taşır. Sesli etkileşimde robotun dinlediğini ve düşündüğünü görsel olarak göstermek için NeoPixel companion modları, wakeword sırasında LED geri bildirimi, çok dilli STT/TTS ve agent_core streaming + native tool yolu eklenir. Autonomy tarafında appraisal/needs modeli, companion satırları ve proaktif planlayıcı güçlendirilir; wakeword openWakeWord/ONNX ve ALSA düzeltmeleri içerir.

## Değişiklik tipi
- [ ] Hata düzeltmesi
- [x] Yeni özellik
- [x] Refactor
- [ ] Dokümantasyon güncellemesi
- [x] Test güncellemesi

## Etkilenen modüller
- `modules/agent_core` — streaming chat, voice-native tool loop, progress i18n, tri-layer unicode
- `modules/autonomy` — appraisal triggers, needs model, companion lines, proactive planner
- `modules/neopixel` — companion VU-meter, jewel thinking/eye, wake_chase, VU gradient
- `modules/speech` — multilingual STT, AudioCapture RMS, ALSA capture fixes
- `modules/wakeword` — openWakeWord pretrained, ONNX, NeoPixel wake/VU feedback
- `modules/vlm_bridge` — local FER service, vision companion events
- `modules/ollama`, `modules/speak`, `modules/interactions`, `modules/gateway`
- `config/agent.yaml`, `.sentrybot/context/companion-upgrade-plan.md`
- `tools/graph-ui` — layout3d.c uyumlu graph export

## Doğrulama
- [ ] Lokal çalıştırma tamamlandı (`python run_robot.py` veya hedef modül çalıştırma)
- [ ] İlgili testler geçiyor
- [x] Gerekli doküman/konfig güncellemeleri yapıldı

## Arduino Kontrat Kontrolü (uygunsa)
- [x] `modules/arduino_serial/contract.py` dışında elle Arduino payload yazılmadı
- [x] Kritik komutlar gerektiğinde `/arduino/request` kullanıyor
- [x] Yeni komut ailesi builder + validator + test içeriyor (bu PR Arduino komutu eklemez)

## Risk ve geri alma
- NeoPixel/wakeword HTTP çağrıları gateway üzerinden yapılır; neopixel modülü kapalıysa sessizce atlanır (düşük risk).
- Companion ve agent_core değişiklikleri geniş kapsamlıdır; sorun halinde `dev` revert veya `main` üzerinde ilgili modül config ile kapatılabilir (`companion`, wakeword LED feedback).
- Wakeword/ALSA değişiklikleri donanıma bağlıdır; Pi dışı ortamda smoke testler mock ile geçer.

## İlgili issue
Companion upgrade handoff: `.sentrybot/context/companion-upgrade-plan.md`