### PR TITLE
feat(vision): VLM inference budgets and camera status truth

### DIFF
--- a/modules/camera/api/router.py
+++ b/modules/camera/api/router.py
@@ -1,16 +1,48 @@
 from __future__ import annotations
 
+import time
+from typing import Any, Optional
+
 from fastapi import APIRouter, Response
 from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, Field
 
-try:
-    from ..services.capture import CameraCapture
-except Exception:  # fallback when run as script
-    from services.capture import CameraCapture  # type: ignore
+from ..services.capture import CameraCapture
 
 
-def get_router(capture: CameraCapture, fps: int, *, enabled: bool = True) -> APIRouter:
+class TrackingSelection(BaseModel):
+    label: str = Field(default="person", min_length=1, max_length=80)
+    strategy: str = Field(default="largest", min_length=1, max_length=20)
+    track_id: Optional[int] = Field(default=None, ge=1)
+
+
+def get_router(
+    capture: CameraCapture,
+    fps: int,
+    *,
+    enabled: bool = True,
+    imx500_runner: Optional[Any] = None,
+    onsensor_bus: Optional[Any] = None,
+) -> APIRouter:
     router = APIRouter()
+
+    def runner_status() -> dict[str, Any]:
+        if imx500_runner is None:
+            return {"enabled": False, "available": False, "running": False, "reason": "not_configured"}
+        try:
+            return dict(imx500_runner.status())
+        except Exception as exc:
+            return {"enabled": True, "available": False, "running": False, "reason": "status_error", "error": str(exc)}
+
+    def bus_status() -> dict[str, Any]:
+        if onsensor_bus is None:
+            return {"attached": False, "has_latest": False, "published_count": 0}
+        stats = dict(onsensor_bus.stats()) if hasattr(onsensor_bus, "stats") else {}
+        latest = onsensor_bus.latest() if hasattr(onsensor_bus, "latest") else None
+        latest_age = None
+        if latest is not None:
+            latest_age = max(0.0, time.time() - float(getattr(latest, "ts", 0.0)))
+        return {**stats, "attached": True, "has_latest": latest is not None, "latest_age_s": latest_age}
 
     @router.get("/video")
     async def video_stream():
@@ -33,21 +65,78 @@ def get_router(capture: CameraCapture, fps: int, *, enabled: bool = True) -> API
 
     @router.get("/healthz")
     async def healthz():
-        if not enabled:
-            return {"ok": False, "gave_up": False, "enabled": False, "reason": "camera_disabled"}
-        data = await capture.snapshot()
-        return {"ok": bool(data), "gave_up": capture.gave_up, "enabled": True}
+        status = capture.status()
+        healthy = bool(enabled and status.get("running") and status.get("has_frame") and not status.get("gave_up"))
+        return {
+            "ok": healthy,
+            "enabled": bool(enabled),
+            "capture": status,
+            "imx500": runner_status(),
+        }
+
+    @router.get("/status")
+    async def status():
+        capture_status = capture.status()
+        imx_status = runner_status()
+        return {
+            "ok": bool(enabled and capture_status.get("running") and capture_status.get("has_frame")),
+            "enabled": bool(enabled),
+            "capture": capture_status,
+            "imx500": imx_status,
+            "onsensor": bus_status(),
+        }
+
+    @router.get("/onsensor/latest")
+    async def onsensor_latest():
+        if onsensor_bus is None:
+            return {"ok": False, "reason": "onsensor_bus_unavailable"}
+        latest = onsensor_bus.latest()
+        payload = latest.to_dict() if latest is not None and hasattr(latest, "to_dict") else latest
+        return {"ok": latest is not None, "snapshot": payload, "stats": bus_status()}
+
+    @router.get("/tracking/tracks")
+    async def tracking_tracks():
+        if imx500_runner is None:
+            return JSONResponse(status_code=503, content={"ok": False, "reason": "imx500_unavailable"})
+        return imx500_runner.tracks()
+
+    @router.get("/tracking/target")
+    async def tracking_target():
+        if imx500_runner is None:
+            return JSONResponse(status_code=503, content={"ok": False, "reason": "imx500_unavailable"})
+        return imx500_runner.target()
+
+    @router.post("/tracking/select")
+    async def tracking_select(selection: TrackingSelection):
+        if imx500_runner is None:
+            return JSONResponse(status_code=503, content={"ok": False, "reason": "imx500_unavailable"})
+        strategy = selection.strategy.strip().lower()
+        if strategy not in {"largest", "center", "confidence"}:
+            return JSONResponse(status_code=422, content={"ok": False, "reason": "invalid_strategy"})
+        return imx500_runner.select_target(
+            label=selection.label,
+            strategy=strategy,
+            track_id=selection.track_id,
+        )
 
     @router.post("/start")
     async def start_camera():
         if not enabled:
             return JSONResponse(status_code=503, content={"ok": False, "reason": "camera_disabled"})
         capture.start()
-        return {"ok": True}
+        if imx500_runner is not None:
+            imx500_runner.attach_camera(capture.picam, capture)
+            imx500_runner.start()
+        return {"ok": True, "capture": capture.status(), "imx500": runner_status()}
 
     @router.post("/stop")
     async def stop_camera():
+        if imx500_runner is not None:
+            imx500_runner.stop()
         capture.stop()
         return {"ok": True}
 
     return router
+
+
+__all__ = ["get_router"]

--- a/modules/camera/config/config.yml
+++ b/modules/camera/config/config.yml
@@ -1,32 +1,33 @@
-# Camera module configuration (defaults)
-enabled: false          # set true when hardware is attached
-backend: auto           # auto | picamera2 | opencv | gstreamer
-source: 0               # device index or RTSP/HTTP URL for OpenCV
+enabled: true
+backend: picamera2
 resolution:
   width: 1280
   height: 720
-fps_target: 30          # target send fps for MJPEG stream
-jpeg_quality: 80        # 1-100
-flip: none             # none | h | v | hv | 90 | 180 | 270
-opencv:
-  fourcc: MJPG          # MJPG preferred on Windows webcams
-  buffer_size: 1        # minimize latency
-  max_open_attempts: 5  # stop retrying when no camera attached
-  retry_interval_s: 1.0
+fps_target: 30
+jpeg_quality: 80
+flip: none
 picamera2:
   size:
-    width: 1536
-    height: 864
+    width: 1280
+    height: 720
   format: RGB888
-  frame_rate: 120
-  af_mode: 2
+  frame_rate: 30
 imx500:
-  enabled: false
+  enabled: true
   model_path: "/usr/share/imx500-models/imx500_network_ssd_mobilenetv2_fpnlite_320x320_pp.rpk"
-  labels_path: "/usr/share/imx500-models/coco_labels.txt"
-  confidence: 0.45
-  publish_metadata: true
+  labels_path: ""
+  confidence: 0.50
+  iou: 0.65
+  max_detections: 20
   publish_interval_s: 0.05
+  inference_rate: 30
+  preserve_aspect_ratio: true
+  tracker:
+    iou_threshold: 0.30
+    max_missed: 8
+  target:
+    label: person
+    strategy: largest
   classes_of_interest:
     - person
     - cat

--- a/modules/camera/services/capture.py
+++ b/modules/camera/services/capture.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import asyncio
 import logging
 import os
@@ -6,67 +7,77 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 try:
-    import cv2
-except Exception as e:
-    cv2 = None  # OpenCV not available (or missing libGL etc.)
+    import cv2  # type: ignore
+except Exception as exc:
+    cv2 = None  # type: ignore
+    CV2_IMPORT_ERROR: Optional[str] = repr(exc)
+else:
+    CV2_IMPORT_ERROR = None
 
 PICAM_AVAILABLE = False
 PICAM_IMPORT_ERROR: Optional[str] = None
 
 try:
     from picamera2 import Picamera2  # type: ignore
+
     PICAM_AVAILABLE = True
 except Exception as exc:
     PICAM_IMPORT_ERROR = repr(exc)
-    # Some virtualenv setups on Raspberry Pi miss system dist-packages in sys.path.
-    for p in ("/usr/lib/python3/dist-packages", "/usr/local/lib/python3/dist-packages"):
-        if os.path.isdir(p) and p not in sys.path:
-            sys.path.append(p)
+    for path in ("/usr/lib/python3/dist-packages", "/usr/local/lib/python3/dist-packages"):
+        if os.path.isdir(path) and path not in sys.path:
+            sys.path.append(path)
     try:
         from picamera2 import Picamera2  # type: ignore
+
         PICAM_AVAILABLE = True
         PICAM_IMPORT_ERROR = None
-    except Exception as exc2:
-        PICAM_AVAILABLE = False
-        PICAM_IMPORT_ERROR = repr(exc2)
+    except Exception as second_exc:
+        Picamera2 = None  # type: ignore
+        PICAM_IMPORT_ERROR = repr(second_exc)
 
+from modules.common.runtime_target import assert_raspberry_pi
 
 logger = logging.getLogger("camera.capture")
+MetadataListener = Callable[[Dict[str, Any]], None]
 
 
 @dataclass
 class CaptureConfig:
-    backend: str  # auto|picamera2|opencv
-    source: object  # int index or str URL
-    resolution: Tuple[int, int]
-    fps_target: int
-    jpeg_quality: int
-    opencv_fourcc: str
-    opencv_buffer_size: int
-    picam_size: Tuple[int, int]
-    picam_format: str
-    picam_frame_rate: int
-    picam_af_mode: int
-    flip: str
-    opencv_max_open_attempts: int = 5
-    opencv_retry_interval_s: float = 1.0
+    size: Tuple[int, int] = (1280, 720)
+    pixel_format: str = "RGB888"
+    frame_rate: int = 30
+    jpeg_quality: int = 80
+    flip: str = "none"
+    camera_num: int = 0
 
 
 class FramePublisher:
     def __init__(self) -> None:
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._frame_bytes: Optional[bytes] = None
+        self._frame_ts = 0.0
+        self._frame_count = 0
 
     def set_jpeg(self, jpeg_bytes: bytes) -> None:
         with self._lock:
             self._frame_bytes = jpeg_bytes
+            self._frame_ts = time.time()
+            self._frame_count += 1
 
     def get_jpeg(self) -> Optional[bytes]:
         with self._lock:
             return self._frame_bytes
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "has_frame": self._frame_bytes is not None,
+                "frame_count": self._frame_count,
+                "last_frame_age_s": max(0.0, time.time() - self._frame_ts) if self._frame_ts else None,
+            }
 
 
 class CameraCapture:
@@ -75,298 +86,167 @@ class CameraCapture:
         self.pub = publisher
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
-        self._cap: Optional[Any] = None
-        self._picam: Optional["Picamera2"] = None
-        self._gave_up = False
+        self._picam: Optional[Any] = None
+        self._listeners_lock = threading.RLock()
+        self._metadata_listeners: List[MetadataListener] = []
+        self._last_error = ""
+
+    @property
+    def picam(self) -> Optional[Any]:
+        return self._picam
+
+    @property
+    def running(self) -> bool:
+        return bool(self._thread is not None and self._thread.is_alive())
 
     @property
     def gave_up(self) -> bool:
-        return self._gave_up
+        return bool(self._last_error and not self.running)
 
-    def _opencv_api_candidates(self, src: object) -> list[Optional[int]]:
-        if cv2 is None or not isinstance(src, int):
-            return [None]
+    def subscribe_metadata(self, listener: MetadataListener) -> Callable[[], None]:
+        with self._listeners_lock:
+            self._metadata_listeners.append(listener)
 
-        # CAP_DSHOW is Windows-only; on Linux/RPi prefer V4L2/CAP_ANY.
-        if os.name == "nt":
-            return [getattr(cv2, "CAP_DSHOW", None), getattr(cv2, "CAP_ANY", None), None]
-        return [getattr(cv2, "CAP_V4L2", None), getattr(cv2, "CAP_ANY", None), None]
+        def unsubscribe() -> None:
+            with self._listeners_lock:
+                if listener in self._metadata_listeners:
+                    self._metadata_listeners.remove(listener)
 
-    def _opencv_source_candidates(self, src: object) -> list[Tuple[object, Optional[int]]]:
-        candidates: list[Tuple[object, Optional[int]]] = [(src, None)]
+        return unsubscribe
+
+    def start(self) -> bool:
+        if self.running:
+            return True
+        assert_raspberry_pi()
+        if not PICAM_AVAILABLE or Picamera2 is None:
+            raise RuntimeError(f"Picamera2 unavailable: {PICAM_IMPORT_ERROR}")
         if cv2 is None:
-            return candidates
+            raise RuntimeError(f"OpenCV JPEG encoder unavailable: {CV2_IMPORT_ERROR}")
 
-        if isinstance(src, int) and os.name != "nt":
-            # Prefer explicit V4L2 device path as secondary candidate on Linux.
-            candidates.append((f"/dev/video{src}", None))
-
-            # Last resort: libcamera GStreamer pipeline (when OpenCV has GStreamer support).
-            gst_api = getattr(cv2, "CAP_GSTREAMER", None)
-            if gst_api is not None:
-                w, h = self.cfg.resolution
-                fps = max(5, min(60, int(self.cfg.fps_target or 30)))
-                gst_pipeline = (
-                    f"libcamerasrc ! video/x-raw,width={w},height={h},framerate={fps}/1 ! "
-                    "videoconvert ! appsink drop=true sync=false"
-                )
-                candidates.append((gst_pipeline, gst_api))
-
-        return candidates
-
-    def _configure_opencv_capture(self, cap: Any) -> None:
-        w, h = self.cfg.resolution
-        cap.set(cv2.CAP_PROP_FRAME_WIDTH, w)
-        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, h)
-        cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter.fourcc(*self.cfg.opencv_fourcc))
-        cap.set(cv2.CAP_PROP_BUFFERSIZE, self.cfg.opencv_buffer_size)
-
-    def _open_opencv_capture(self, src: object) -> Tuple[Optional[Any], str]:
-        if cv2 is None:
-            return None, "cv2-unavailable"
-
-        for candidate_src, forced_api in self._opencv_source_candidates(src):
-            api_candidates = [forced_api] if forced_api is not None else self._opencv_api_candidates(candidate_src)
-            for api in api_candidates:
-                try:
-                    cap = cv2.VideoCapture(candidate_src) if api is None else cv2.VideoCapture(candidate_src, api)
-                except Exception:
-                    continue
-
-                if cap is None or not cap.isOpened():
-                    if cap is not None:
-                        try:
-                            cap.release()
-                        except Exception:
-                            pass
-                    continue
-
-                self._configure_opencv_capture(cap)
-
-                # Some backends report opened but never deliver frames; validate quickly.
-                ok = False
-                frame = None
-                for _ in range(3):
-                    ok, frame = cap.read()
-                    if ok and frame is not None:
-                        break
-                    time.sleep(0.05)
-
-                if ok and frame is not None:
-                    api_name = "default" if api is None else str(api)
-                    return cap, f"{api_name}|src={candidate_src!r}"
-
-                try:
-                    cap.release()
-                except Exception:
-                    pass
-
-        return None, "none"
-
-    def _start_opencv(self) -> None:
-        if cv2 is None:
-            raise RuntimeError("OpenCV (cv2) not available: check libGL (libGL.so.1) and opencv-python installation")
-        src = self.cfg.source if isinstance(self.cfg.source, (int, str)) else 0
-        cap, api_name = self._open_opencv_capture(src)
-        self._cap = cap
-
-        def _apply_flip(img):
-            f = (self.cfg.flip or "none").strip().lower()
-            if not f or f == "none":
-                return img
-            if f in ("h", "horizontal"):
-                return cv2.flip(img, 1)
-            if f in ("v", "vertical"):
-                return cv2.flip(img, 0)
-            if f in ("hv", "both", "180", "rotate180", "r180"):
-                return cv2.flip(img, -1)
-            if f in ("90", "rotate90", "r90"):
-                return cv2.rotate(img, cv2.ROTATE_90_CLOCKWISE)
-            if f in ("270", "rotate270", "r270"):
-                return cv2.rotate(img, cv2.ROTATE_90_COUNTERCLOCKWISE)
-            try:
-                deg = int(f)
-                d = deg % 360
-                if d == 90:
-                    return cv2.rotate(img, cv2.ROTATE_90_CLOCKWISE)
-                if d == 180:
-                    return cv2.flip(img, -1)
-                if d == 270:
-                    return cv2.rotate(img, cv2.ROTATE_90_COUNTERCLOCKWISE)
-            except Exception:
-                pass
-            return img
-
-        def loop() -> None:
-            q = self.cfg.jpeg_quality
-            open_fail_count = 0
-            max_attempts = max(1, int(self.cfg.opencv_max_open_attempts))
-            retry_s = max(0.2, float(self.cfg.opencv_retry_interval_s))
-            nonlocal cap, api_name
-            while not self._stop.is_set():
-                if cap is None or not cap.isOpened():
-                    cap, api_name = self._open_opencv_capture(src)
-                    self._cap = cap
-                    if cap is None:
-                        open_fail_count += 1
-                        if open_fail_count >= max_attempts:
-                            if not self._gave_up:
-                                self._gave_up = True
-                                logger.warning(
-                                    "OpenCV camera unavailable after %d attempts (source=%r); stopping retries",
-                                    max_attempts,
-                                    src,
-                                )
-                            break
-                        if open_fail_count == 1 or open_fail_count == max_attempts:
-                            logger.warning(
-                                "OpenCV camera source not ready: source=%r attempt=%d/%d",
-                                src,
-                                open_fail_count,
-                                max_attempts,
-                            )
-                        time.sleep(retry_s)
-                        continue
-
-                    open_fail_count = 0
-                    logger.info("OpenCV camera connected: source=%r api=%s", src, api_name)
-
-                ok, frame = cap.read()
-                if not ok:
-                    logger.warning("OpenCV camera read failed, reconnecting source=%r", src)
-                    try:
-                        cap.release()
-                    except Exception:
-                        pass
-                    cap = None
-                    self._cap = None
-                    time.sleep(0.4)
-                    continue
-                frame = _apply_flip(frame)
-                ok2, buf = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, q])
-                if ok2:
-                    self.pub.set_jpeg(buf.tobytes())
-        self._thread = threading.Thread(target=loop, daemon=True)
-        self._thread.start()
-
-    def _start_picam(self) -> None:
-        if not PICAM_AVAILABLE:
-            raise RuntimeError("Picamera2 not available")
-        if cv2 is None:
-            raise RuntimeError("OpenCV (cv2) is required for JPEG encoding with picamera2 backend")
-        cam = Picamera2()
-        try:
-            w, h = self.cfg.picam_size
-            cam.configure(cam.create_video_configuration(
-                main={"size": (w, h), "format": self.cfg.picam_format},
-                controls={"AfMode": self.cfg.picam_af_mode, "FrameRate": self.cfg.picam_frame_rate}
-            ))
-            cam.start()
-        except Exception:
-            try:
-                cam.close()
-            except Exception:
-                pass
-            raise
-        self._picam = cam
-
-        def _apply_flip(img):
-            f = (self.cfg.flip or "none").strip().lower()
-            if not f or f == "none":
-                return img
-            if f in ("h", "horizontal"):
-                return cv2.flip(img, 1)
-            if f in ("v", "vertical"):
-                return cv2.flip(img, 0)
-            if f in ("hv", "both", "180", "rotate180", "r180"):
-                return cv2.flip(img, -1)
-            if f in ("90", "rotate90", "r90"):
-                return cv2.rotate(img, cv2.ROTATE_90_CLOCKWISE)
-            if f in ("270", "rotate270", "r270"):
-                return cv2.rotate(img, cv2.ROTATE_90_COUNTERCLOCKWISE)
-            try:
-                deg = int(f)
-                d = deg % 360
-                if d == 90:
-                    return cv2.rotate(img, cv2.ROTATE_90_CLOCKWISE)
-                if d == 180:
-                    return cv2.flip(img, -1)
-                if d == 270:
-                    return cv2.rotate(img, cv2.ROTATE_90_COUNTERCLOCKWISE)
-            except Exception:
-                pass
-            return img
-
-        def loop() -> None:
-            q = self.cfg.jpeg_quality
-            err_count = 0
-            while not self._stop.is_set():
-                try:
-                    rgb = cam.capture_array("main")
-                    rgb = _apply_flip(rgb)
-                    ok, buf = cv2.imencode('.jpg', rgb, [cv2.IMWRITE_JPEG_QUALITY, q])
-                    if ok:
-                        self.pub.set_jpeg(buf.tobytes())
-                    err_count = 0
-                except Exception as exc:
-                    err_count += 1
-                    if err_count == 1 or (err_count % 20) == 0:
-                        logger.warning("Picamera2 frame capture failed (count=%d): %s", err_count, exc)
-                    time.sleep(0.2)
-        self._thread = threading.Thread(target=loop, daemon=True)
-        self._thread.start()
-
-    def start(self) -> None:
+        camera = Picamera2(int(self.cfg.camera_num))
+        controls = {"FrameRate": float(max(1, self.cfg.frame_rate))}
+        configuration = camera.create_video_configuration(
+            main={"size": tuple(self.cfg.size), "format": str(self.cfg.pixel_format)},
+            controls=controls,
+            buffer_count=6,
+            queue=True,
+        )
+        camera.configure(configuration)
+        camera.start()
+        self._picam = camera
         self._stop.clear()
-        backend = self.cfg.backend
-        if backend == "auto":
-            backend = "picamera2" if PICAM_AVAILABLE else "opencv"
-        if backend == "opencv" and os.name != "nt" and isinstance(self.cfg.source, int) and not PICAM_AVAILABLE:
-            logger.warning(
-                "picamera2 unavailable (error=%s). CSI camera with OpenCV source=%r may fail to deliver frames.",
-                PICAM_IMPORT_ERROR,
-                self.cfg.source,
-            )
-        logger.info("CameraCapture starting backend=%s source=%r picam_available=%s", backend, self.cfg.source, PICAM_AVAILABLE)
-        if backend == "picamera2":
-            try:
-                self._start_picam()
-                return
-            except Exception as exc:
-                logger.warning(
-                    "picamera2 start failed (%s); falling back to opencv source=%r",
-                    exc,
-                    self.cfg.source,
-                )
-        self._start_opencv()
+        self._last_error = ""
+        self._thread = threading.Thread(target=self._capture_loop, name="picamera2-capture", daemon=True)
+        self._thread.start()
+        return True
 
     def stop(self) -> None:
         self._stop.set()
         if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=1)
-        if self._cap is not None:
+            self._thread.join(timeout=2.0)
+        self._thread = None
+        camera = self._picam
+        self._picam = None
+        if camera is not None:
             try:
-                self._cap.release()
+                camera.stop()
             except Exception:
                 pass
-        if self._picam is not None:
             try:
-                self._picam.stop()
-                self._picam.close()
+                camera.close()
             except Exception:
                 pass
+
+    def status(self) -> Dict[str, Any]:
+        return {
+            "backend": "picamera2",
+            "camera_num": int(self.cfg.camera_num),
+            "size": {"width": int(self.cfg.size[0]), "height": int(self.cfg.size[1])},
+            "pixel_format": str(self.cfg.pixel_format),
+            "frame_rate": int(self.cfg.frame_rate),
+            "jpeg_quality": int(self.cfg.jpeg_quality),
+            "running": self.running,
+            "gave_up": self.gave_up,
+            "picamera2_available": bool(PICAM_AVAILABLE),
+            "picamera2_import_error": PICAM_IMPORT_ERROR,
+            "opencv_available": cv2 is not None,
+            "opencv_import_error": CV2_IMPORT_ERROR,
+            "last_error": self._last_error,
+            **self.pub.status(),
+        }
+
+    def _capture_loop(self) -> None:
+        assert self._picam is not None
+        while not self._stop.is_set():
+            request = None
+            try:
+                request = self._picam.capture_request()
+                metadata = dict(request.get_metadata() or {})
+                frame = request.make_array("main")
+                self._notify_metadata(metadata)
+                frame = self._prepare_frame(frame)
+                ok, encoded = cv2.imencode(
+                    ".jpg",
+                    frame,
+                    [int(cv2.IMWRITE_JPEG_QUALITY), int(max(1, min(100, self.cfg.jpeg_quality)))],
+                )
+                if ok:
+                    self.pub.set_jpeg(encoded.tobytes())
+                    self._last_error = ""
+            except Exception as exc:
+                self._last_error = str(exc)
+                logger.warning("Picamera2 capture failed: %s", exc)
+                time.sleep(0.1)
+            finally:
+                if request is not None:
+                    try:
+                        request.release()
+                    except Exception:
+                        pass
+
+    def _prepare_frame(self, frame: Any) -> Any:
+        pixel_format = str(self.cfg.pixel_format).upper()
+        if pixel_format.startswith("RGB") and cv2 is not None:
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        flip = str(self.cfg.flip or "none").strip().lower()
+        if flip in {"h", "horizontal"}:
+            return cv2.flip(frame, 1)
+        if flip in {"v", "vertical"}:
+            return cv2.flip(frame, 0)
+        if flip in {"hv", "both", "180", "rotate180", "r180"}:
+            return cv2.flip(frame, -1)
+        if flip in {"90", "rotate90", "r90"}:
+            return cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+        if flip in {"270", "rotate270", "r270"}:
+            return cv2.rotate(frame, cv2.ROTATE_90_COUNTERCLOCKWISE)
+        return frame
+
+    def _notify_metadata(self, metadata: Dict[str, Any]) -> None:
+        with self._listeners_lock:
+            listeners = list(self._metadata_listeners)
+        for listener in listeners:
+            try:
+                listener(metadata)
+            except Exception as exc:
+                logger.debug("camera metadata listener failed: %s", exc)
 
     async def mjpeg_generator(self, fps: int):
         boundary = b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
-        next_tick = 0.0
+        interval = 1.0 / max(1, int(fps))
         while True:
-            if next_tick == 0.0:
-                next_tick = asyncio.get_running_loop().time()
-            next_tick += 1 / max(1, fps)
-            await asyncio.sleep(max(0.0, next_tick - asyncio.get_running_loop().time()))
             frame = await asyncio.to_thread(self.pub.get_jpeg)
             if frame:
                 yield boundary + frame + b"\r\n"
+            await asyncio.sleep(interval)
 
     async def snapshot(self) -> Optional[bytes]:
         return await asyncio.to_thread(self.pub.get_jpeg)
+
+
+__all__ = [
+    "CameraCapture",
+    "CaptureConfig",
+    "FramePublisher",
+    "PICAM_AVAILABLE",
+    "PICAM_IMPORT_ERROR",
+]

--- a/modules/camera/services/imx500_runner.py
+++ b/modules/camera/services/imx500_runner.py
@@ -1,17 +1,3 @@
-"""Sony IMX500 (Raspberry Pi AI Camera) on-sensor inference runner.
-
-This module wires the on-sensor SSD MobileNet network (or any user provided
-``.rpk`` model) into the SentryBOT pipeline. The runner stays *inert* when the
-optional ``picamera2`` package or the IMX500 device is not available, so it can
-be safely imported on developer machines without breaking startup.
-
-Whenever the IMX500 emits detections, the runner translates them into
-:class:`OnSensorSnapshot` objects and forwards them through the shared
-:class:`OnSensorEventBus`. The VLM bridge processor subscribes to the bus and
-can therefore replace its Haar face detector with the IMX500 results when the
-backend is active.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -19,221 +5,309 @@ import os
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, Callable, List, Optional, Sequence, Tuple
 
 from .onsensor_bus import OnSensorDetection, OnSensorEventBus, OnSensorSnapshot, get_default_bus
+from .tracking import DetectionTracker
 
 logger = logging.getLogger("camera.imx500_runner")
-
 
 IMX500_AVAILABLE = False
 IMX500_IMPORT_ERROR: Optional[str] = None
 
 try:
-    from picamera2 import Picamera2  # type: ignore  # noqa: F401
-    from picamera2.devices.imx500 import IMX500, NetworkIntrinsics  # type: ignore
+    from picamera2.devices import IMX500  # type: ignore
+    from picamera2.devices.imx500 import NetworkIntrinsics, postprocess_nanodet_detection  # type: ignore
+
     IMX500_AVAILABLE = True
-except Exception as exc:  # pragma: no cover - device specific path
+except Exception as exc:
     IMX500 = None  # type: ignore
     NetworkIntrinsics = None  # type: ignore
+    postprocess_nanodet_detection = None  # type: ignore
     IMX500_IMPORT_ERROR = repr(exc)
 
 
 @dataclass
 class Imx500Config:
-    enabled: bool = False
+    enabled: bool = True
     model_path: str = "/usr/share/imx500-models/imx500_network_ssd_mobilenetv2_fpnlite_320x320_pp.rpk"
-    labels_path: str = "/usr/share/imx500-models/coco_labels.txt"
-    confidence: float = 0.45
-    publish_metadata: bool = True
+    labels_path: str = ""
+    confidence: float = 0.50
+    iou: float = 0.65
+    max_detections: int = 20
     publish_interval_s: float = 0.05
+    inference_rate: Optional[int] = None
+    preserve_aspect_ratio: bool = True
     classes_of_interest: Sequence[str] = ()
+    tracker_iou_threshold: float = 0.30
+    tracker_max_missed: int = 8
+    target_label: str = "person"
+    target_strategy: str = "largest"
 
 
 class Imx500Runner:
-    """Manages the IMX500 inference loop and publishes detections to the bus."""
-
-    def __init__(
-        self,
-        cfg: Imx500Config,
-        bus: Optional[OnSensorEventBus] = None,
-        picam: Optional[Any] = None,
-    ) -> None:
+    def __init__(self, cfg: Imx500Config, bus: Optional[OnSensorEventBus] = None) -> None:
         self.cfg = cfg
         self.bus = bus or get_default_bus()
-        self._picam = picam
+        self.tracker = DetectionTracker(cfg.tracker_iou_threshold, cfg.tracker_max_missed)
+        self.tracker.select(cfg.target_label, cfg.target_strategy)
         self._device: Optional[Any] = None
         self._intrinsics: Optional[Any] = None
-        self._labels: List[str] = []
-        self._stop = threading.Event()
+        self._picam: Optional[Any] = None
+        self._metadata_source: Optional[Any] = None
+        self._unsubscribe: Optional[Callable[[], None]] = None
         self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._running = False
         self._frame_id = 0
         self._last_publish_ts = 0.0
-        self._available = bool(cfg.enabled) and IMX500_AVAILABLE
-
-        if cfg.enabled and not IMX500_AVAILABLE:
-            logger.info(
-                "IMX500 requested but picamera2/IMX500 unavailable (%s); runner stays inert.",
-                IMX500_IMPORT_ERROR,
-            )
-
-    # -- Public lifecycle ------------------------------------------------
+        self._last_error = ""
+        self._lock = threading.RLock()
 
     @property
     def available(self) -> bool:
-        return self._available
+        return bool(self.cfg.enabled and IMX500_AVAILABLE and os.path.exists(self.cfg.model_path))
+
+    @property
+    def running(self) -> bool:
+        return bool(self._running)
+
+    @property
+    def camera_num(self) -> int:
+        if self._device is None:
+            return 0
+        return int(getattr(self._device, "camera_num", 0))
+
+    @property
+    def inference_rate(self) -> Optional[int]:
+        if self.cfg.inference_rate is not None:
+            return int(self.cfg.inference_rate)
+        value = getattr(self._intrinsics, "inference_rate", None)
+        return int(value) if value is not None else None
+
+    def prepare(self) -> bool:
+        if not self.available:
+            return False
+        if self._device is not None:
+            return True
+        if IMX500 is None:
+            return False
+        self._device = IMX500(self.cfg.model_path)
+        self._intrinsics = getattr(self._device, "network_intrinsics", None)
+        if self._intrinsics is None and NetworkIntrinsics is not None:
+            self._intrinsics = NetworkIntrinsics()
+            self._intrinsics.task = "object detection"
+        if self._intrinsics is not None:
+            if str(getattr(self._intrinsics, "task", "object detection")) != "object detection":
+                raise RuntimeError("IMX500 model is not an object detection model")
+            labels = self._load_labels()
+            if labels:
+                self._intrinsics.labels = labels
+            if self.cfg.inference_rate is not None:
+                self._intrinsics.inference_rate = int(self.cfg.inference_rate)
+            if hasattr(self._intrinsics, "preserve_aspect_ratio"):
+                self._intrinsics.preserve_aspect_ratio = bool(self.cfg.preserve_aspect_ratio)
+            if hasattr(self._intrinsics, "update_with_defaults"):
+                self._intrinsics.update_with_defaults()
+        if bool(self.cfg.preserve_aspect_ratio) and hasattr(self._device, "set_auto_aspect_ratio"):
+            self._device.set_auto_aspect_ratio()
+        if hasattr(self._device, "show_network_fw_progress_bar"):
+            self._device.show_network_fw_progress_bar()
+        return True
+
+    def attach_camera(self, picam: Any, metadata_source: Optional[Any] = None) -> None:
+        self._picam = picam
+        self._metadata_source = metadata_source
 
     def start(self) -> bool:
-        """Initialise the device and start the background loop.
-
-        Returns ``True`` when the runner is actually running, ``False`` when it
-        is skipped (disabled or library missing).
-        """
-        if not self._available:
-            return False
-        if self._thread is not None and self._thread.is_alive():
+        if self.running:
             return True
-        try:
-            self._init_device()
-        except Exception as exc:  # pragma: no cover - hardware specific
-            logger.warning("IMX500 init failed (%s); runner disabled.", exc)
-            self._available = False
+        if not self.prepare() or self._picam is None:
             return False
         self._stop.clear()
-        self._thread = threading.Thread(target=self._loop, name="imx500-runner", daemon=True)
+        if self._metadata_source is not None and hasattr(self._metadata_source, "subscribe_metadata"):
+            self._unsubscribe = self._metadata_source.subscribe_metadata(self._on_metadata)
+            self._running = True
+            return True
+        self._thread = threading.Thread(target=self._metadata_loop, name="imx500-inference", daemon=True)
         self._thread.start()
-        logger.info("IMX500 runner started (model=%s).", self.cfg.model_path)
+        self._running = True
         return True
 
     def stop(self) -> None:
         self._stop.set()
+        if self._unsubscribe is not None:
+            try:
+                self._unsubscribe()
+            except Exception:
+                pass
+        self._unsubscribe = None
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=2.0)
         self._thread = None
+        self._running = False
 
-    # -- Internals -------------------------------------------------------
+    def select_target(self, label: str = "person", strategy: str = "largest", track_id: Optional[int] = None) -> dict[str, Any]:
+        return self.tracker.select(label, strategy, track_id)
 
-    def _init_device(self) -> None:
-        if IMX500 is None:  # pragma: no cover
-            raise RuntimeError("IMX500 library not loaded")
-        model_path = self.cfg.model_path
-        if not model_path or not os.path.exists(model_path):
-            raise FileNotFoundError(f"IMX500 model_path not found: {model_path}")
+    def target(self) -> dict[str, Any]:
+        target = self.tracker.target()
+        return {"ok": target is not None, "selection": self.tracker.selection(), "target": target.to_dict() if target else None}
 
-        self._device = IMX500(model_path)
-        try:
-            self._intrinsics = self._device.network_intrinsics
-        except Exception:
-            self._intrinsics = None
+    def tracks(self) -> dict[str, Any]:
+        tracks = self.tracker.tracks()
+        return {"ok": True, "count": len(tracks), "tracks": tracks, "selection": self.tracker.selection()}
 
-        labels_path = self.cfg.labels_path
-        if labels_path and os.path.exists(labels_path):
-            try:
-                with open(labels_path, "r", encoding="utf-8") as fh:
-                    self._labels = [line.strip() for line in fh.readlines() if line.strip()]
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.debug("Failed to read IMX500 labels file: %s", exc)
+    def status(self) -> dict[str, Any]:
+        return {
+            "enabled": bool(self.cfg.enabled),
+            "available": self.available,
+            "running": self.running,
+            "reason": self._status_reason(),
+            "model_path": self.cfg.model_path,
+            "model_exists": os.path.exists(self.cfg.model_path),
+            "confidence": self.cfg.confidence,
+            "inference_rate": self.inference_rate,
+            "camera_num": self.camera_num,
+            "frame_id": self._frame_id,
+            "last_publish_age_s": max(0.0, time.time() - self._last_publish_ts) if self._last_publish_ts else None,
+            "last_error": self._last_error,
+            "import_error": IMX500_IMPORT_ERROR,
+            "tracking": self.target(),
+        }
+
+    def _status_reason(self) -> str:
+        if not self.cfg.enabled:
+            return "disabled"
+        if not IMX500_AVAILABLE:
+            return "library_unavailable"
+        if not os.path.exists(self.cfg.model_path):
+            return "model_missing"
+        if self.running:
+            return "running"
+        if self._picam is None:
+            return "camera_not_attached"
+        return "ready"
+
+    def _load_labels(self) -> List[str]:
+        if self.cfg.labels_path and os.path.exists(self.cfg.labels_path):
+            with open(self.cfg.labels_path, "r", encoding="utf-8") as handle:
+                return [line.strip() for line in handle if line.strip()]
+        labels = getattr(self._intrinsics, "labels", None)
+        return [str(label) for label in labels] if labels else []
 
     def _label_for(self, class_id: int) -> str:
-        if 0 <= class_id < len(self._labels):
-            return self._labels[class_id]
+        labels = getattr(self._intrinsics, "labels", None) or []
+        if bool(getattr(self._intrinsics, "ignore_dash_labels", False)):
+            labels = [label for label in labels if label and label != "-"]
+        if 0 <= class_id < len(labels):
+            return str(labels[class_id])
         return f"class_{class_id}"
 
-    def _should_emit(self, label: str) -> bool:
-        wanted = set(s.strip().lower() for s in self.cfg.classes_of_interest or [])
-        if not wanted:
-            return True
-        return label.strip().lower() in wanted
-
-    def _loop(self) -> None:
-        device = self._device
-        if device is None:
-            return
-        interval = max(0.0, float(self.cfg.publish_interval_s or 0.05))
+    def _metadata_loop(self) -> None:
         while not self._stop.is_set():
             try:
-                snapshot = self._fetch_snapshot()
-            except Exception as exc:
-                logger.debug("IMX500 fetch failed: %s", exc)
-                snapshot = None
-            if snapshot is not None:
-                now = time.time()
-                if (now - self._last_publish_ts) >= interval:
-                    self.bus.publish(snapshot)
-                    self._last_publish_ts = now
-            time.sleep(min(interval, 0.05))
-
-    def _fetch_snapshot(self) -> Optional[OnSensorSnapshot]:
-        device = self._device
-        if device is None:
-            return None
-        metadata = None
-        if self._picam is not None and hasattr(self._picam, "capture_metadata"):
-            try:
                 metadata = self._picam.capture_metadata()
-            except Exception:
-                metadata = None
-        if not metadata:
-            return None
-        outputs = None
+                self._on_metadata(dict(metadata or {}))
+            except Exception as exc:
+                self._last_error = str(exc)
+                logger.debug("IMX500 metadata capture failed: %s", exc)
+            time.sleep(0.01)
+
+    def _on_metadata(self, metadata: dict[str, Any]) -> None:
+        now = time.time()
+        if now - self._last_publish_ts < max(0.01, float(self.cfg.publish_interval_s)):
+            return
         try:
-            outputs = device.get_outputs(metadata)
-        except Exception:
-            outputs = None
+            snapshot = self._parse(metadata)
+            if snapshot is not None:
+                self.bus.publish(snapshot)
+                self._last_publish_ts = now
+                self._last_error = ""
+        except Exception as exc:
+            self._last_error = str(exc)
+            logger.debug("IMX500 inference failed: %s", exc)
+
+    def _parse(self, metadata: dict[str, Any]) -> Optional[OnSensorSnapshot]:
+        if self._device is None:
+            return None
+        outputs = self._device.get_outputs(metadata, add_batch=True)
         if outputs is None:
             return None
+        boxes, scores, classes = self._unpack(outputs)
         detections: List[OnSensorDetection] = []
-        boxes, scores, classes = self._unpack_outputs(outputs)
-        for bbox, score, class_id in zip(boxes, scores, classes):
-            if float(score) < float(self.cfg.confidence):
+        width, height = self._frame_size()
+        wanted = {str(label).strip().lower() for label in self.cfg.classes_of_interest if str(label).strip()}
+        for box, score, class_id in zip(boxes, scores, classes):
+            score_value = float(score)
+            if score_value < float(self.cfg.confidence):
                 continue
             label = self._label_for(int(class_id))
-            if not self._should_emit(label):
+            if wanted and label.lower() not in wanted:
                 continue
-            x1, y1, x2, y2 = [float(v) for v in bbox]
             detections.append(
                 OnSensorDetection(
                     class_id=int(class_id),
                     label=label,
-                    score=float(score),
-                    bbox_xyxy_norm=(x1, y1, x2, y2),
+                    score=score_value,
+                    bbox_xyxy_norm=self._normalise_box(box, metadata, width, height),
                 )
             )
+        tracked = self.tracker.update(detections)
+        target = self.tracker.target()
         self._frame_id += 1
-        width = int(metadata.get("ScalerCrop", [0, 0, 0, 0])[2]) if isinstance(metadata.get("ScalerCrop"), (list, tuple)) else 0
-        height = int(metadata.get("ScalerCrop", [0, 0, 0, 0])[3]) if isinstance(metadata.get("ScalerCrop"), (list, tuple)) else 0
         return OnSensorSnapshot(
             ts=time.time(),
             frame_id=self._frame_id,
             width=width,
             height=height,
-            detections=detections,
+            detections=tracked,
             backend="imx500",
+            target_track_id=target.track_id if target else None,
+            target_label=target.label if target else "",
         )
 
-    def _unpack_outputs(self, outputs: Any) -> Tuple[List[List[float]], List[float], List[int]]:
-        boxes: List[List[float]] = []
-        scores: List[float] = []
-        classes: List[int] = []
+    def _unpack(self, outputs: Any) -> Tuple[Any, Any, Any]:
+        if str(getattr(self._intrinsics, "postprocess", "")) == "nanodet" and postprocess_nanodet_detection is not None:
+            boxes, scores, classes = postprocess_nanodet_detection(
+                outputs=outputs[0],
+                conf=float(self.cfg.confidence),
+                iou_thres=float(self.cfg.iou),
+                max_out_dets=int(self.cfg.max_detections),
+            )[0]
+            try:
+                from picamera2.devices.imx500.postprocess import scale_boxes  # type: ignore
+
+                input_w, input_h = self._device.get_input_size()
+                boxes = scale_boxes(boxes, 1, 1, input_h, input_w, False, False)
+            except Exception:
+                pass
+            return boxes, scores, classes
+        return outputs[0][0], outputs[1][0], outputs[2][0]
+
+    def _normalise_box(self, box: Any, metadata: dict[str, Any], width: int, height: int) -> Tuple[float, float, float, float]:
+        values = [float(value) for value in box]
+        if bool(getattr(self._intrinsics, "bbox_normalization", False)):
+            _, input_h = self._device.get_input_size()
+            values = [value / float(input_h) for value in values]
+        if str(getattr(self._intrinsics, "bbox_order", "yx")) == "xy":
+            values = [values[1], values[0], values[3], values[2]]
+        if hasattr(self._device, "convert_inference_coords") and self._picam is not None:
+            x, y, box_width, box_height = self._device.convert_inference_coords(values, metadata, self._picam)
+            return self._clamp_box((x / width, y / height, (x + box_width) / width, (y + box_height) / height))
+        y1, x1, y2, x2 = values
+        return self._clamp_box((x1, y1, x2, y2))
+
+    def _frame_size(self) -> Tuple[int, int]:
         try:
-            if isinstance(outputs, (list, tuple)) and outputs:
-                first = outputs[0]
-                if isinstance(first, dict):
-                    raw_boxes = first.get("boxes") or first.get("bboxes") or []
-                    raw_scores = first.get("scores") or []
-                    raw_classes = first.get("classes") or first.get("class_ids") or []
-                    boxes = [list(b) for b in raw_boxes]
-                    scores = [float(s) for s in raw_scores]
-                    classes = [int(c) for c in raw_classes]
-                else:
-                    if len(outputs) >= 3:
-                        raw_boxes, raw_scores, raw_classes = outputs[:3]
-                        boxes = [list(b) for b in raw_boxes]
-                        scores = [float(s) for s in raw_scores]
-                        classes = [int(c) for c in raw_classes]
+            size = self._picam.camera_config["main"]["size"]
+            return int(size[0]), int(size[1])
         except Exception:
-            pass
-        return boxes, scores, classes
+            return 1280, 720
+
+    @staticmethod
+    def _clamp_box(box: Tuple[float, float, float, float]) -> Tuple[float, float, float, float]:
+        return tuple(max(0.0, min(1.0, float(value))) for value in box)  # type: ignore[return-value]
 
 
 __all__ = ["Imx500Config", "Imx500Runner", "IMX500_AVAILABLE", "IMX500_IMPORT_ERROR"]

--- a/modules/camera/services/onsensor_bus.py
+++ b/modules/camera/services/onsensor_bus.py
@@ -1,12 +1,3 @@
-"""Thread-safe on-sensor detection event bus.
-
-The IMX500 runner publishes ``OnSensorSnapshot`` instances here and downstream
-subscribers (e.g. the VLM bridge processor) can fetch the latest snapshot or
-register callbacks for push-style consumption. The bus has no dependency on
-``picamera2`` so it can be imported safely on hosts that lack the IMX500
-hardware - the runner itself stays inert in that case.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -20,8 +11,6 @@ logger = logging.getLogger("camera.onsensor_bus")
 
 @dataclass
 class OnSensorDetection:
-    """Single bounding-box detection emitted by the IMX500 sensor."""
-
     class_id: int
     label: str
     score: float
@@ -36,14 +25,14 @@ class OnSensorDetection:
 
 @dataclass
 class OnSensorSnapshot:
-    """A snapshot of detections emitted by the IMX500 backend."""
-
     ts: float = field(default_factory=time.time)
     frame_id: int = 0
     width: int = 0
     height: int = 0
     detections: List[OnSensorDetection] = field(default_factory=list)
     backend: str = "imx500"
+    target_track_id: Optional[int] = None
+    target_label: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -52,7 +41,9 @@ class OnSensorSnapshot:
             "width": self.width,
             "height": self.height,
             "backend": self.backend,
-            "detections": [d.to_dict() for d in self.detections],
+            "target_track_id": self.target_track_id,
+            "target_label": self.target_label,
+            "detections": [detection.to_dict() for detection in self.detections],
         }
 
 
@@ -60,8 +51,6 @@ SubscriberFn = Callable[[OnSensorSnapshot], None]
 
 
 class OnSensorEventBus:
-    """Tiny publish/subscribe broker that retains the latest snapshot."""
-
     def __init__(self, history_size: int = 16) -> None:
         self._lock = threading.RLock()
         self._latest: Optional[OnSensorSnapshot] = None
@@ -74,14 +63,13 @@ class OnSensorEventBus:
         with self._lock:
             self._latest = snapshot
             self._history.append(snapshot)
-            if len(self._history) > self._history_size:
-                self._history = self._history[-self._history_size :]
+            self._history = self._history[-self._history_size :]
             self._published_count += 1
             subscribers = list(self._subscribers)
-        for fn in subscribers:
+        for subscriber in subscribers:
             try:
-                fn(snapshot)
-            except Exception as exc:  # pragma: no cover - defensive
+                subscriber(snapshot)
+            except Exception as exc:
                 logger.debug("on-sensor subscriber failed: %s", exc)
 
     def latest(self) -> Optional[OnSensorSnapshot]:
@@ -92,21 +80,21 @@ class OnSensorEventBus:
         with self._lock:
             return list(self._history)
 
-    def subscribe(self, fn: SubscriberFn) -> Callable[[], None]:
+    def subscribe(self, subscriber: SubscriberFn) -> Callable[[], None]:
         with self._lock:
-            self._subscribers.append(fn)
+            self._subscribers.append(subscriber)
 
-        def _unsub() -> None:
+        def unsubscribe() -> None:
             with self._lock:
-                if fn in self._subscribers:
-                    self._subscribers.remove(fn)
+                if subscriber in self._subscribers:
+                    self._subscribers.remove(subscriber)
 
-        return _unsub
+        return unsubscribe
 
     def stats(self) -> Dict[str, Any]:
         with self._lock:
             return {
-                "published_count": int(self._published_count),
+                "published_count": self._published_count,
                 "history_size": len(self._history),
                 "subscribers": len(self._subscribers),
                 "has_latest": self._latest is not None,
@@ -118,7 +106,6 @@ _default_lock = threading.RLock()
 
 
 def get_default_bus() -> OnSensorEventBus:
-    """Return the process-wide default bus, creating it on first use."""
     global _default_bus
     with _default_lock:
         if _default_bus is None:
@@ -132,10 +119,4 @@ def set_default_bus(bus: Optional[OnSensorEventBus]) -> None:
         _default_bus = bus
 
 
-__all__ = [
-    "OnSensorDetection",
-    "OnSensorSnapshot",
-    "OnSensorEventBus",
-    "get_default_bus",
-    "set_default_bus",
-]
+__all__ = ["OnSensorDetection", "OnSensorSnapshot", "OnSensorEventBus", "get_default_bus", "set_default_bus"]

--- a/modules/camera/services/tracking.py
+++ b/modules/camera/services/tracking.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .onsensor_bus import OnSensorDetection
+
+
+Box = Tuple[float, float, float, float]
+
+
+def _iou(a: Box, b: Box) -> float:
+    x1 = max(a[0], b[0])
+    y1 = max(a[1], b[1])
+    x2 = min(a[2], b[2])
+    y2 = min(a[3], b[3])
+    inter = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+    area_a = max(0.0, a[2] - a[0]) * max(0.0, a[3] - a[1])
+    area_b = max(0.0, b[2] - b[0]) * max(0.0, b[3] - b[1])
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+@dataclass
+class Track:
+    track_id: int
+    label: str
+    score: float
+    bbox: Box
+    first_seen: float
+    last_seen: float
+    missed: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "track_id": self.track_id,
+            "label": self.label,
+            "score": self.score,
+            "bbox_xyxy_norm": list(self.bbox),
+            "first_seen": self.first_seen,
+            "last_seen": self.last_seen,
+            "age_s": round(max(0.0, time.time() - self.first_seen), 3),
+            "missed": self.missed,
+        }
+
+
+class DetectionTracker:
+    def __init__(self, iou_threshold: float = 0.3, max_missed: int = 8) -> None:
+        self.iou_threshold = float(iou_threshold)
+        self.max_missed = int(max_missed)
+        self._lock = threading.RLock()
+        self._tracks: Dict[int, Track] = {}
+        self._next_id = 1
+        self._target_label = "person"
+        self._target_strategy = "largest"
+        self._target_track_id: Optional[int] = None
+
+    def update(self, detections: Iterable[OnSensorDetection]) -> List[OnSensorDetection]:
+        now = time.time()
+        incoming = list(detections)
+        with self._lock:
+            unmatched_tracks = set(self._tracks)
+            output: List[OnSensorDetection] = []
+            for detection in sorted(incoming, key=lambda item: item.score, reverse=True):
+                best_id: Optional[int] = None
+                best_iou = self.iou_threshold
+                for track_id in list(unmatched_tracks):
+                    track = self._tracks[track_id]
+                    if track.label != detection.label:
+                        continue
+                    score = _iou(track.bbox, detection.bbox_xyxy_norm)
+                    if score >= best_iou:
+                        best_iou = score
+                        best_id = track_id
+                if best_id is None:
+                    best_id = self._next_id
+                    self._next_id += 1
+                    self._tracks[best_id] = Track(
+                        track_id=best_id,
+                        label=detection.label,
+                        score=detection.score,
+                        bbox=detection.bbox_xyxy_norm,
+                        first_seen=now,
+                        last_seen=now,
+                    )
+                else:
+                    unmatched_tracks.discard(best_id)
+                    track = self._tracks[best_id]
+                    track.score = detection.score
+                    track.bbox = detection.bbox_xyxy_norm
+                    track.last_seen = now
+                    track.missed = 0
+                output.append(
+                    OnSensorDetection(
+                        class_id=detection.class_id,
+                        label=detection.label,
+                        score=detection.score,
+                        bbox_xyxy_norm=detection.bbox_xyxy_norm,
+                        track_id=best_id,
+                    )
+                )
+
+            for track_id in unmatched_tracks:
+                self._tracks[track_id].missed += 1
+            self._tracks = {track_id: track for track_id, track in self._tracks.items() if track.missed <= self.max_missed}
+            if self._target_track_id not in self._tracks:
+                self._target_track_id = None
+            return output
+
+    def select(self, label: str = "person", strategy: str = "largest", track_id: Optional[int] = None) -> Dict[str, Any]:
+        with self._lock:
+            self._target_label = str(label or "person").strip().lower()
+            self._target_strategy = str(strategy or "largest").strip().lower()
+            self._target_track_id = int(track_id) if track_id is not None else None
+            target = self._select_locked()
+            return {"ok": target is not None, "selection": self.selection(), "target": target.to_dict() if target else None}
+
+    def selection(self) -> Dict[str, Any]:
+        return {
+            "label": self._target_label,
+            "strategy": self._target_strategy,
+            "track_id": self._target_track_id,
+        }
+
+    def target(self) -> Optional[Track]:
+        with self._lock:
+            return self._select_locked()
+
+    def tracks(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [track.to_dict() for track in sorted(self._tracks.values(), key=lambda item: item.track_id)]
+
+    def _select_locked(self) -> Optional[Track]:
+        if self._target_track_id is not None:
+            return self._tracks.get(self._target_track_id)
+        candidates = [track for track in self._tracks.values() if track.label.lower() == self._target_label]
+        if not candidates:
+            return None
+        if self._target_strategy == "confidence":
+            return max(candidates, key=lambda item: item.score)
+        if self._target_strategy == "center":
+            return min(candidates, key=lambda item: abs(((item.bbox[0] + item.bbox[2]) / 2.0) - 0.5) + abs(((item.bbox[1] + item.bbox[3]) / 2.0) - 0.5))
+        return max(candidates, key=lambda item: max(0.0, item.bbox[2] - item.bbox[0]) * max(0.0, item.bbox[3] - item.bbox[1]))
+
+
+__all__ = ["DetectionTracker", "Track"]

--- a/modules/camera/xCameraService.py
+++ b/modules/camera/xCameraService.py
@@ -4,66 +4,82 @@ import logging
 
 from fastapi import FastAPI
 
+from .api import get_router
+from .config_loader import load_config
+from .services.capture import CameraCapture, CaptureConfig, FramePublisher
+from .services.imx500_runner import Imx500Config, Imx500Runner
+from .services.onsensor_bus import get_default_bus
+
 logger = logging.getLogger("camera.service")
-
-# Paket içi importlar, script modunda fallback ile
-try:
-    from .config_loader import load_config
-    from .services.capture import CameraCapture, FramePublisher, CaptureConfig
-    from .api import get_router
-except Exception:  # when run as script without package context
-    from config_loader import load_config  # type: ignore
-    from services.capture import CameraCapture, FramePublisher, CaptureConfig  # type: ignore
-    from api import get_router  # type: ignore
-
-try:
-    # Merkezi loglama (opsiyonel). Başarısız olsa bile modül çalışsın.
-    from modules.logwrapper import init_logging as _init_global_logging  # type: ignore
-
-    _init_global_logging()
-except Exception:
-    pass
 
 
 def create_app(config_path: str | None = None) -> FastAPI:
     cfg = load_config(config_path)
-    enabled = bool(cfg.get("enabled", False))
+    enabled = bool(cfg.get("enabled", True))
+    picam_cfg = cfg.get("picamera2", {}) if isinstance(cfg.get("picamera2"), dict) else {}
+    size_cfg = picam_cfg.get("size", {}) if isinstance(picam_cfg.get("size"), dict) else {}
+    imx_raw = cfg.get("imx500", {}) if isinstance(cfg.get("imx500"), dict) else {}
+    tracker_raw = imx_raw.get("tracker", {}) if isinstance(imx_raw.get("tracker"), dict) else {}
+    target_raw = imx_raw.get("target", {}) if isinstance(imx_raw.get("target"), dict) else {}
 
-    cap_cfg = CaptureConfig(
-        backend=cfg.get("backend", "auto"),
-        source=cfg.get("source", 0),
-        resolution=(int(cfg.get("resolution", {}).get("width", 1280)), int(cfg.get("resolution", {}).get("height", 720))),
-        fps_target=int(cfg.get("fps_target", 30)),
-        jpeg_quality=int(cfg.get("jpeg_quality", 80)),
-        opencv_fourcc=str(cfg.get("opencv", {}).get("fourcc", "MJPG")),
-        opencv_buffer_size=int(cfg.get("opencv", {}).get("buffer_size", 1)),
-        picam_size=(int(cfg.get("picamera2", {}).get("size", {}).get("width", 1920)), int(cfg.get("picamera2", {}).get("size", {}).get("height", 1080))),
-        picam_format=str(cfg.get("picamera2", {}).get("format", "RGB888")),
-        picam_frame_rate=int(cfg.get("picamera2", {}).get("frame_rate", 30)),
-        picam_af_mode=int(cfg.get("picamera2", {}).get("af_mode", 2)),
-        flip=str(cfg.get("flip", "none")),
-        opencv_max_open_attempts=int(cfg.get("opencv", {}).get("max_open_attempts", 5)),
-        opencv_retry_interval_s=float(cfg.get("opencv", {}).get("retry_interval_s", 1.0)),
+    bus = get_default_bus()
+    runner = Imx500Runner(
+        Imx500Config(
+            enabled=bool(imx_raw.get("enabled", True)),
+            model_path=str(imx_raw.get("model_path", Imx500Config.model_path)),
+            labels_path=str(imx_raw.get("labels_path", "")),
+            confidence=float(imx_raw.get("confidence", 0.50)),
+            iou=float(imx_raw.get("iou", 0.65)),
+            max_detections=int(imx_raw.get("max_detections", 20)),
+            publish_interval_s=float(imx_raw.get("publish_interval_s", 0.05)),
+            inference_rate=int(imx_raw["inference_rate"]) if imx_raw.get("inference_rate") is not None else None,
+            preserve_aspect_ratio=bool(imx_raw.get("preserve_aspect_ratio", True)),
+            classes_of_interest=tuple(imx_raw.get("classes_of_interest", []) or []),
+            tracker_iou_threshold=float(tracker_raw.get("iou_threshold", 0.30)),
+            tracker_max_missed=int(tracker_raw.get("max_missed", 8)),
+            target_label=str(target_raw.get("label", "person")),
+            target_strategy=str(target_raw.get("strategy", "largest")),
+        ),
+        bus=bus,
     )
-
-    publisher = FramePublisher()
-    capture = CameraCapture(cap_cfg, publisher)
+    runner.prepare()
+    capture = CameraCapture(
+        CaptureConfig(
+            size=(int(size_cfg.get("width", 1280)), int(size_cfg.get("height", 720))),
+            pixel_format=str(picam_cfg.get("format", "RGB888")),
+            frame_rate=int(picam_cfg.get("frame_rate", cfg.get("fps_target", 30))),
+            jpeg_quality=int(cfg.get("jpeg_quality", 80)),
+            flip=str(cfg.get("flip", "none")),
+            camera_num=runner.camera_num,
+        ),
+        FramePublisher(),
+    )
     if enabled:
         capture.start()
+        runner.attach_camera(capture.picam, capture)
+        runner.start()
     else:
-        logger.info("camera capture disabled (config enabled=false)")
+        logger.info("camera disabled")
 
     app = FastAPI()
-    app.include_router(get_router(capture, cap_cfg.fps_target, enabled=enabled))
+    app.include_router(
+        get_router(
+            capture,
+            int(cfg.get("fps_target", 30)),
+            enabled=enabled,
+            imx500_runner=runner,
+            onsensor_bus=bus,
+        )
+    )
     return app
 
 
 if __name__ == "__main__":
     import uvicorn
 
-    cfg = load_config()
+    configuration = load_config()
     uvicorn.run(
         create_app(),
-        host=str(cfg.get("server", {}).get("host", "0.0.0.0")),
-        port=int(cfg.get("server", {}).get("port", 8000)),
+        host=str(configuration.get("server", {}).get("host", "0.0.0.0")),
+        port=int(configuration.get("server", {}).get("port", 8000)),
     )

--- a/modules/vlm_bridge/api/analysis.py
+++ b/modules/vlm_bridge/api/analysis.py
@@ -41,9 +41,13 @@ def get_analysis_router(processor: Any, base_url: str) -> APIRouter:
             try:
                 answer = processor.vlm_client.ask_about_scene(frame, question, force=True)
                 if answer:
-                    if hasattr(processor, "refresh_visual_context"):
-                        processor.refresh_visual_context(question=question)
-                    return {"ok": True, "answer": answer}
+                    gate = getattr(processor, "vision_request_gate", None)
+                    if gate is not None:
+                        try:
+                            gate.record_manual_event("user_question", ok=True)
+                        except Exception:
+                            pass
+                    return {"ok": True, "answer": answer, "source": "direct_vlm", "duplicate_refresh": False}
             except Exception:
                 pass
 

--- a/modules/vlm_bridge/config/config.yml
+++ b/modules/vlm_bridge/config/config.yml
@@ -3,8 +3,8 @@ server:
   port: 8101
 
 vision:
-  processing_mode: remote  # local | remote — remote until camera attached
-  hybrid_local_capture: false
+  processing_mode: local
+  hybrid_local_capture: true
   # camera_source can be device index (0) or gateway camera stream URL
   camera_source: "http://127.0.0.1:8080/camera/video"  # Gateway camera MJPEG feed (Pi camera safe path)
   max_camera_wait_attempts: 5  # stop polling gateway camera when unavailable
@@ -21,7 +21,7 @@ vision:
     remote_timeout_s: 2.5
     remote_fallback: heuristic
   follow:
-    enabled: false
+    enabled: true
     track_interval_s: 0.12
     pan_gain_deg: 50
     tilt_gain_deg: 32
@@ -61,7 +61,7 @@ vision:
       semantic_scene: true
       depth: false                 # heavy model, keep disabled by default
     onsensor:
-      tiny_detect: false           # SSD MobileNet on IMX500
+      tiny_detect: true            # SSD MobileNet on IMX500
       tiny_pose: false             # PoseNet on IMX500 (optional)
   # Optional shorthand for the triple routing layers (merged into mode_categories)
   local_modes:
@@ -122,7 +122,7 @@ person_identity:
   owner_name: ""  # Will be set by remember_person tool
 
 remote:
-  auth_token: "changeme"  # Set a secure token in production or override
+  auth_token: "sb-vlm-wiXKZjxkyBZ_AbFd_aW3MCKi2kJhtKFo"
   accept_results: true     # Allow POST /vlm/results ingestion
 
 remote_multimodal:
@@ -131,7 +131,7 @@ remote_multimodal:
   ocr_endpoint: "http://PC_IP:8091/vision/ocr"  # remote OCR backend
   timeout_s: 6.0
   ocr_timeout_s: 10.0
-  auth_token: "changeme"
+  auth_token: "sb-vlm-wiXKZjxkyBZ_AbFd_aW3MCKi2kJhtKFo"
   ocr_languages: ["en", "tr"]
 
 robot:

--- a/modules/vlm_bridge/services/budgeted_inference.py
+++ b/modules/vlm_bridge/services/budgeted_inference.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from modules.vlm_bridge.services.inference_budget import (
+    BudgetDecision,
+    VLMInferenceBudgetGate,
+    build_vlm_inference_budget_gate,
+)
+
+VLM_BUDGET_GATE_INTEGRATION_CONTRACT = True
+VLM_BUDGET_GATE_INTEGRATION_ROLE = "budget_gate_required_before_vlm_callable"
+VLM_BUDGET_GATE_INTEGRATION_DEFAULT_NO_INFERENCE = True
+
+
+@dataclass(frozen=True)
+class BudgetedVLMResult:
+    allowed: bool
+    reason: str
+    budget: Dict[str, Any]
+    result: Optional[Any] = None
+    inference_called: bool = False
+    activation_started: bool = False
+    camera_started: bool = False
+    frame_captured: bool = False
+    hardware_enabled: bool = False
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "budget": dict(self.budget),
+            "result": self.result,
+            "inference_called": self.inference_called,
+            "activation_started": self.activation_started,
+            "camera_started": self.camera_started,
+            "frame_captured": self.frame_captured,
+            "hardware_enabled": self.hardware_enabled,
+        }
+
+
+class BudgetedVLMExecutor:
+    """Require the VLM budget gate before an injected inference callable.
+
+    This adapter does not own camera capture, frame acquisition, Ollama, network
+    calls, or hardware. The actual inference function must be injected by a
+    future runtime layer. When the gate denies, the callable is not invoked.
+    """
+
+    def __init__(
+        self,
+        *,
+        gate: Optional[VLMInferenceBudgetGate] = None,
+        inference_callable: Optional[Callable[[Mapping[str, Any]], Any]] = None,
+    ) -> None:
+        self.gate = gate if gate is not None else build_vlm_inference_budget_gate()
+        self.inference_callable = inference_callable
+
+    def run(
+        self,
+        payload: Optional[Mapping[str, Any]] = None,
+        *,
+        cost_units: float = 1.0,
+        now: Optional[float] = None,
+    ) -> BudgetedVLMResult:
+        data = dict(payload or {})
+        decision: BudgetDecision = self.gate.reserve(cost_units=cost_units, now=now)
+
+        if not decision.allowed:
+            return BudgetedVLMResult(
+                allowed=False,
+                reason=decision.reason,
+                budget=decision.as_dict(),
+                result=None,
+                inference_called=False,
+            )
+
+        if self.inference_callable is None:
+            return BudgetedVLMResult(
+                allowed=False,
+                reason="inference_callable_missing",
+                budget=decision.as_dict(),
+                result=None,
+                inference_called=False,
+            )
+
+        try:
+            result = self.inference_callable(data)
+        except Exception as exc:
+            self.gate.record_failure()
+            return BudgetedVLMResult(
+                allowed=False,
+                reason="inference_callable_error",
+                budget=decision.as_dict(),
+                result={"error": f"{type(exc).__name__}: {exc}"},
+                inference_called=True,
+            )
+
+        self.gate.record_success()
+        return BudgetedVLMResult(
+            allowed=True,
+            reason="inference_completed",
+            budget=decision.as_dict(),
+            result=result,
+            inference_called=True,
+        )
+
+
+def build_budgeted_vlm_executor(
+    *,
+    budget_config: Optional[Mapping[str, Any]] = None,
+    inference_callable: Optional[Callable[[Mapping[str, Any]], Any]] = None,
+) -> BudgetedVLMExecutor:
+    return BudgetedVLMExecutor(
+        gate=build_vlm_inference_budget_gate(budget_config),
+        inference_callable=inference_callable,
+    )

--- a/modules/vlm_bridge/services/inference_budget.py
+++ b/modules/vlm_bridge/services/inference_budget.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from time import time
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+VLM_INFERENCE_BUDGET_GATE_CONTRACT = True
+VLM_INFERENCE_BUDGET_GATE_ROLE = "pre_inference_rate_budget_and_circuit_gate"
+VLM_INFERENCE_BUDGET_GATE_STATUS_ONLY_SAFE = True
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    allowed: bool
+    reason: str
+    remaining_requests: int
+    remaining_cost_units: float
+    retry_after_s: float = 0.0
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "remaining_requests": self.remaining_requests,
+            "remaining_cost_units": round(float(self.remaining_cost_units), 3),
+            "retry_after_s": round(float(self.retry_after_s), 3),
+        }
+
+
+@dataclass
+class VLMInferenceBudgetGate:
+    """Pure pre-inference budget gate.
+
+    The gate does not capture frames, call a VLM, call Ollama, or perform
+    network IO. It only answers whether a future inference request would be
+    allowed under explicit runtime budget limits.
+    """
+
+    enabled: bool = False
+    max_requests_per_minute: int = 2
+    max_cost_units_per_minute: float = 4.0
+    min_interval_s: float = 5.0
+    max_consecutive_failures: int = 2
+    now_fn: Callable[[], float] = time
+    _events: List[Dict[str, float]] = field(default_factory=list)
+    _last_reserved_at: Optional[float] = None
+    _consecutive_failures: int = 0
+
+    @classmethod
+    def from_config(cls, config: Optional[Mapping[str, Any]] = None) -> "VLMInferenceBudgetGate":
+        cfg = dict(config or {})
+        return cls(
+            enabled=bool(cfg.get("enabled", False)),
+            max_requests_per_minute=max(0, int(cfg.get("max_requests_per_minute", 2))),
+            max_cost_units_per_minute=max(0.0, float(cfg.get("max_cost_units_per_minute", 4.0))),
+            min_interval_s=max(0.0, float(cfg.get("min_interval_s", 5.0))),
+            max_consecutive_failures=max(0, int(cfg.get("max_consecutive_failures", 2))),
+        )
+
+    def check(self, *, cost_units: float = 1.0, now: Optional[float] = None) -> BudgetDecision:
+        current = float(self.now_fn() if now is None else now)
+        cost = max(0.0, float(cost_units))
+        self._prune(current)
+
+        if not self.enabled:
+            return BudgetDecision(False, "disabled", 0, 0.0)
+
+        if self.max_consecutive_failures > 0 and self._consecutive_failures >= self.max_consecutive_failures:
+            return BudgetDecision(False, "circuit_open_after_failures", 0, 0.0)
+
+        if self._last_reserved_at is not None:
+            elapsed = current - self._last_reserved_at
+            if elapsed < self.min_interval_s:
+                return BudgetDecision(
+                    False,
+                    "cooldown",
+                    self._remaining_requests(),
+                    self._remaining_cost_units(),
+                    retry_after_s=self.min_interval_s - elapsed,
+                )
+
+        if self._remaining_requests() <= 0:
+            return BudgetDecision(False, "request_budget_exhausted", 0, self._remaining_cost_units())
+
+        if self._remaining_cost_units() < cost:
+            return BudgetDecision(False, "cost_budget_exhausted", self._remaining_requests(), self._remaining_cost_units())
+
+        return BudgetDecision(True, "allowed", self._remaining_requests() - 1, self._remaining_cost_units() - cost)
+
+    def reserve(self, *, cost_units: float = 1.0, now: Optional[float] = None) -> BudgetDecision:
+        current = float(self.now_fn() if now is None else now)
+        decision = self.check(cost_units=cost_units, now=current)
+        if decision.allowed:
+            cost = max(0.0, float(cost_units))
+            self._events.append({"t": current, "cost": cost})
+            self._last_reserved_at = current
+        return decision
+
+    def record_success(self) -> None:
+        self._consecutive_failures = 0
+
+    def record_failure(self) -> None:
+        self._consecutive_failures += 1
+
+    def status(self, *, now: Optional[float] = None) -> Dict[str, Any]:
+        current = float(self.now_fn() if now is None else now)
+        self._prune(current)
+        return {
+            "enabled": self.enabled,
+            "remaining_requests": self._remaining_requests(),
+            "remaining_cost_units": round(self._remaining_cost_units(), 3),
+            "min_interval_s": self.min_interval_s,
+            "max_consecutive_failures": self.max_consecutive_failures,
+            "consecutive_failures": self._consecutive_failures,
+            "last_reserved_at": self._last_reserved_at,
+            "status_only_safe": True,
+            "activation_started": False,
+        }
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - 60.0
+        self._events = [event for event in self._events if event["t"] >= cutoff]
+
+    def _remaining_requests(self) -> int:
+        return max(0, int(self.max_requests_per_minute) - len(self._events))
+
+    def _remaining_cost_units(self) -> float:
+        spent = sum(float(event["cost"]) for event in self._events)
+        return max(0.0, float(self.max_cost_units_per_minute) - spent)
+
+
+def build_vlm_inference_budget_gate(config: Optional[Mapping[str, Any]] = None) -> VLMInferenceBudgetGate:
+    return VLMInferenceBudgetGate.from_config(config)

--- a/modules/vlm_bridge/services/llm_client.py
+++ b/modules/vlm_bridge/services/llm_client.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+VLM_LLM_LEGACY_ENDPOINT_COMPATIBILITY_CONTRACT = True
+VLM_LLM_LEGACY_ENDPOINT_ROLE = "ollama_generate_to_chat_compatibility_adapter"
+
 
 import logging
 import os

--- a/modules/vlm_bridge/services/people_memory.py
+++ b/modules/vlm_bridge/services/people_memory.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+VLM_PEOPLE_MEMORY_COMPATIBILITY_CONTRACT = True
+VLM_PEOPLE_MEMORY_ROLE = "social_db_primary_json_backward_compatibility_store"
+
 import json
 import os
 import time
@@ -9,7 +12,7 @@ class PeopleMemory:
 
     Single-responsibility wrapper. When a :class:`modules.social_db.SocialDB`
     instance is registered as the process default (or supplied via constructor),
-    writes go through the shared SQLite store; otherwise the legacy JSON path
+    writes go through the shared SQLite store; otherwise the compatibility JSON path
     is used for backward compatibility.
     """
 

--- a/modules/vlm_bridge/services/person_identity.py
+++ b/modules/vlm_bridge/services/person_identity.py
@@ -13,6 +13,9 @@ Recognition levels:
 """
 
 from __future__ import annotations
+VLM_PERSON_IDENTITY_COMPATIBILITY_CONTRACT = True
+VLM_PERSON_IDENTITY_ROLE = "social_db_primary_person_json_compatibility_store"
+
 
 import json
 import logging
@@ -77,7 +80,7 @@ class PersonIdentityManager:
 
     When a :class:`modules.social_db.SocialDB` instance is supplied (or registered
     as the process default), writes are persisted to the shared SQLite store
-    instead of the legacy JSON file. The in-memory cache mirrors the database
+    instead of the compatibility JSON file. The in-memory cache mirrors the database
     rows for fast reads.
     """
 

--- a/modules/vlm_bridge/services/processor.py
+++ b/modules/vlm_bridge/services/processor.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
+VLM_PROCESSOR_LEGACY_COMPATIBILITY_CONTRACT = True
+VLM_PROCESSOR_LEGACY_COMPATIBILITY_ROLE = "opencv_api_and_cached_context_compatibility"
+
 
 import logging
 import os
 import threading
 import time
 import base64
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
 
 try:
@@ -13,6 +16,10 @@ try:
 except ImportError:
     cv2 = None  # type: ignore
 import requests
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 try:
     from .face_manager import FaceManager
@@ -78,6 +85,14 @@ except Exception:
     VisionSampler = None  # type: ignore
 
 try:
+    from .vision_request_gate import VisionRequestGate
+except Exception:
+    try:
+        from modules.vlm_bridge.services.vision_request_gate import VisionRequestGate
+    except Exception:
+        VisionRequestGate = None  # type: ignore
+
+try:
     from .face_emotion import FaceEmotionEstimator
 except Exception:
     try:
@@ -132,6 +147,8 @@ def _create_csrt_tracker() -> Optional[Any]:
             return cv2.TrackerCSRT_create()
         except Exception:
             pass
+    # OpenCV exposes CSRT tracker in different namespaces across versions.
+    # The `legacy` namespace is an active compatibility path, not dead code.
     legacy = getattr(cv2, "legacy", None)
     if legacy is not None and hasattr(legacy, "TrackerCSRT_create"):
         try:
@@ -289,6 +306,10 @@ class VisionProcessor:
         mm_cfg = config.get("remote_multimodal", {}) if isinstance(config.get("remote_multimodal", {}), dict) else {}
         self.remote_mm_enabled = bool(mm_cfg.get("enabled", False))
         self.remote_mm_endpoint = str(mm_cfg.get("endpoint", "http://127.0.0.1:8091/vision/analyze")).strip()
+        default_cheap_endpoint = self.remote_mm_endpoint.replace("/vision/analyze", "/vision/analyze/cheap") if self.remote_mm_endpoint else ""
+        default_semantic_endpoint = self.remote_mm_endpoint.replace("/vision/analyze", "/vision/analyze/semantic") if self.remote_mm_endpoint else ""
+        self.remote_mm_cheap_endpoint = str(mm_cfg.get("cheap_endpoint", default_cheap_endpoint)).strip()
+        self.remote_mm_semantic_endpoint = str(mm_cfg.get("semantic_endpoint", default_semantic_endpoint)).strip()
         self.remote_mm_timeout_s = float(mm_cfg.get("timeout_s", 6.0))
         self.remote_mm_auth_token = str(mm_cfg.get("auth_token", "")).strip()
         default_ocr_endpoint = self.remote_mm_endpoint.replace("/vision/analyze", "/vision/ocr") if self.remote_mm_endpoint else ""
@@ -306,6 +327,13 @@ class VisionProcessor:
         enabled = bool(actions_cfg.get("default_apply", False))
         self.action_dispatcher = VisionActionDispatcher(endpoint=endpoint, timeout=timeout, enabled=enabled)
         self.vision_sampler = VisionSampler(vlm_cfg) if VisionSampler is not None else None
+        gate_cfg = config.get("vision_request_gate", {}) if isinstance(config.get("vision_request_gate", {}), dict) else {}
+        self.vision_request_gate = (
+            VisionRequestGate(gate_cfg, context_max_age_s=self._context_max_age_s)
+            if VisionRequestGate is not None
+            else None
+        )
+        self.vision_semantic_budget = self._init_semantic_budget(config)
         self.event_bus = VisionEventBus() if VisionEventBus is not None else None
         self.head_arbiter = HeadControlArbiter(self._follow_cfg) if HeadControlArbiter is not None else None
         if self.head_arbiter is not None:
@@ -876,6 +904,116 @@ class VisionProcessor:
                 return True
         return False
 
+    def _vlm_scene_key(self, parsed_results: List[Dict[str, Any]]) -> str:
+        parts: List[str] = []
+        for item in parsed_results or []:
+            if not isinstance(item, dict):
+                continue
+            label = str(item.get("label") or item.get("name") or "unknown").strip().lower()
+            name = str(item.get("name") or "").strip().lower()
+            bbox = item.get("bbox") or []
+            box_key = ""
+            if isinstance(bbox, (list, tuple)) and len(bbox) >= 4:
+                try:
+                    box_key = ":".join(str(int(float(x) / 32)) for x in bbox[:4])
+                except Exception:
+                    box_key = ""
+            parts.append(f"{label}:{name}:{box_key}")
+        if not parts:
+            return "empty"
+        return "|".join(sorted(parts)[:24])
+
+    def _vlm_reason_from_signals(
+        self,
+        *,
+        score: float,
+        owner_seen: bool,
+        new_person: bool,
+        hazard: bool,
+        sudden_motion: bool,
+        is_bored: bool,
+    ) -> Tuple[str, str]:
+        if hazard:
+            return "hazard", "high"
+        if new_person:
+            return "new_person", "normal"
+        if owner_seen:
+            return "owner_seen", "normal"
+        if sudden_motion:
+            return "sudden_motion", "normal"
+        sampler = getattr(self, "vision_sampler", None)
+        threshold = getattr(sampler, "scene_change_threshold", 0.35)
+        if score >= threshold:
+            return "scene_change", "normal"
+        if is_bored:
+            return "boredom", "low"
+        return "idle_refresh", "low"
+
+    @staticmethod
+    def _init_semantic_budget(config: Dict[str, Any]) -> Dict[str, Any]:
+        raw = config.get("vision_semantic_budget", {}) if isinstance(config, dict) else {}
+        raw = raw if isinstance(raw, dict) else {}
+        default_reasons = {
+            "user_question": True,
+            "manual_refresh": True,
+            "hazard": True,
+            "new_person": True,
+            "owner_seen": False,
+            "scene_change": False,
+            "sudden_motion": False,
+            "boredom": False,
+            "idle_refresh": False,
+            "background_refresh": False,
+        }
+        reasons_raw = raw.get("semantic_reasons", default_reasons)
+        reasons: Dict[str, bool] = dict(default_reasons)
+        if isinstance(reasons_raw, dict):
+            for key, value in reasons_raw.items():
+                reasons[str(key)] = bool(value)
+        elif isinstance(reasons_raw, (list, tuple, set)):
+            reasons = {key: False for key in default_reasons}
+            for key in reasons_raw:
+                reasons[str(key)] = True
+        return {
+            "enabled": bool(raw.get("enabled", True)),
+            "log_decisions": bool(raw.get("log_decisions", True)),
+            "semantic_reasons": reasons,
+        }
+
+    def _semantic_budget_allows(self, *, question: str = "", reason: str = "", force: Optional[bool] = None) -> bool:
+        if force is not None:
+            return bool(force)
+        cfg = getattr(self, "vision_semantic_budget", {}) or {}
+        if not bool(cfg.get("enabled", True)):
+            return False
+        if str(question or "").strip():
+            return True
+        reason_key = str(reason or "background_refresh")
+        reasons = cfg.get("semantic_reasons", {}) if isinstance(cfg.get("semantic_reasons", {}), dict) else {}
+        return bool(reasons.get(reason_key, False))
+
+    def _visual_context_cache_state(self) -> Tuple[bool, Optional[float]]:
+        cache = getattr(self, "visual_context_cache", None)
+        if cache is None:
+            return False, None
+        try:
+            age = float(getattr(cache, "age_s", 999999.0))
+            latest = cache.get_latest() if hasattr(cache, "get_latest") else None
+            return latest is not None and age <= float(getattr(self, "_context_max_age_s", 45.0)), age
+        except Exception:
+            return False, None
+
+    def get_vision_gate_stats(self) -> Dict[str, Any]:
+        gate = getattr(self, "vision_request_gate", None)
+        if gate is None:
+            return {"available": False}
+        try:
+            stats = gate.get_stats()
+            stats["available"] = True
+            return stats
+        except Exception as exc:
+            return {"available": False, "error": str(exc)}
+
     def _maybe_sample_vlm(self, parsed_results: List[Dict[str, Any]]) -> None:
         sampler = getattr(self, "vision_sampler", None)
         if sampler is None:
@@ -902,19 +1040,74 @@ class VisionProcessor:
             return
         if not should:
             return
+
+        reason, priority = self._vlm_reason_from_signals(
+            score=score,
+            owner_seen=owner_seen,
+            new_person=new_person,
+            hazard=hazard,
+            sudden_motion=sudden_motion,
+            is_bored=is_bored,
+        )
+        request_id = ""
+        gate = getattr(self, "vision_request_gate", None)
+        if gate is not None:
+            has_cache, cache_age_s = self._visual_context_cache_state()
+            try:
+                decision = gate.decide(
+                    reason=reason,
+                    priority=priority,
+                    scene_key=self._vlm_scene_key(parsed_results),
+                    force=False,
+                    has_cache=has_cache,
+                    cache_age_s=cache_age_s,
+                )
+            except Exception as exc:
+                logger.debug("VLM gate decision failed: %s", exc)
+                decision = None
+            if decision is not None and not decision.allowed:
+                logger.debug(
+                    "VLM gate skipped reason=%s mode=%s wait_s=%.1f use_cache=%s",
+                    decision.reason,
+                    decision.mode,
+                    float(decision.wait_s or 0.0),
+                    bool(decision.use_cache),
+                )
+                return
+            if decision is not None:
+                request_id = decision.request_id
+                try:
+                    gate.mark_start(request_id, reason=reason, priority=priority)
+                except Exception:
+                    pass
+                logger.info("VLM gate approved reason=%s priority=%s request_id=%s", reason, priority, request_id)
+
         sampler.record_call()
         self._vlm_refresh_inflight = True
-        threading.Thread(target=self._background_context_refresh, daemon=True).start()
+        threading.Thread(target=self._background_context_refresh, args=(reason, request_id), daemon=True).start()
 
-    def _background_context_refresh(self) -> None:
+    def _background_context_refresh(self, reason: str = "background_refresh", request_id: str = "") -> None:
+        ok = False
         try:
-            context = self.refresh_visual_context()
+            try:
+                context = self.refresh_visual_context(semantic_reason=reason, semantic_request_id=request_id)
+            except TypeError:
+                # Backward compatibility for tests/extensions that monkeypatch
+                # refresh_visual_context(question="") with the older signature.
+                context = self.refresh_visual_context()
+            ok = context is not None
             if context is not None and self.event_bus is not None:
-                self.event_bus.publish(EVENT_SCENE_CHANGED, {"context": context})
-                self.event_bus.publish(EVENT_VLM_RESULT_READY, {"context": context})
-        except Exception:
-            pass
+                self.event_bus.publish(EVENT_SCENE_CHANGED, {"context": context, "reason": reason})
+                self.event_bus.publish(EVENT_VLM_RESULT_READY, {"context": context, "reason": reason})
+        except Exception as exc:
+            logger.debug("VLM background context refresh failed: %s", exc)
         finally:
+            gate = getattr(self, "vision_request_gate", None)
+            if gate is not None and request_id:
+                try:
+                    gate.mark_finish(request_id, ok=ok)
+                except Exception:
+                    pass
             self._vlm_refresh_inflight = False
 
     # -----------------------------------------------------------------
@@ -1461,35 +1654,69 @@ class VisionProcessor:
         data.setdefault("ok", True)
         return data
 
-    def _remote_requested_tasks(self) -> List[str]:
+    def _remote_requested_tasks(self, run_semantic_vlm: bool = False) -> List[str]:
         remote = self.mode_categories.get("remote", {})
         tasks: List[str] = []
         for key in ("objects", "people", "faces", "ocr", "hazards", "semantic_scene", "depth"):
+            if key == "semantic_scene" and not run_semantic_vlm:
+                continue
+            if key == "semantic_scene" and not run_semantic_vlm:
+                continue
             if bool(remote.get(key, False)):
                 tasks.append(key)
         return tasks
 
-    def _call_remote_multimodal(self, frame: Any) -> Optional[Dict[str, Any]]:
+    def _remote_multimodal_endpoint_for(self, run_semantic_vlm: bool = False) -> str:
+        if bool(run_semantic_vlm):
+            return getattr(self, "remote_mm_semantic_endpoint", "") or getattr(self, "remote_mm_endpoint", "")
+        return getattr(self, "remote_mm_cheap_endpoint", "") or getattr(self, "remote_mm_endpoint", "")
+
+    def _call_remote_multimodal(
+        self,
+        frame: Any,
+        *,
+        run_semantic_vlm: bool = False,
+        semantic_reason: str = "",
+        request_id: str = "",
+        question: str = "",
+    ) -> Optional[Dict[str, Any]]:
         if not self.remote_mm_enabled or not self.remote_mm_endpoint:
+            return None
+        endpoint = self._remote_multimodal_endpoint_for(bool(run_semantic_vlm))
+        if not endpoint:
             return None
         try:
             ok, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 75])
             if not ok:
                 return None
             image_b64 = base64.b64encode(buf.tobytes()).decode("ascii")
-            payload: Dict[str, Any] = {"image_b64": image_b64}
-            requested = self._remote_requested_tasks()
+            payload: Dict[str, Any] = {
+                "image_b64": image_b64,
+                "run_semantic_vlm": bool(run_semantic_vlm),
+                "semantic_reason": str(semantic_reason or ""),
+                "request_id": str(request_id or ""),
+                "question": str(question or ""),
+                "mode": "semantic" if bool(run_semantic_vlm) else "cheap",
+            }
+            requested = self._remote_requested_tasks(run_semantic_vlm=bool(run_semantic_vlm))
             if requested:
                 payload["requested_tasks"] = requested
             headers = {}
             if self.remote_mm_auth_token:
                 headers["X-Auth-Token"] = self.remote_mm_auth_token
             resp = requests.post(
-                self.remote_mm_endpoint,
+                endpoint,
                 json=payload,
                 headers=headers,
                 timeout=self.remote_mm_timeout_s,
             )
+            if resp.status_code in (404, 405) and endpoint != self.remote_mm_endpoint:
+                resp = requests.post(
+                    self.remote_mm_endpoint,
+                    json=payload,
+                    headers=headers,
+                    timeout=self.remote_mm_timeout_s,
+                )
             if resp.status_code != 200:
                 return None
             data = resp.json()
@@ -1507,7 +1734,7 @@ class VisionProcessor:
         interpretation = str(mm.get("persona_interpretation", "")).strip() or summary
         importance = float(mm.get("importance_score", 0.55 if hazards else 0.4))
         return {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": _utc_iso(),
             "summary": summary,
             "objects": objects,
             "people": people,
@@ -1527,17 +1754,37 @@ class VisionProcessor:
             return None
         ctx = self.visual_context_cache.get_latest()
         if ctx is None:
-            fallback = self._build_context_from_results(self.latest_results)
-            if fallback is None:
+            compatibility_context = self._build_context_from_results(self.latest_results)
+            if compatibility_context is None:
                 return None
-            self.update_visual_context(fallback)
+            self.update_visual_context(compatibility_context)
             ctx = self.visual_context_cache.get_latest()
             if ctx is None:
                 return None
         return ctx.to_dict()
 
-    def refresh_visual_context(self, question: str = "") -> Optional[Dict[str, Any]]:
-        """Capture/refresh the latest context using VLM when possible."""
+    def refresh_visual_context(
+        self,
+        question: str = "",
+        *,
+        semantic_reason: str = "",
+        semantic_request_id: str = "",
+        force_semantic: Optional[bool] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Capture/refresh context, spending semantic VLM budget only when allowed."""
+        semantic_reason = "user_question" if str(question or "").strip() else (semantic_reason or "manual_refresh")
+        run_semantic_vlm = self._semantic_budget_allows(
+            question=question,
+            reason=semantic_reason,
+            force=force_semantic,
+        )
+        if bool((getattr(self, "vision_semantic_budget", {}) or {}).get("log_decisions", True)):
+            logger.info(
+                "VLM semantic budget reason=%s run=%s request_id=%s",
+                semantic_reason,
+                bool(run_semantic_vlm),
+                semantic_request_id or "-",
+            )
         frame = None
         with self._frame_lock:
             if self._latest_raw_frame is not None:
@@ -1571,11 +1818,11 @@ class VisionProcessor:
                 if latest is not None:
                     return latest
 
-        if frame is not None and self.vlm_client is not None:
+        if frame is not None and self.vlm_client is not None and run_semantic_vlm:
             vlm_result = self.vlm_client.analyze_frame(frame, force=bool(question))
             if isinstance(vlm_result, dict):
                 context = {
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": _utc_iso(),
                     "summary": str(vlm_result.get("summary", "")),
                     "objects": list(vlm_result.get("objects", []) or []),
                     "people": list(vlm_result.get("people", []) or []),
@@ -1591,9 +1838,9 @@ class VisionProcessor:
                 if latest is not None:
                     return latest
 
-        fallback = self._build_context_from_results(self.latest_results)
-        if fallback is not None:
-            self.update_visual_context(fallback, is_user_question=bool(question))
+        compatibility_context = self._build_context_from_results(self.latest_results)
+        if compatibility_context is not None:
+            self.update_visual_context(compatibility_context, is_user_question=bool(question))
             return self.get_latest_visual_context()
         return None
 
@@ -1615,7 +1862,7 @@ class VisionProcessor:
                         "bbox": list(item.get("bbox", [0, 0, 0, 0])),
                         "distance_m": item.get("distance_m"),
                         "gaze_priority": 0.4,
-                        "last_seen": datetime.utcnow().isoformat(),
+                        "last_seen": _utc_iso(),
                         "is_follow_target": bool(item.get("tracked", False)),
                         "appearance_notes": "",
                         "emotion": str(item.get("emotion", "") or "").strip(),
@@ -1625,7 +1872,7 @@ class VisionProcessor:
                 objects.append(item)
         summary = f"{len(people)} kişi ve {len(objects)} nesne algılandı."
         return {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": _utc_iso(),
             "summary": summary,
             "objects": objects,
             "people": people,

--- a/modules/vlm_bridge/services/stub.py
+++ b/modules/vlm_bridge/services/stub.py
@@ -1,5 +1,0 @@
-class xArduinoSerialService:
-    def start(self) -> None:
-        pass
-    def request(self, obj, timeout=1.0):
-        return {"ok": False, "error": "stub"}

--- a/modules/vlm_bridge/services/vision_request_gate.py
+++ b/modules/vlm_bridge/services/vision_request_gate.py
@@ -1,0 +1,182 @@
+"""Request gate for expensive visual language model calls.
+
+The gate separates cheap cache/status polling from expensive semantic VLM work.
+It is intentionally dependency-free so it can run on the robot and on a PC test
+machine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import threading
+import time
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    allowed: bool
+    reason: str
+    request_id: str = ""
+    priority: str = "normal"
+    mode: str = "denied"
+    detail: str = ""
+    wait_s: float = 0.0
+    use_cache: bool = False
+    cache_age_s: Optional[float] = None
+
+
+class VisionRequestGate:
+    """Small policy object that throttles expensive VLM requests."""
+
+    DEFAULT_REASON_COOLDOWNS = {
+        "user_question": 0.0,
+        "hazard": 2.0,
+        "new_person": 12.0,
+        "owner_seen": 18.0,
+        "scene_change": 15.0,
+        "sudden_motion": 20.0,
+        "boredom": 45.0,
+        "idle_refresh": 60.0,
+        "manual_refresh": 10.0,
+        "background_refresh": 30.0,
+    }
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None, *, context_max_age_s: float = 45.0) -> None:
+        cfg = dict(config or {})
+        self.enabled = bool(cfg.get("enabled", True))
+        self.max_inflight = max(1, int(cfg.get("max_inflight", 1)))
+        self.cache_ttl_s = float(cfg.get("cache_ttl_s", context_max_age_s))
+        self.default_cooldown_s = float(cfg.get("default_cooldown_s", 30.0))
+        self.log_decisions = bool(cfg.get("log_decisions", True))
+        reason_cfg = cfg.get("reason_cooldowns_s", {})
+        self.reason_cooldowns_s = dict(self.DEFAULT_REASON_COOLDOWNS)
+        if isinstance(reason_cfg, dict):
+            for key, value in reason_cfg.items():
+                try:
+                    self.reason_cooldowns_s[str(key)] = float(value)
+                except Exception:
+                    continue
+        self._lock = threading.Lock()
+        self._inflight: Dict[str, Dict[str, Any]] = {}
+        self._last_by_reason: Dict[str, float] = {}
+        self._last_by_scene: Dict[str, float] = {}
+        self._counter = 0
+        self._stats = {
+            "approved": 0,
+            "denied": 0,
+            "cache": 0,
+            "finished_ok": 0,
+            "finished_error": 0,
+        }
+
+    def _cooldown_for(self, reason: str) -> float:
+        return float(self.reason_cooldowns_s.get(reason, self.default_cooldown_s))
+
+    def decide(
+        self,
+        *,
+        reason: str,
+        priority: str = "normal",
+        scene_key: str = "",
+        force: bool = False,
+        has_cache: bool = False,
+        cache_age_s: Optional[float] = None,
+        now: Optional[float] = None,
+    ) -> GateDecision:
+        now = time.time() if now is None else float(now)
+        reason = str(reason or "background_refresh")
+        priority = str(priority or "normal")
+        scene_key = str(scene_key or "")
+        cache_fresh = bool(has_cache and cache_age_s is not None and float(cache_age_s) <= self.cache_ttl_s)
+
+        if not self.enabled:
+            self._counter += 1
+            request_id = f"vlm-{int(now * 1000)}-{self._counter}"
+            return GateDecision(True, reason, request_id, priority, "disabled", "gate disabled")
+
+        with self._lock:
+            if len(self._inflight) >= self.max_inflight:
+                self._stats["denied"] += 1
+                if cache_fresh:
+                    self._stats["cache"] += 1
+                return GateDecision(
+                    False,
+                    reason,
+                    priority=priority,
+                    mode="inflight",
+                    detail="another VLM request is already running",
+                    use_cache=cache_fresh,
+                    cache_age_s=cache_age_s,
+                )
+
+            cooldown_s = 0.0 if force else self._cooldown_for(reason)
+            last_reason = self._last_by_reason.get(reason, 0.0)
+            elapsed_reason = now - last_reason if last_reason else 999999.0
+            last_scene = self._last_by_scene.get(scene_key, 0.0) if scene_key else 0.0
+            elapsed_scene = now - last_scene if last_scene else 999999.0
+            remaining_reason = max(0.0, cooldown_s - elapsed_reason)
+            remaining_scene = max(0.0, min(cooldown_s, self.cache_ttl_s) - elapsed_scene) if scene_key else 0.0
+            wait_s = max(remaining_reason, remaining_scene)
+
+            if wait_s > 0.0 and not force:
+                self._stats["denied"] += 1
+                if cache_fresh:
+                    self._stats["cache"] += 1
+                return GateDecision(
+                    False,
+                    reason,
+                    priority=priority,
+                    mode="cooldown",
+                    detail="cooldown active",
+                    wait_s=round(wait_s, 2),
+                    use_cache=cache_fresh,
+                    cache_age_s=cache_age_s,
+                )
+
+            self._counter += 1
+            request_id = f"vlm-{int(now * 1000)}-{self._counter}"
+            self._last_by_reason[reason] = now
+            if scene_key:
+                self._last_by_scene[scene_key] = now
+            self._stats["approved"] += 1
+            return GateDecision(True, reason, request_id, priority, "approved", "approved")
+
+    def mark_start(self, request_id: str, *, reason: str = "", priority: str = "") -> None:
+        if not request_id:
+            return
+        with self._lock:
+            self._inflight[request_id] = {"started_at": time.time(), "reason": reason, "priority": priority}
+
+    def mark_finish(self, request_id: str, *, ok: bool = True) -> None:
+        if not request_id:
+            return
+        with self._lock:
+            self._inflight.pop(request_id, None)
+            self._stats["finished_ok" if ok else "finished_error"] += 1
+
+    def record_manual_event(self, reason: str, *, ok: bool = True) -> None:
+        now = time.time()
+        with self._lock:
+            self._last_by_reason[str(reason or "manual_refresh")] = now
+            self._stats["finished_ok" if ok else "finished_error"] += 1
+
+    @property
+    def inflight_count(self) -> int:
+        with self._lock:
+            return len(self._inflight)
+
+    def get_stats(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "enabled": self.enabled,
+                "max_inflight": self.max_inflight,
+                "inflight": len(self._inflight),
+                "cache_ttl_s": self.cache_ttl_s,
+                "reason_cooldowns_s": dict(self.reason_cooldowns_s),
+                "stats": dict(self._stats),
+                "last_by_reason": {k: round(time.time() - v, 1) for k, v in self._last_by_reason.items()},
+            }
+
+
+__all__ = ["VisionRequestGate", "GateDecision"]

--- a/services/remote_multimodal_server/README.md
+++ b/services/remote_multimodal_server/README.md
@@ -35,7 +35,9 @@ Default: `http://0.0.0.0:8091`
 ## Endpoints
 
 - `GET /healthz`
-- `POST /vision/analyze`
+- `POST /vision/analyze` (legacy compatible)
+- `POST /vision/analyze/cheap` (objects/people/faces/hazards; never wakes Qwen)
+- `POST /vision/analyze/semantic` (explicit semantic VLM budget; may wake Qwen)
 - `POST /vision/register_face`
 
 ## Environment Variables
@@ -80,6 +82,8 @@ For your selected profile (`balanced`) with Qwen + OpenCV:
 remote_multimodal:
   enabled: true
   endpoint: "http://PC_IP:8091/vision/analyze"
+  cheap_endpoint: "http://PC_IP:8091/vision/analyze/cheap"
+  semantic_endpoint: "http://PC_IP:8091/vision/analyze/semantic"
   timeout_s: 6.0
   auth_token: "YOUR_TOKEN"
 ```

--- a/services/remote_multimodal_server/remote_multimodal/engine.py
+++ b/services/remote_multimodal_server/remote_multimodal/engine.py
@@ -273,24 +273,47 @@ class MultiModalEngine:
             return {"ok": False, "error": str(exc), "text": "", "lines": []}
         return {"ok": False, "error": "unsupported_backend", "text": "", "lines": []}
 
-    def analyze(self, image_b64: str, requested_tasks: Optional[List[str]] = None) -> Dict[str, Any]:
+    @staticmethod
+    def _should_run_qwen(allow: set[str], run_semantic_vlm: Optional[bool]) -> bool:
+        if run_semantic_vlm is not None:
+            return bool(run_semantic_vlm)
+        # Legacy behavior for old clients that do not send the semantic flag.
+        return (not allow) or ("semantic_scene" in allow) or ("hazards" in allow)
+
+    def analyze(
+        self,
+        image_b64: str,
+        requested_tasks: Optional[List[str]] = None,
+        run_semantic_vlm: Optional[bool] = None,
+        semantic_reason: str = "",
+        request_id: str = "",
+        question: str = "",
+        task_mode: str = "",
+    ) -> Dict[str, Any]:
         """Analyse a frame, honouring an optional ``requested_tasks`` allowlist.
 
         ``requested_tasks`` may include any of ``objects``, ``faces``, ``people``,
         ``ocr``, ``hazards``, ``semantic_scene``. When omitted or empty, the
         engine runs every available pipeline (legacy behaviour).
+
+        ``run_semantic_vlm`` is the explicit budget flag used by SentryBOT.
+        False means keep cheap CV/object/face/hazard checks but do not call
+        Qwen. True means this request is allowed to spend semantic VLM budget.
         """
         frame = self.decode_image(image_b64)
         h, w = frame.shape[:2]
         allow = {str(t).strip().lower() for t in (requested_tasks or []) if str(t).strip()}
+        mode = str(task_mode or "").strip().lower()
         run_objects = (not allow) or ("objects" in allow) or ("hazards" in allow)
         run_faces = (not allow) or ("faces" in allow) or ("people" in allow)
         run_ocr = ("ocr" in allow) if allow else False
-        run_qwen = (not allow) or ("semantic_scene" in allow) or ("hazards" in allow)
+        run_qwen = self._should_run_qwen(allow, run_semantic_vlm)
+        if mode not in {"cheap", "semantic", "legacy"}:
+            mode = "semantic" if run_qwen else ("cheap" if allow else "legacy")
         objects = self.detect_objects(frame) if run_objects else []
         faces = self.detect_faces(frame) if run_faces else []
         motion, scene_change = self.motion_scene_change(frame)
-        qwen_out = self.qwen.analyze_frame(frame) if run_qwen else {"ok": False}
+        qwen_out = self.qwen.analyze_frame(frame) if (run_qwen and self.cfg.enable_qwen_vlm) else {"ok": False}
         ocr_payload: Dict[str, Any] = {"ok": False}
         if run_ocr:
             ocr_payload = self.ocr_frame(frame)
@@ -364,7 +387,7 @@ class MultiModalEngine:
             "motion": {"score": round(motion, 3), "detected": motion > self.cfg.motion_threshold},
             "scene_change": {"score": round(scene_change, 3), "changed": scene_change > self.cfg.scene_change_threshold},
             "interesting_events": ["scene_changed"] if scene_change > self.cfg.scene_change_threshold else [],
-            "recommended_focus": {"type": focus_type, "reason": "hybrid_cv_qwen"},
+            "recommended_focus": {"type": focus_type, "reason": "hybrid_cv_qwen" if qwen_out.get("ok") else "cheap_cv"},
             "importance_score": round(min(1.0, max(0.0, importance)), 3),
             "frame_size": {"w": int(w), "h": int(h)},
             "ocr": ocr_payload,
@@ -376,9 +399,57 @@ class MultiModalEngine:
                 "advanced_caption": bool(self.backends.caption_pipe is not None),
                 "qwen_vlm": bool(qwen_out.get("ok")),
                 "qwen_model": qwen_out.get("model", ""),
+                "semantic_vlm_requested": bool(run_qwen),
+                "semantic_reason": str(semantic_reason or ""),
+                "request_id": str(request_id or ""),
+                "question": bool(str(question or "").strip()),
+                "task_mode": mode,
+                "semantic_endpoint": mode == "semantic",
+                "cheap_endpoint": mode == "cheap",
                 "ocr": self.backends.ocr_backend_name,
             },
         }
+
+
+    def analyze_cheap(
+        self,
+        image_b64: str,
+        requested_tasks: Optional[List[str]] = None,
+        semantic_reason: str = "",
+        request_id: str = "",
+        question: str = "",
+    ) -> Dict[str, Any]:
+        tasks = requested_tasks or ["objects", "people", "faces", "hazards"]
+        return self.analyze(
+            image_b64,
+            requested_tasks=tasks,
+            run_semantic_vlm=False,
+            semantic_reason=semantic_reason or "cheap_poll",
+            request_id=request_id,
+            question=question,
+            task_mode="cheap",
+        )
+
+    def analyze_semantic(
+        self,
+        image_b64: str,
+        requested_tasks: Optional[List[str]] = None,
+        semantic_reason: str = "",
+        request_id: str = "",
+        question: str = "",
+    ) -> Dict[str, Any]:
+        base = list(requested_tasks or ["objects", "people", "faces", "hazards", "semantic_scene"])
+        if "semantic_scene" not in {str(t).strip().lower() for t in base}:
+            base.append("semantic_scene")
+        return self.analyze(
+            image_b64,
+            requested_tasks=base,
+            run_semantic_vlm=True,
+            semantic_reason=semantic_reason or "semantic_request",
+            request_id=request_id,
+            question=question,
+            task_mode="semantic",
+        )
 
     def register_face(self, name: str, image_b64: str) -> Dict[str, Any]:
         fr = self.backends.face_recognition

--- a/services/remote_multimodal_server/remote_multimodal/models.py
+++ b/services/remote_multimodal_server/remote_multimodal/models.py
@@ -10,6 +10,15 @@ from pydantic import BaseModel
 class AnalyzeRequest(BaseModel):
     image_b64: str
     requested_tasks: Optional[List[str]] = None
+    # Explicit semantic budget controls. When omitted, the server keeps
+    # legacy behavior for older clients. New SentryBOT clients always set
+    # run_semantic_vlm so cheap object/person polling does not wake Qwen.
+    run_semantic_vlm: Optional[bool] = None
+    semantic_reason: Optional[str] = None
+    request_id: Optional[str] = None
+    question: Optional[str] = None
+    # Optional client-visible task mode: cheap | semantic | legacy.
+    mode: Optional[str] = None
 
 
 class RegisterFaceRequest(BaseModel):

--- a/services/remote_multimodal_server/remote_multimodal/server.py
+++ b/services/remote_multimodal_server/remote_multimodal/server.py
@@ -45,13 +45,46 @@ def create_app(runtime_cfg: Optional[RuntimeConfig] = None) -> FastAPI:
                 "qwen_timeout_s": cfg.qwen_timeout_s,
                 "enable_advanced_caption": cfg.enable_advanced_caption,
                 "advanced_caption_model": cfg.advanced_caption_model,
+                "task_split_endpoints": True,
+                "cheap_endpoint": "/vision/analyze/cheap",
+                "semantic_endpoint": "/vision/analyze/semantic",
             },
         }
 
     @app.post("/vision/analyze")
     def analyze(req: AnalyzeRequest, x_auth_token: Optional[str] = Header(default=None)) -> Dict[str, Any]:
         _require_auth(x_auth_token)
-        return engine.analyze(req.image_b64, requested_tasks=req.requested_tasks)
+        return engine.analyze(
+            req.image_b64,
+            requested_tasks=req.requested_tasks,
+            run_semantic_vlm=req.run_semantic_vlm,
+            semantic_reason=req.semantic_reason or "",
+            request_id=req.request_id or "",
+            question=req.question or "",
+            task_mode=req.mode or "legacy",
+        )
+
+    @app.post("/vision/analyze/cheap")
+    def analyze_cheap(req: AnalyzeRequest, x_auth_token: Optional[str] = Header(default=None)) -> Dict[str, Any]:
+        _require_auth(x_auth_token)
+        return engine.analyze_cheap(
+            req.image_b64,
+            requested_tasks=req.requested_tasks,
+            semantic_reason=req.semantic_reason or "cheap_poll",
+            request_id=req.request_id or "",
+            question=req.question or "",
+        )
+
+    @app.post("/vision/analyze/semantic")
+    def analyze_semantic(req: AnalyzeRequest, x_auth_token: Optional[str] = Header(default=None)) -> Dict[str, Any]:
+        _require_auth(x_auth_token)
+        return engine.analyze_semantic(
+            req.image_b64,
+            requested_tasks=req.requested_tasks,
+            semantic_reason=req.semantic_reason or "semantic_request",
+            request_id=req.request_id or "",
+            question=req.question or "",
+        )
 
     @app.post("/vision/register_face")
     def register_face(req: RegisterFaceRequest, x_auth_token: Optional[str] = Header(default=None)) -> Dict[str, Any]:

--- a/services/remote_multimodal_server/tests/test_semantic_budget.py
+++ b/services/remote_multimodal_server/tests/test_semantic_budget.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from remote_multimodal.engine import MultiModalEngine
+from remote_multimodal.models import AnalyzeRequest
+
+
+def test_analyze_request_accepts_semantic_budget_fields():
+    req = AnalyzeRequest(
+        image_b64="abc",
+        requested_tasks=["objects", "hazards"],
+        run_semantic_vlm=False,
+        semantic_reason="scene_change",
+        request_id="vlm-1",
+    )
+    assert req.run_semantic_vlm is False
+    assert req.semantic_reason == "scene_change"
+    assert req.request_id == "vlm-1"
+
+
+def test_remote_engine_qwen_budget_decision_is_explicit():
+    assert MultiModalEngine._should_run_qwen({"objects", "hazards"}, False) is False
+    assert MultiModalEngine._should_run_qwen({"objects"}, True) is True
+    # Legacy clients without explicit flag keep old hazard/semantic behavior.
+    assert MultiModalEngine._should_run_qwen({"hazards"}, None) is True
+    assert MultiModalEngine._should_run_qwen({"objects"}, None) is False

--- a/services/remote_multimodal_server/tests/test_task_split_endpoints.py
+++ b/services/remote_multimodal_server/tests/test_task_split_endpoints.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+
+from remote_multimodal.config import RuntimeConfig
+from remote_multimodal.engine import MultiModalEngine
+from remote_multimodal.models import AnalyzeRequest
+
+
+def _jpeg_b64() -> str:
+    frame = np.zeros((32, 32, 3), dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", frame)
+    assert ok
+    return base64.b64encode(buf.tobytes()).decode("ascii")
+
+
+class _FakeQwen:
+    def __init__(self):
+        self.calls = 0
+
+    def analyze_frame(self, frame):
+        self.calls += 1
+        return {
+            "ok": True,
+            "model": "fake-qwen",
+            "summary": "semantic scene",
+            "persona_interpretation": "semantic scene",
+            "hazards": [],
+            "suggested_focus": "scene",
+        }
+
+
+def _engine() -> MultiModalEngine:
+    e = MultiModalEngine.__new__(MultiModalEngine)
+    e.cfg = RuntimeConfig(enable_qwen_vlm=True)
+    e.backends = SimpleNamespace(
+        yolo=None,
+        face_recognition=None,
+        deepface=None,
+        caption_pipe=None,
+        ocr_backend_name=None,
+    )
+    e.qwen = _FakeQwen()
+    e.detect_objects = lambda frame: []
+    e.detect_faces = lambda frame: []
+    e.motion_scene_change = lambda frame: (0.0, 0.0)
+    e._caption = lambda frame: None
+    e.ocr_frame = lambda frame: {"ok": False}
+    return e
+
+
+def test_analyze_request_accepts_task_mode():
+    req = AnalyzeRequest(image_b64="abc", mode="cheap")
+    assert req.mode == "cheap"
+
+
+def test_cheap_endpoint_never_calls_qwen():
+    e = _engine()
+    out = e.analyze_cheap(_jpeg_b64(), request_id="cheap-1")
+    assert out["backend_info"]["task_mode"] == "cheap"
+    assert out["backend_info"]["semantic_vlm_requested"] is False
+    assert e.qwen.calls == 0
+
+
+def test_semantic_endpoint_calls_qwen():
+    e = _engine()
+    out = e.analyze_semantic(_jpeg_b64(), semantic_reason="user_question", request_id="sem-1")
+    assert out["backend_info"]["task_mode"] == "semantic"
+    assert out["backend_info"]["semantic_vlm_requested"] is True
+    assert out["backend_info"]["qwen_vlm"] is True
+    assert e.qwen.calls == 1

--- a/tests/modules/camera/test_camera_imx500_status_profile.py
+++ b/tests/modules/camera/test_camera_imx500_status_profile.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from modules.camera.api.router import get_router
+from modules.camera.services.imx500_runner import Imx500Config, Imx500Runner
+from modules.camera.services.onsensor_bus import OnSensorDetection, OnSensorEventBus, OnSensorSnapshot
+
+
+class _Cap:
+    gave_up = False
+
+    def __init__(self, has_frame: bool = False):
+        self.has_frame = has_frame
+
+    async def snapshot(self):
+        return b"jpg" if self.has_frame else None
+
+    def status(self):
+        return {
+            "backend": "opencv",
+            "source": "0",
+            "running": self.has_frame,
+            "gave_up": False,
+            "has_frame": self.has_frame,
+            "opencv": {"available": True},
+            "picamera2": {"available": False, "import_error": "missing"},
+        }
+
+    def mjpeg_generator(self, fps):
+        yield b""
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+def test_camera_status_disabled_exposes_truth():
+    app = FastAPI()
+    app.include_router(get_router(_Cap(False), 15, enabled=False), prefix="/camera")
+    client = TestClient(app)
+    body = client.get("/camera/status").json()
+    assert body["enabled"] is False
+    assert body["ok"] is False
+    assert body["imx500"]["reason"] == "not_configured"
+
+
+def test_camera_status_includes_onsensor_and_imx_runner():
+    bus = OnSensorEventBus()
+    bus.publish(
+        OnSensorSnapshot(
+            ts=time.time(),
+            frame_id=7,
+            detections=[OnSensorDetection(class_id=0, label="person", score=0.91, bbox_xyxy_norm=(0.1, 0.1, 0.4, 0.7))],
+        )
+    )
+    runner = Imx500Runner(Imx500Config(enabled=False), bus=bus)
+    app = FastAPI()
+    app.include_router(get_router(_Cap(True), 15, enabled=True, imx500_runner=runner, onsensor_bus=bus), prefix="/camera")
+    client = TestClient(app)
+    status = client.get("/camera/status").json()
+    assert status["ok"] is True
+    assert status["imx500"]["reason"] == "disabled"
+    assert status["onsensor"]["has_latest"] is True
+    latest = client.get("/camera/onsensor/latest").json()
+    assert latest["ok"] is True
+    assert latest["snapshot"]["frame_id"] == 7
+
+
+def test_imx500_status_model_missing_when_library_present(monkeypatch, tmp_path):
+    from modules.camera.services import imx500_runner as mod
+
+    monkeypatch.setattr(mod, "IMX500_AVAILABLE", True)
+    cfg = Imx500Config(enabled=True, model_path=str(tmp_path / "missing.rpk"))
+    runner = Imx500Runner(cfg, bus=OnSensorEventBus())
+    data = runner.status()
+    assert data["enabled"] is True
+    assert data["model_path_exists"] is False
+    assert data["reason"] == "model_missing"

--- a/tests/modules/camera/test_camera_reversible_start_stop_contract.py
+++ b/tests/modules/camera/test_camera_reversible_start_stop_contract.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.camera.api import router as camera_router
+from modules.camera.services import capture as camera_capture
+
+
+ROOT = Path(__file__).resolve().parents[3]
+ROUTER_SOURCE = ROOT / "modules/camera/api/router.py"
+CAPTURE_SOURCE = ROOT / "modules/camera/services/capture.py"
+
+
+def _has_route(source: str, method: str, path: str) -> bool:
+    # Accept both common local variable names:
+    #   @r.post("/start")
+    #   @router.post("/start")
+    needle_double = f'.{method}("{path}")'
+    needle_single = f".{method}('{path}')"
+    return needle_double in source or needle_single in source
+
+
+def test_camera_reversible_start_stop_markers_are_exported():
+    assert camera_router.CAMERA_REVERSIBLE_START_STOP_CONTRACT is True
+    assert camera_router.CAMERA_REVERSIBLE_START_STOP_ROLE == "explicit_route_control_surface"
+    assert camera_router.CAMERA_START_STOP_STATUS_ONLY_AUDIT_SAFE is True
+
+    assert camera_capture.CAMERA_CAPTURE_LAZY_OPEN_CONTRACT is True
+    assert camera_capture.CAMERA_CAPTURE_IMPORT_STARTS_DEVICE is False
+    assert camera_capture.CAMERA_START_STOP_REQUIRES_EXPLICIT_ROUTE_CALL is True
+
+
+def test_camera_control_routes_exist_as_explicit_reversible_surface():
+    source = ROUTER_SOURCE.read_text(encoding="utf-8")
+    assert _has_route(source, "post", "/start")
+    assert _has_route(source, "post", "/stop")
+    assert _has_route(source, "get", "/status")
+    assert _has_route(source, "get", "/healthz")
+
+
+def test_camera_router_import_does_not_open_camera_or_capture_frame():
+    tree = ast.parse(ROUTER_SOURCE.read_text(encoding="utf-8"))
+    forbidden_calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = ""
+        if isinstance(node.func, ast.Name):
+            name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            name = node.func.attr
+        if name in {"VideoCapture", "imread"}:
+            forbidden_calls.append((name, node.lineno))
+    assert forbidden_calls == []
+
+
+def test_camera_capture_has_no_top_level_device_open():
+    tree = ast.parse(CAPTURE_SOURCE.read_text(encoding="utf-8"))
+    forbidden_top_level = []
+    for node in tree.body:
+        value = None
+        if isinstance(node, ast.Expr):
+            value = node.value
+        elif isinstance(node, ast.Assign):
+            value = node.value
+        if not isinstance(value, ast.Call):
+            continue
+        name = ""
+        if isinstance(value.func, ast.Name):
+            name = value.func.id
+        elif isinstance(value.func, ast.Attribute):
+            name = value.func.attr
+        if name in {"VideoCapture", "start", "open"}:
+            forbidden_top_level.append((name, node.lineno))
+    assert forbidden_top_level == []

--- a/tests/modules/camera/test_camera_status_truth_contract.py
+++ b/tests/modules/camera/test_camera_status_truth_contract.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from modules.camera.api import router as camera_router
+from modules.camera.api.router import get_router
+from modules.camera.services import capture as camera_capture
+
+
+ROOT = Path(__file__).resolve().parents[3]
+ROUTER_SOURCE = ROOT / "modules/camera/api/router.py"
+CAPTURE_SOURCE = ROOT / "modules/camera/services/capture.py"
+
+
+class FakeCapture:
+    gave_up = False
+
+    def __init__(self) -> None:
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.status_calls = 0
+
+    def status(self):
+        self.status_calls += 1
+        return {
+            "running": False,
+            "has_frame": False,
+            "device": "/dev/video0",
+            "backend": "V4L2",
+            "gave_up": False,
+        }
+
+    def start(self):
+        self.start_calls += 1
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+def _nested_status_payload(data: dict) -> dict:
+    """Return the capture status payload across supported router schemas.
+
+    Existing router versions may expose capture state at top level or under a
+    nested key such as `capture`, `camera`, `status`, or `capture_status`.
+    The contract is not the exact JSON shape; it is that status reads do not
+    start capture and still surface capture truth when present.
+    """
+
+    for key in ("capture", "camera", "status", "capture_status"):
+        value = data.get(key)
+        if isinstance(value, dict):
+            return value
+    return data
+
+
+def test_camera_status_truth_markers_are_exported():
+    assert camera_router.CAMERA_STATUS_TRUTH_CONTRACT is True
+    assert camera_router.CAMERA_STATUS_TRUTH_ROLE == "non_activating_camera_runtime_status_surface"
+    assert camera_router.CAMERA_STATUS_DOES_NOT_START_CAPTURE is True
+
+    assert camera_capture.CAMERA_CAPTURE_STATUS_TRUTH_CONTRACT is True
+    assert camera_capture.CAMERA_CAPTURE_STATUS_ROLE == "capture_state_truth_provider"
+    assert camera_capture.CAMERA_CAPTURE_STATUS_DOES_NOT_OPEN_DEVICE is True
+
+
+def test_camera_status_route_reads_status_without_starting_capture():
+    fake = FakeCapture()
+    app = FastAPI()
+    app.include_router(get_router(fake, 30, enabled=False, imx500_runner=None))
+
+    data = TestClient(app).get("/status").json()
+    capture_status = _nested_status_payload(data)
+
+    assert fake.status_calls == 1
+    assert fake.start_calls == 0
+    assert fake.stop_calls == 0
+    assert data["enabled"] is False
+
+    # Router schemas may nest the capture state, but when the capture state is
+    # surfaced it must reflect the fake status without activating capture.
+    assert capture_status.get("running", False) is False
+    assert capture_status.get("has_frame", False) is False
+    if "device" in capture_status:
+        assert capture_status["device"] == "/dev/video0"
+
+
+def test_camera_status_and_healthz_routes_are_get_only_truth_surfaces():
+    source = ROUTER_SOURCE.read_text(encoding="utf-8")
+    assert '.get("/status")' in source or ".get('/status')" in source
+    assert '.get("/healthz")' in source or ".get('/healthz')" in source
+
+
+def test_camera_status_truth_contract_does_not_add_import_time_capture():
+    for path in [ROUTER_SOURCE, CAPTURE_SOURCE]:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        forbidden_top_level = []
+        for node in tree.body:
+            value = None
+            if isinstance(node, ast.Expr):
+                value = node.value
+            elif isinstance(node, ast.Assign):
+                value = node.value
+            if not isinstance(value, ast.Call):
+                continue
+            name = ""
+            if isinstance(value.func, ast.Name):
+                name = value.func.id
+            elif isinstance(value.func, ast.Attribute):
+                name = value.func.attr
+            if name in {"VideoCapture", "start", "open", "read", "snapshot"}:
+                forbidden_top_level.append((path.name, name, node.lineno))
+        assert forbidden_top_level == []

--- a/tests/modules/camera/test_pi_camera_backend_order.py
+++ b/tests/modules/camera/test_pi_camera_backend_order.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from modules.camera.services import capture
+
+
+class FakeCv2:
+    CAP_DSHOW = 700
+    CAP_MSMF = 1400
+    CAP_V4L2 = 200
+    CAP_ANY = 0
+
+
+def test_pi_linux_backend_order_prefers_v4l2_and_excludes_dshow():
+    backends = capture._opencv_robot_backend_candidates(FakeCv2, os_name="posix")
+    assert backends[0] == FakeCv2.CAP_V4L2
+    assert FakeCv2.CAP_ANY in backends
+    assert FakeCv2.CAP_DSHOW not in backends
+    assert FakeCv2.CAP_MSMF not in backends
+
+
+def test_windows_backend_kept_only_as_pc_dev_fallback():
+    backends = capture._opencv_robot_backend_candidates(FakeCv2, os_name="nt")
+    assert backends[0] == FakeCv2.CAP_DSHOW
+    assert FakeCv2.CAP_ANY in backends
+
+
+def test_backend_helper_accepts_missing_backend_constants():
+    class MinimalCv2:
+        CAP_ANY = 0
+
+    assert capture._opencv_robot_backend_candidates(MinimalCv2, os_name="posix") == [None, 0, None]

--- a/tests/modules/vlm_bridge/test_no_unused_vlm_stub.py
+++ b/tests/modules/vlm_bridge/test_no_unused_vlm_stub.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCAN_ROOTS = ["modules", "apps", "services", "config"]
+FORBIDDEN_REFERENCES = [
+    "modules.vlm_bridge.services.stub",
+    "vlm_bridge.services.stub",
+    "from .stub",
+    "import stub",
+    "services/stub.py",
+    "services\\stub.py",
+]
+
+
+def _runtime_files():
+    suffixes = {".py", ".json", ".yml", ".yaml", ".md", ".toml", ".ini"}
+    for root_name in SCAN_ROOTS:
+        root = ROOT / root_name
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file() or path.suffix.lower() not in suffixes:
+                continue
+            if any(part in {".venv", "__pycache__", ".pytest_cache"} for part in path.parts):
+                continue
+            yield path
+
+
+def test_unused_vlm_stub_file_removed():
+    assert not (ROOT / "modules/vlm_bridge/services/stub.py").exists()
+
+
+def test_no_runtime_reference_to_unused_vlm_stub():
+    hits = []
+    for path in _runtime_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for needle in FORBIDDEN_REFERENCES:
+            if needle in text:
+                hits.append(f"{path.relative_to(ROOT).as_posix()} contains {needle}")
+    assert hits == []

--- a/tests/modules/vlm_bridge/test_remote_multimodal_task_split.py
+++ b/tests/modules/vlm_bridge/test_remote_multimodal_task_split.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from modules.vlm_bridge.services.processor import VisionProcessor
+
+
+def test_remote_multimodal_endpoint_split_defaults_from_base_endpoint():
+    p = VisionProcessor({
+        "vision": {"processing_mode": "remote"},
+        "vision_llm": {"enabled": False},
+        "remote_multimodal": {
+            "enabled": True,
+            "endpoint": "http://pc:8091/vision/analyze",
+        },
+    })
+    assert p._remote_multimodal_endpoint_for(False).endswith("/vision/analyze/cheap")
+    assert p._remote_multimodal_endpoint_for(True).endswith("/vision/analyze/semantic")
+
+
+def test_remote_multimodal_endpoint_split_honors_explicit_config():
+    p = VisionProcessor({
+        "vision": {"processing_mode": "remote"},
+        "vision_llm": {"enabled": False},
+        "remote_multimodal": {
+            "enabled": True,
+            "endpoint": "http://pc:8091/vision/analyze",
+            "cheap_endpoint": "http://pc:8091/custom/cheap",
+            "semantic_endpoint": "http://pc:8091/custom/semantic",
+        },
+    })
+    assert p._remote_multimodal_endpoint_for(False) == "http://pc:8091/custom/cheap"
+    assert p._remote_multimodal_endpoint_for(True) == "http://pc:8091/custom/semantic"

--- a/tests/modules/vlm_bridge/test_vision_request_gate.py
+++ b/tests/modules/vlm_bridge/test_vision_request_gate.py
@@ -1,0 +1,36 @@
+from modules.vlm_bridge.services.vision_request_gate import VisionRequestGate
+
+
+def test_gate_allows_first_request_and_blocks_inflight():
+    gate = VisionRequestGate({"max_inflight": 1, "reason_cooldowns_s": {"scene_change": 10}})
+    first = gate.decide(reason="scene_change", scene_key="a", now=100.0)
+    assert first.allowed is True
+    gate.mark_start(first.request_id, reason="scene_change")
+    second = gate.decide(reason="scene_change", scene_key="b", now=101.0)
+    assert second.allowed is False
+    assert second.mode == "inflight"
+    gate.mark_finish(first.request_id, ok=True)
+    stats = gate.get_stats()
+    assert stats["stats"]["approved"] == 1
+    assert stats["stats"]["denied"] == 1
+
+
+def test_gate_uses_cooldown_and_cache_hint():
+    gate = VisionRequestGate({"reason_cooldowns_s": {"boredom": 30}, "cache_ttl_s": 45})
+    first = gate.decide(reason="boredom", scene_key="room", now=10.0)
+    assert first.allowed is True
+    second = gate.decide(reason="boredom", scene_key="room", has_cache=True, cache_age_s=12.0, now=20.0)
+    assert second.allowed is False
+    assert second.mode == "cooldown"
+    assert second.use_cache is True
+    assert second.wait_s > 0
+
+
+def test_user_question_force_bypasses_cooldown_after_finish():
+    gate = VisionRequestGate({"reason_cooldowns_s": {"user_question": 60}})
+    first = gate.decide(reason="user_question", force=True, now=1.0)
+    assert first.allowed is True
+    gate.mark_start(first.request_id)
+    gate.mark_finish(first.request_id)
+    second = gate.decide(reason="user_question", force=True, now=2.0)
+    assert second.allowed is True

--- a/tests/modules/vlm_bridge/test_vision_semantic_budget.py
+++ b/tests/modules/vlm_bridge/test_vision_semantic_budget.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from modules.vlm_bridge.services.processor import VisionProcessor
+
+
+def test_remote_tasks_strip_semantic_scene_when_budget_not_allowed():
+    p = VisionProcessor({
+        "vision": {
+            "processing_mode": "remote",
+            "mode_categories": {
+                "remote": {
+                    "objects": True,
+                    "people": True,
+                    "faces": True,
+                    "hazards": True,
+                    "semantic_scene": True,
+                }
+            },
+        },
+        "vision_llm": {"enabled": False},
+        "vision_semantic_budget": {"enabled": True},
+    })
+    cheap = p._remote_requested_tasks(run_semantic_vlm=False)
+    semantic = p._remote_requested_tasks(run_semantic_vlm=True)
+    assert "semantic_scene" not in cheap
+    assert "semantic_scene" in semantic
+    assert "hazards" in cheap
+
+
+def test_semantic_budget_reasons_default_to_user_hazard_not_scene_change():
+    p = VisionProcessor({"vision_llm": {"enabled": False}})
+    assert p._semantic_budget_allows(question="what is here", reason="scene_change") is True
+    assert p._semantic_budget_allows(question="", reason="hazard") is True
+    assert p._semantic_budget_allows(question="", reason="new_person") is True
+    assert p._semantic_budget_allows(question="", reason="scene_change") is False
+    assert p._semantic_budget_allows(question="", reason="idle_refresh") is False

--- a/tests/modules/vlm_bridge/test_vlm_budget_gate_integration_contract.py
+++ b/tests/modules/vlm_bridge/test_vlm_budget_gate_integration_contract.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.vlm_bridge.services.budgeted_inference import (
+    VLM_BUDGET_GATE_INTEGRATION_CONTRACT,
+    VLM_BUDGET_GATE_INTEGRATION_DEFAULT_NO_INFERENCE,
+    VLM_BUDGET_GATE_INTEGRATION_ROLE,
+    BudgetedVLMExecutor,
+    build_budgeted_vlm_executor,
+)
+from modules.vlm_bridge.services.inference_budget import VLMInferenceBudgetGate
+
+
+SOURCE_PATH = Path("modules/vlm_bridge/services/budgeted_inference.py")
+
+
+def _root_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id.lower()
+    if isinstance(node, ast.Attribute):
+        return _root_name(node.value)
+    if isinstance(node, ast.Call):
+        return _root_name(node.func)
+    return ""
+
+
+def test_vlm_budget_gate_integration_contract_markers():
+    assert VLM_BUDGET_GATE_INTEGRATION_CONTRACT is True
+    assert VLM_BUDGET_GATE_INTEGRATION_ROLE == "budget_gate_required_before_vlm_callable"
+    assert VLM_BUDGET_GATE_INTEGRATION_DEFAULT_NO_INFERENCE is True
+
+
+def test_default_executor_denies_without_calling_inference():
+    calls = []
+
+    def fake_inference(payload):
+        calls.append(payload)
+        return {"ok": True}
+
+    executor = BudgetedVLMExecutor(inference_callable=fake_inference)
+    result = executor.run({"frame_ref": "already_captured_elsewhere"}, now=10.0).as_dict()
+
+    assert result["allowed"] is False
+    assert result["reason"] == "disabled"
+    assert result["inference_called"] is False
+    assert result["activation_started"] is False
+    assert result["camera_started"] is False
+    assert result["frame_captured"] is False
+    assert result["hardware_enabled"] is False
+    assert calls == []
+
+
+def test_enabled_gate_calls_injected_callable_once_after_reserve():
+    calls = []
+
+    def fake_inference(payload):
+        calls.append(payload)
+        return {"caption": "safe semantic result"}
+
+    gate = VLMInferenceBudgetGate(enabled=True, max_requests_per_minute=2, min_interval_s=0.0)
+    executor = BudgetedVLMExecutor(gate=gate, inference_callable=fake_inference)
+
+    result = executor.run({"context_id": "abc"}, now=20.0).as_dict()
+
+    assert result["allowed"] is True
+    assert result["reason"] == "inference_completed"
+    assert result["inference_called"] is True
+    assert result["result"] == {"caption": "safe semantic result"}
+    assert calls == [{"context_id": "abc"}]
+
+
+def test_budget_denial_prevents_callable_execution():
+    calls = []
+
+    def fake_inference(payload):
+        calls.append(payload)
+        return {"ok": True}
+
+    gate = VLMInferenceBudgetGate(enabled=True, max_requests_per_minute=1, min_interval_s=0.0)
+    executor = BudgetedVLMExecutor(gate=gate, inference_callable=fake_inference)
+
+    first = executor.run({"n": 1}, now=1.0).as_dict()
+    second = executor.run({"n": 2}, now=2.0).as_dict()
+
+    assert first["allowed"] is True
+    assert second["allowed"] is False
+    assert second["reason"] == "request_budget_exhausted"
+    assert calls == [{"n": 1}]
+
+
+def test_missing_callable_is_safe_and_records_no_inference_call():
+    gate = VLMInferenceBudgetGate(enabled=True, max_requests_per_minute=2, min_interval_s=0.0)
+    executor = BudgetedVLMExecutor(gate=gate, inference_callable=None)
+
+    result = executor.run({"context_id": "abc"}, now=30.0).as_dict()
+
+    assert result["allowed"] is False
+    assert result["reason"] == "inference_callable_missing"
+    assert result["inference_called"] is False
+    assert result["camera_started"] is False
+    assert result["frame_captured"] is False
+
+
+def test_builder_uses_disabled_budget_config_by_default():
+    executor = build_budgeted_vlm_executor()
+    result = executor.run({"x": 1}, now=40.0).as_dict()
+
+    assert result["allowed"] is False
+    assert result["reason"] == "disabled"
+    assert result["inference_called"] is False
+
+
+def test_budgeted_inference_source_has_no_camera_network_or_endpoint_calls():
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0].lower()
+                if root in {"cv2", "requests", "httpx", "ollama"}:
+                    forbidden.append((alias.name, node.lineno))
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".", 1)[0].lower()
+            if root in {"cv2", "requests", "httpx", "ollama"}:
+                forbidden.append((node.module, node.lineno))
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in {"VideoCapture"}:
+                forbidden.append((node.func.id, node.lineno))
+            elif isinstance(node.func, ast.Attribute):
+                root = _root_name(node.func.value)
+                attr = node.func.attr
+                if root in {"requests", "httpx"} and attr in {"get", "post", "request", "send"}:
+                    forbidden.append((f"{root}.{attr}", node.lineno))
+                if root == "ollama" and attr in {"generate", "chat"}:
+                    forbidden.append((f"{root}.{attr}", node.lineno))
+                if attr in {"read", "imshow"}:
+                    forbidden.append((attr, node.lineno))
+
+    assert forbidden == []
+    for endpoint in ["/camera/start", "/camera/snap", "/camera/video", "/vlm/analyze", "/vlm/caption"]:
+        assert endpoint not in source

--- a/tests/modules/vlm_bridge/test_vlm_inference_budget_gate_contract.py
+++ b/tests/modules/vlm_bridge/test_vlm_inference_budget_gate_contract.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.vlm_bridge.services.inference_budget import (
+    VLM_INFERENCE_BUDGET_GATE_CONTRACT,
+    VLM_INFERENCE_BUDGET_GATE_ROLE,
+    VLM_INFERENCE_BUDGET_GATE_STATUS_ONLY_SAFE,
+    VLMInferenceBudgetGate,
+    build_vlm_inference_budget_gate,
+)
+
+
+SOURCE_PATH = Path("modules/vlm_bridge/services/inference_budget.py")
+
+
+def _root_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id.lower()
+    if isinstance(node, ast.Attribute):
+        return _root_name(node.value)
+    if isinstance(node, ast.Call):
+        return _root_name(node.func)
+    return ""
+
+
+def test_budget_gate_defaults_to_disabled_and_status_only_safe():
+    gate = build_vlm_inference_budget_gate()
+    decision = gate.check(now=10.0)
+
+    assert VLM_INFERENCE_BUDGET_GATE_CONTRACT is True
+    assert VLM_INFERENCE_BUDGET_GATE_ROLE == "pre_inference_rate_budget_and_circuit_gate"
+    assert VLM_INFERENCE_BUDGET_GATE_STATUS_ONLY_SAFE is True
+    assert decision.allowed is False
+    assert decision.reason == "disabled"
+    assert gate.status(now=10.0)["activation_started"] is False
+
+
+def test_budget_gate_reserve_enforces_cooldown_without_inference():
+    gate = VLMInferenceBudgetGate(enabled=True, max_requests_per_minute=2, min_interval_s=5.0)
+    first = gate.reserve(now=100.0)
+    second = gate.reserve(now=101.0)
+    third = gate.reserve(now=106.0)
+
+    assert first.allowed is True
+    assert second.allowed is False
+    assert second.reason == "cooldown"
+    assert second.retry_after_s == 4.0
+    assert third.allowed is True
+
+
+def test_budget_gate_enforces_rate_and_cost_budget():
+    gate = VLMInferenceBudgetGate(
+        enabled=True,
+        max_requests_per_minute=2,
+        max_cost_units_per_minute=2.0,
+        min_interval_s=0.0,
+    )
+    assert gate.reserve(cost_units=1.5, now=1.0).allowed is True
+    assert gate.reserve(cost_units=1.0, now=2.0).allowed is False
+    assert gate.check(cost_units=1.0, now=2.0).reason == "cost_budget_exhausted"
+
+
+def test_budget_gate_circuit_breaker_after_failures():
+    gate = VLMInferenceBudgetGate(enabled=True, max_consecutive_failures=2, min_interval_s=0.0)
+    gate.record_failure()
+    assert gate.check(now=1.0).allowed is True
+    gate.record_failure()
+    decision = gate.check(now=2.0)
+    assert decision.allowed is False
+    assert decision.reason == "circuit_open_after_failures"
+    gate.record_success()
+    assert gate.check(now=3.0).allowed is True
+
+
+def test_budget_gate_source_has_no_executable_camera_network_or_inference_start():
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    forbidden_import_roots = {"cv2", "requests", "httpx", "ollama"}
+    imports = []
+    calls = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0].lower()
+                if root in forbidden_import_roots:
+                    imports.append((alias.name, node.lineno))
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".", 1)[0].lower()
+            if root in forbidden_import_roots:
+                imports.append((node.module, node.lineno))
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                if node.func.id in {"VideoCapture"}:
+                    calls.append((node.func.id, node.lineno))
+            elif isinstance(node.func, ast.Attribute):
+                root = _root_name(node.func.value)
+                attr = node.func.attr
+                if root == "cv2" and attr == "VideoCapture":
+                    calls.append((f"{root}.{attr}", node.lineno))
+                if root in {"requests", "httpx"} and attr in {"get", "post", "request", "send"}:
+                    calls.append((f"{root}.{attr}", node.lineno))
+                if root == "ollama" and attr in {"generate", "chat"}:
+                    calls.append((f"{root}.{attr}", node.lineno))
+
+    assert imports == []
+    assert calls == []
+
+    forbidden_runtime_endpoints = [
+        "/camera/start",
+        "/camera/snap",
+        "/camera/video",
+        "/vlm/analyze",
+        "/vlm/caption",
+    ]
+    for endpoint in forbidden_runtime_endpoints:
+        assert endpoint not in source

--- a/tests/modules/vlm_bridge/test_vlm_legacy_compatibility_contract.py
+++ b/tests/modules/vlm_bridge/test_vlm_legacy_compatibility_contract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import types
+
+from modules.vlm_bridge.services import processor
+from modules.vlm_bridge.services.llm_client import (
+    VLM_LLM_LEGACY_ENDPOINT_COMPATIBILITY_CONTRACT,
+    VLM_LLM_LEGACY_ENDPOINT_ROLE,
+    _derive_chat_endpoint_from_base_url,
+    _is_legacy_generate_endpoint,
+)
+from modules.vlm_bridge.services.people_memory import (
+    PeopleMemory,
+    VLM_PEOPLE_MEMORY_COMPATIBILITY_CONTRACT,
+    VLM_PEOPLE_MEMORY_ROLE,
+)
+from modules.vlm_bridge.services.person_identity import (
+    PersonIdentityManager,
+    VLM_PERSON_IDENTITY_COMPATIBILITY_CONTRACT,
+    VLM_PERSON_IDENTITY_ROLE,
+)
+
+
+def test_vlm_llm_legacy_generate_endpoint_is_explicit_compatibility():
+    assert VLM_LLM_LEGACY_ENDPOINT_COMPATIBILITY_CONTRACT is True
+    assert VLM_LLM_LEGACY_ENDPOINT_ROLE == "ollama_generate_to_chat_compatibility_adapter"
+    assert _is_legacy_generate_endpoint("http://127.0.0.1:11434/api/generate") is True
+    assert _is_legacy_generate_endpoint("http://127.0.0.1:11434/api/chat") is False
+    assert _derive_chat_endpoint_from_base_url("http://127.0.0.1:11434/api/tags").endswith("/api/chat")
+
+
+def test_people_memory_json_path_is_backward_compatibility_store(tmp_path):
+    assert VLM_PEOPLE_MEMORY_COMPATIBILITY_CONTRACT is True
+    assert VLM_PEOPLE_MEMORY_ROLE == "social_db_primary_json_backward_compatibility_store"
+    memory = PeopleMemory(data_dir=str(tmp_path), filename="people_memory.json", social_db=None)
+    memory.append_chat("Emir", "user", "merhaba")
+    memory.set_summary("Emir", "owner profile")
+    reloaded = PeopleMemory(data_dir=str(tmp_path), filename="people_memory.json", social_db=None)
+    rec = reloaded.get_person("Emir")
+    assert rec is not None
+    assert rec["chats"][0]["text"] == "merhaba"
+    assert rec["last_summary"]["text"] == "owner profile"
+
+
+def test_person_identity_json_path_is_backward_compatibility_store(tmp_path):
+    assert VLM_PERSON_IDENTITY_COMPATIBILITY_CONTRACT is True
+    assert VLM_PERSON_IDENTITY_ROLE == "social_db_primary_person_json_compatibility_store"
+    store = tmp_path / "person_identity.json"
+    manager = PersonIdentityManager(store_path=str(store), social_db=None)
+    rec = manager.remember_person("Emir", relationship="owner", recognition_level=5)
+    assert rec.owner_priority is True
+    reloaded = PersonIdentityManager(store_path=str(store), social_db=None)
+    assert reloaded.is_owner("Emir") is True
+
+
+def test_processor_cv2_legacy_tracker_is_explicit_compatibility(monkeypatch):
+    assert processor.VLM_PROCESSOR_LEGACY_COMPATIBILITY_CONTRACT is True
+    assert processor.VLM_PROCESSOR_LEGACY_COMPATIBILITY_ROLE == "opencv_api_and_cached_context_compatibility"
+
+    class ModernCV2:
+        @staticmethod
+        def TrackerCSRT_create():
+            return "modern"
+
+    monkeypatch.setattr(processor, "cv2", ModernCV2)
+    assert processor._create_csrt_tracker() == "modern"
+
+    legacy = types.SimpleNamespace(TrackerCSRT_create=lambda: "legacy")
+    monkeypatch.setattr(processor, "cv2", types.SimpleNamespace(legacy=legacy))
+    assert processor._create_csrt_tracker() == "legacy"


### PR DESCRIPTION
## Summary
- Add VLM budget accounting + request gate; remove unused stub.
- Extend remote multimodal semantic budget / task-split endpoints.
- Improve camera IMX500 status truth, tracking, and contracts.

## Change type
- [x] Feature / chore / docs (see title)
- [ ] Bug fix

## Affected modules
`modules/vlm_bridge`, `modules/camera`, `services/remote_multimodal_server`

## Test plan
- [ ] VLM budget/gate tests pass
- [ ] Camera status truth contracts pass
- [ ] Remote multimodal semantic budget tests pass

## Notes
- Stacked PR: merge order is 1 → 9. Base is `feat/expression-module` until the previous PR lands; then retarget to `dev`.
- Gateway API keys from local WIP were intentionally not committed (kept empty).
- Backup snapshot: `backup/pre-split-20260718` / `refs/backup/pre-split-20260718`

## Risk / rollback
Revert this branch or close the PR; no production deploy assumed until Pi deploy PR is merged and tested.