### PR TITLE
feat(audio): TTS/STT/Ollama truth and wakeword asset alignment

### DIFF
--- a/modules/ollama/api/chat_routes.py
+++ b/modules/ollama/api/chat_routes.py
@@ -7,6 +7,47 @@ import requests
 logger = logging.getLogger("ollama.api")
 
 
+def _safe_llm_exc_text(exc: Exception) -> str:
+    try:
+        from modules.config_center.log_redact import redact_secrets
+
+        return redact_secrets(str(exc))[:500]
+    except Exception:
+        return str(exc)[:500]
+
+
+def _is_llm_not_found(exc: Exception) -> bool:
+    msg = _safe_llm_exc_text(exc).lower()
+    return (
+        "404" in msg
+        or "not found" in msg
+        or "model not found" in msg
+        or "status code: 404" in msg
+    )
+
+
+def _llm_unavailable_payload(
+    *,
+    provider_name: str,
+    model: str,
+    active_persona: str,
+    detail: str,
+    reason: str = "llm_model_unavailable",
+) -> Dict[str, Any]:
+    return {
+        "ok": False,
+        "answer": "",
+        "text": "",
+        "thoughts": "",
+        "persona": active_persona,
+        "model": model,
+        "provider": provider_name,
+        "error": reason,
+        "reason": reason,
+        "detail": detail,
+    }
+
+
 def get_chat_router(
     chat: Any,
     translator: Any,
@@ -69,12 +110,28 @@ def get_chat_router(
         try:
             result = chat.chat(query_en)
         except requests.HTTPError as exc:
-            from modules.config_center.log_redact import redact_secrets
-
-            logger.warning("LLM upstream request failed: %s", redact_secrets(exc))
+            detail = _safe_llm_exc_text(exc)
+            if _is_llm_not_found(exc):
+                logger.info("LLM chat unavailable; using fallback path: %s", detail)
+                return _llm_unavailable_payload(
+                    provider_name=provider_name,
+                    model=model,
+                    active_persona=active_persona,
+                    detail=detail,
+                )
+            logger.warning("LLM upstream request failed: %s", detail)
             raise HTTPException(status_code=502, detail="LLM upstream request failed") from exc
         except Exception as exc:
-            logger.exception("LLM chat failed: %s", exc)
+            detail = _safe_llm_exc_text(exc)
+            if _is_llm_not_found(exc):
+                logger.info("LLM chat unavailable; using fallback path: %s", detail)
+                return _llm_unavailable_payload(
+                    provider_name=provider_name,
+                    model=model,
+                    active_persona=active_persona,
+                    detail=detail,
+                )
+            logger.exception("LLM chat failed: %s", detail)
             raise HTTPException(status_code=500, detail="LLM chat failed") from exc
 
         answer_en = str(result.get("text", ""))

--- a/modules/ollama/api/health.py
+++ b/modules/ollama/api/health.py
@@ -8,6 +8,38 @@ import requests
 logger = logging.getLogger("ollama.api")
 
 
+def _model_name_matches(available: list[str], wanted: str) -> bool:
+    target = str(wanted or "").strip()
+    if not target or target == "unknown":
+        return True
+    candidates = {target, target.split(":", 1)[0], f"{target}:latest"}
+    normalized = set()
+    for name in available:
+        n = str(name or "").strip()
+        if not n:
+            continue
+        normalized.add(n)
+        normalized.add(n.split(":", 1)[0])
+    return any(c in normalized for c in candidates)
+
+
+def _normalize_ollama_daemon_base_url(raw: Any) -> tuple[str, str]:
+    configured = str(raw or "").strip().rstrip("/")
+    value = configured
+    lowered = value.lower()
+    if (
+        not value
+        or "@gateway" in lowered
+        or lowered in {"http://127.0.0.1:8080", "http://localhost:8080"}
+        or lowered.startswith("http://127.0.0.1:8080/")
+        or lowered.startswith("http://localhost:8080/")
+        or lowered.endswith("/ollama")
+        or lowered.endswith("/ollama/chat")
+    ):
+        value = "http://127.0.0.1:11434"
+    return value, configured
+
+
 def get_health_router(cfg: dict, provider_name: str, model: str) -> APIRouter:
     r = APIRouter(tags=["ollama-health"])
 
@@ -15,14 +47,34 @@ def get_health_router(cfg: dict, provider_name: str, model: str) -> APIRouter:
     def healthz():
         info: Dict[str, Any] = {"ok": True, "provider": provider_name, "model": model}
         if provider_name == "ollama":
-            base = str(cfg.get("ollama", {}).get("base_url", "http://127.0.0.1:11434")).rstrip("/")
+            base, configured_base = _normalize_ollama_daemon_base_url(cfg.get("ollama", {}).get("base_url", "http://127.0.0.1:11434"))
             info["base_url"] = base
+            if configured_base and configured_base != base:
+                info["configured_base_url"] = configured_base
+                info["base_url_corrected"] = True
             try:
                 resp = requests.get(f"{base}/api/tags", timeout=2.0)
                 info["daemon_ok"] = resp.status_code == 200
-                info["ok"] = bool(info["daemon_ok"])
+                names: list[str] = []
+                if resp.status_code == 200:
+                    try:
+                        data = resp.json() if resp.content else {}
+                    except Exception:
+                        data = {}
+                    items = data.get("models", []) if isinstance(data, dict) else []
+                    for item in items:
+                        if isinstance(item, dict) and item.get("name"):
+                            names.append(str(item.get("name")))
+                info["models_count"] = len(names)
+                info["model_available"] = _model_name_matches(names, model)
+                info["ok"] = bool(info["daemon_ok"] and info["model_available"])
+                if info["daemon_ok"] and not info["model_available"]:
+                    info["error"] = "ollama_model_missing"
+                    info["expected_model"] = model
+                    info["available_models"] = names[:20]
             except Exception as exc:
                 info["daemon_ok"] = False
+                info["model_available"] = False
                 info["ok"] = False
                 info["error"] = str(exc)
         elif provider_name == "google_ai_studio":

--- a/modules/ollama/config_loader.py
+++ b/modules/ollama/config_loader.py
@@ -55,7 +55,24 @@ def _pick_model(agent_cfg: Dict[str, Any], llm_cfg: Dict[str, Any], ollama_cfg: 
 
 
 def _normalize_base_url(raw: Any) -> str:
-    return str(raw or "").strip().rstrip("/")
+    value = str(raw or "").strip().rstrip("/")
+    env_override = str(os.getenv("SENTRYBOT_OLLAMA_BASE_URL") or os.getenv("OLLAMA_BASE_URL") or "").strip().rstrip("/")
+    if env_override:
+        value = env_override
+    lowered = value.lower()
+    # The gateway usually runs on 8080. It is not the Ollama daemon.
+    # Accidentally probing http://127.0.0.1:8080/api/tags creates false 404/self-call failures.
+    if (
+        not value
+        or "@gateway" in lowered
+        or lowered in {"http://127.0.0.1:8080", "http://localhost:8080"}
+        or lowered.startswith("http://127.0.0.1:8080/")
+        or lowered.startswith("http://localhost:8080/")
+        or lowered.endswith("/ollama")
+        or lowered.endswith("/ollama/chat")
+    ):
+        return "http://127.0.0.1:11434"
+    return value
 
 
 def load_config(config_path: str | None = None) -> Dict[str, Any]:
@@ -98,6 +115,8 @@ def load_config(config_path: str | None = None) -> Dict[str, Any]:
                 "base_url": _normalize_base_url(
                     agent_cfg.get("ollama_base_url")
                     or ollama_global.get("base_url")
+                    or os.getenv("SENTRYBOT_OLLAMA_BASE_URL")
+                    or os.getenv("OLLAMA_BASE_URL")
                     or os.getenv("AGENT_OLLAMA_BASE_URL")
                     or "http://127.0.0.1:11434"
                 ),
@@ -116,6 +135,8 @@ def load_config(config_path: str | None = None) -> Dict[str, Any]:
             agent_cfg.get("ollama_base_url")
             or llm_cfg.get("base_url")
             or ollama_global.get("base_url")
+            or os.getenv("SENTRYBOT_OLLAMA_BASE_URL")
+            or os.getenv("OLLAMA_BASE_URL")
             or os.getenv("AGENT_OLLAMA_BASE_URL")
             or "http://127.0.0.1:11434"
         )

--- a/modules/ollama/services/clients.py
+++ b/modules/ollama/services/clients.py
@@ -38,9 +38,25 @@ def _sanitize_google_api_key(raw_value: Any) -> str:
     return value
 
 
+def _normalize_ollama_daemon_base_url(raw: Any) -> str:
+    value = str(raw or "").strip().rstrip("/")
+    lowered = value.lower()
+    if (
+        not value
+        or "@gateway" in lowered
+        or lowered in {"http://127.0.0.1:8080", "http://localhost:8080"}
+        or lowered.startswith("http://127.0.0.1:8080/")
+        or lowered.startswith("http://localhost:8080/")
+        or lowered.endswith("/ollama")
+        or lowered.endswith("/ollama/chat")
+    ):
+        return "http://127.0.0.1:11434"
+    return value
+
+
 class OllamaClient:
     def __init__(self, base_url: str, model: str, request_timeout: float = 60.0) -> None:
-        self.base_url = base_url.rstrip("/")
+        self.base_url = _normalize_ollama_daemon_base_url(base_url)
         self.model = model
         self.timeout = request_timeout
 

--- a/modules/speak/api/router.py
+++ b/modules/speak/api/router.py
@@ -1,161 +1,157 @@
 from __future__ import annotations
-from fastapi import APIRouter
-from typing import TYPE_CHECKING
+
 import asyncio
+import base64
 import logging
 import re
 import time
 import uuid
+from typing import TYPE_CHECKING, Any, Dict
+
+from fastapi import APIRouter
+
+from modules.common.latency_trace import latency_trace
 
 if TYPE_CHECKING:
     from modules.speak.xSpeakService import SpeakService
 
-
 logger = logging.getLogger("speak.api")
+
+
+def _split_text_chunks(text: str, max_chars: int = 180) -> list[str]:
+    raw = str(text or "").strip()
+    if not raw:
+        return []
+    parts = [part.strip() for part in re.split(r"(?<=[.!?…])\s+", raw) if part.strip()]
+    chunks: list[str] = []
+    for part in parts:
+        words = part.split()
+        buffer: list[str] = []
+        for word in words:
+            candidate = " ".join(buffer + [word])
+            if buffer and len(candidate) > max_chars:
+                chunks.append(" ".join(buffer))
+                buffer = [word]
+            else:
+                buffer.append(word)
+        if buffer:
+            chunks.append(" ".join(buffer))
+    return chunks
+
 
 def get_router(service: SpeakService) -> APIRouter:
     router = APIRouter()
-    stream_jobs: dict[str, dict] = {}
-
-    def _split_text_chunks(text: str, max_chars: int = 180) -> list[str]:
-        raw = str(text or "").strip()
-        if not raw:
-            return []
-        parts = [p.strip() for p in re.split(r"(?<=[.!?])\s+", raw) if p.strip()]
-        chunks: list[str] = []
-        for part in parts:
-            if len(part) <= max_chars:
-                chunks.append(part)
-                continue
-            # Long sentence fallback: hard wrap by words.
-            words = part.split()
-            buf = []
-            for w in words:
-                candidate = (" ".join(buf + [w])).strip()
-                if len(candidate) > max_chars and buf:
-                    chunks.append(" ".join(buf))
-                    buf = [w]
-                else:
-                    buf.append(w)
-            if buf:
-                chunks.append(" ".join(buf))
-        return chunks
+    stream_jobs: Dict[str, Dict[str, Any]] = {}
 
     @router.get("/speak/status")
-    async def status():
-        return {"ready": getattr(service, "tts", None) is not None}
+    async def status() -> Dict[str, Any]:
+        health = service.tts.health()
+        return {"ready": bool(health.get("available", False)), "tts": health}
+
+    @router.get("/speak/latency/latest")
+    async def latest_latency() -> Dict[str, Any]:
+        trace = latency_trace.latest()
+        return {"ok": trace is not None, "trace": trace}
+
+    @router.get("/speak/latency/{trace_id}")
+    async def latency(trace_id: str) -> Dict[str, Any]:
+        trace = latency_trace.get(trace_id)
+        return {"ok": trace is not None, "trace": trace}
 
     @router.post("/speak/stop")
-    async def stop():
-        """Stop in-progress TTS playback immediately."""
-        try:
-            return await asyncio.to_thread(service.stop_speaking)
-        except Exception as e:
-            logger.exception("/speak/stop failed")
-            return {"ok": False, "error": repr(e)}
+    async def stop() -> Dict[str, Any]:
+        return await asyncio.to_thread(service.stop_speaking)
 
     @router.post("/speak/say")
-    async def say(payload: dict):
+    async def say(payload: dict) -> Dict[str, Any]:
         text = str(payload.get("text", "")).strip()
-        engine = payload.get("engine")
-        tone = payload.get("tone")
-        speaker_wav = payload.get("speaker_wav")
-        language = payload.get("language")
         if not text:
             return {"ok": False, "error": "text is empty"}
-        
-        logger.info("TTS >>> %s (engine=%s)", text, engine or "default")
+        trace_id = str(payload.get("trace_id") or uuid.uuid4().hex[:16])
         try:
-            # Offload blocking TTS to thread to avoid event loop freeze
             return await asyncio.to_thread(
                 service.speak,
                 text,
-                engine=engine,
-                tone=tone,
-                speaker_wav=speaker_wav,
-                language=language,
+                engine=payload.get("engine"),
+                tone=payload.get("tone"),
+                speaker_wav=payload.get("speaker_wav"),
+                language=payload.get("language"),
+                trace_id=trace_id,
             )
-        except Exception as e:
+        except Exception as exc:
             logger.exception("/speak/say failed")
-            return {"ok": False, "error": repr(e)}
+            latency_trace.finish(trace_id, "failed", {"detail": repr(exc)})
+            return {"ok": False, "trace_id": trace_id, "error": repr(exc)}
 
     @router.post("/speak/say_stream")
-    async def say_stream(payload: dict):
-        """Start clause-chunked TTS in background for lower perceived latency."""
+    async def say_stream(payload: dict) -> Dict[str, Any]:
         text = str(payload.get("text", "")).strip()
-        engine = payload.get("engine")
-        tone = payload.get("tone")
-        speaker_wav = payload.get("speaker_wav")
-        language = payload.get("language")
-        max_chars = int(payload.get("max_chunk_chars", 180) or 180)
         if not text:
             return {"ok": False, "error": "text is empty"}
-
-        chunks = _split_text_chunks(text, max_chars=max_chars)
+        chunks = _split_text_chunks(text, max_chars=max(40, int(payload.get("max_chunk_chars", 180))))
         if not chunks:
             return {"ok": False, "error": "text has no speakable chunks"}
 
         job_id = uuid.uuid4().hex[:12]
+        trace_id = str(payload.get("trace_id") or uuid.uuid4().hex[:16])
+        latency_trace.ensure(trace_id, {"component": "speak.stream", "chunks": len(chunks)})
         stream_jobs[job_id] = {
             "status": "running",
             "created_at": time.time(),
             "done_chunks": 0,
             "total_chunks": len(chunks),
+            "trace_id": trace_id,
             "error": "",
         }
 
-        async def _run():
+        async def run() -> None:
             try:
                 from modules.speak.services.player import _play_stop
 
-                for idx, chunk in enumerate(chunks, start=1):
+                for index, chunk in enumerate(chunks, start=1):
                     if _play_stop.is_set():
-                        job = stream_jobs.get(job_id)
-                        if job is not None:
-                            job["status"] = "interrupted"
+                        stream_jobs[job_id]["status"] = "interrupted"
+                        latency_trace.finish(trace_id, "interrupted")
                         return
-                    await asyncio.to_thread(
+                    latency_trace.mark(trace_id, "tts.chunk_start", {"index": index})
+                    result = await asyncio.to_thread(
                         service.speak,
                         chunk,
-                        engine=engine,
-                        tone=tone,
-                        speaker_wav=speaker_wav,
-                        language=language,
+                        engine=payload.get("engine"),
+                        tone=payload.get("tone"),
+                        speaker_wav=payload.get("speaker_wav"),
+                        language=payload.get("language"),
+                        trace_id=trace_id,
                     )
-                    job = stream_jobs.get(job_id)
-                    if job is not None:
-                        job["done_chunks"] = idx
+                    if not result.get("ok"):
+                        raise RuntimeError(str(result.get("detail") or result.get("error") or "TTS failed"))
+                    stream_jobs[job_id]["done_chunks"] = index
+                stream_jobs[job_id]["status"] = "done"
             except Exception as exc:
-                job = stream_jobs.get(job_id)
-                if job is not None:
-                    job["status"] = "failed"
-                    job["error"] = repr(exc)
-                return
+                stream_jobs[job_id]["status"] = "failed"
+                stream_jobs[job_id]["error"] = repr(exc)
+                latency_trace.finish(trace_id, "failed", {"detail": repr(exc)})
 
-            job = stream_jobs.get(job_id)
-            if job is not None:
-                job["status"] = "done"
-
-        asyncio.create_task(_run())
-        return {"ok": True, "job_id": job_id, "chunks": len(chunks)}
+        asyncio.create_task(run())
+        return {"ok": True, "job_id": job_id, "trace_id": trace_id, "chunks": len(chunks)}
 
     @router.get("/speak/jobs/{job_id}")
-    async def job_status(job_id: str):
+    async def job_status(job_id: str) -> Dict[str, Any]:
         job = stream_jobs.get(str(job_id))
-        if not job:
-            return {"ok": False, "error": "job not found"}
-        return {"ok": True, "job": job}
+        return {"ok": job is not None, "job": job}
 
     @router.post("/speak/play")
-    async def play(payload: dict):
-        import base64
+    async def play(payload: dict) -> Dict[str, Any]:
         data_b64 = payload.get("data")
         if not data_b64:
             return {"ok": False, "error": "data (base64 WAV) is required"}
         try:
-            buf = base64.b64decode(data_b64)
-            return service.play_wav(buf)
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+            return await asyncio.to_thread(
+                service.play_wav,
+                base64.b64decode(data_b64),
+                trace_id=payload.get("trace_id"),
+            )
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
 
     return router

--- a/modules/speak/config/config.yml
+++ b/modules/speak/config/config.yml
@@ -1,37 +1,32 @@
-# Speak (TTS) module configuration
-
 server:
   host: 0.0.0.0
   port: 8083
-
 audio_out:
-  device: null          # ALSA device (e.g., sysdefault, hw:1,0). For MAX98357A via I2S set the correct ALSA card.
+  device: null
   samplerate: 22050
-  channels: 1           # MAX98357A is mono; driver may expose stereo. Upmix handled in code.
+  channels: 1
   dtype: float32
-
 tts:
-  engine: piper      # pyttsx3 | piper | xtts | dummy
+  engine: piper
+  allow_dummy_fallback: false
   language: tr
-  voice: source         # optional voice id — default olarak kaynak sesi kullanılacak
+  voice: source
   rate: 170
   volume: 1.0
   samplerate: 22050
-  # Piper ayarları
   piper:
-    bin_path: piper
     voice: tr
     auto_language: true
     prefer_text_language: false
     lock_session_language: true
-    # Dil için Piper sesi yoksa bu motorla seslendir (pyttsx3 | xtts | dummy).
-    fallback_engine: pyttsx3
+    fallback_engine: ''
+    preload_voices:
+    - tr
   language_voices:
     tr: tr
     en: glados
   model_path: data/piper_models/tr_TR-dfki-medium/tr_TR-dfki-medium.onnx
   config_path: data/piper_models/tr_TR-dfki-medium/tr_TR-dfki-medium.onnx.json
-  samplerate: 22050
   speaker: null
   length_scale: null
   noise_scale: null
@@ -43,60 +38,14 @@ tts:
     glados:
       model_path: data/piper_models/en-glados-medium/glados_piper_medium.onnx
       config_path: data/piper_models/en-glados-medium/glados_piper_medium.onnx.json
-
-  # XTTS ayarları (ayrı env'de çalışan local HTTP servis)
-  # Örn: PC üzerindeki server_app TTS proxy: http://PC_IP:5000/tts/synthesize
   xtts:
     endpoint: http://192.168.1.100:5000/tts/synthesize
     timeout: 120
     language: tr
-    speaker_wav: null          # ses kopyalama için referans wav yolu (opsiyonel)
-
+    speaker_wav: null
 liveliness:
   enabled: true
-  event_driven_effects: true
-  interactions_base_url: "@gateway/interactions"
-  speech_effect:
-    name: PULSE
-    tone_effect_map:
-      fast: COMET
-      neutral: PULSE
-      calm: BREATHE
-      tired: THEATER_CHASE
-    emphasis_effect_map:
-      exclamation: COMET
-      question: TWINKLE
-    rhythm:
-      enabled: false
-      mode: clauses           # words | clauses
-      effect: PULSE
-      words_per_beat: 3
-      clauses_per_beat: 1
-      max_beats: 4
-      duration_ms: 150
-      max_pause_marks: 4
-      pause_effect_map:
-        ",": TWINKLE
-        ";": TWINKLE
-        ":": BREATHE
-        ".": BREATHE
-    min_duration_ms: 400
-    max_duration_ms: 7000
-    chars_per_second: 16
-    force: false
-
-# Natural speech: light disfluency/filler injection so replies sound less robotic.
+  expression_base_url: '@gateway/expression'
+  event_timeout_s: 0.35
 naturalness:
-  enabled: true
-  filler_probability: 0.22   # chance to prepend a filler to an utterance
-  min_chars: 12              # skip very short replies (e.g. "Evet.")
-  fillers:
-    default: ["Şey,", "Yani,", "Hmm,"]
-    joy: ["Aa,", "Hey,", "Bak,"]
-    excitement: ["Vay,", "Aa,", "Hey,"]
-    curiosity: ["Hmm,", "Bak,", "Şey,"]
-    sadness: ["Eh,", "Şey...", "Hmm,"]
-    tired: ["Of,", "Hmm,", "Şey,"]
-    anger: ["Bak,", "Yani,"]
-
-# note: external compressed audio decoding removed; /speak/play expects base64 WAV
+  enabled: false

--- a/modules/speak/config_loader.py
+++ b/modules/speak/config_loader.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+SPEAK_CONFIG_COMPATIBILITY_CONTRACT = True
+SPEAK_CONFIG_COMPATIBILITY_ROLE = "agent_yaml_shorthand_alias_normalizer"
+
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -45,14 +48,14 @@ def _resolve_piper_paths(piper: Dict[str, Any]) -> Dict[str, Any]:
 def _normalize_speak_section(section: Dict[str, Any]) -> Dict[str, Any]:
     """Keep agent.yaml as single source, with small compatibility aliases.
 
-    Supports legacy shorthand keys like `speak.engine` by mapping them into
+    Supports compatibility shorthand keys like `speak.engine` by mapping them into
     `speak.tts.engine` when present.
     """
     out = deepcopy(section)
     tts = out.get("tts") if isinstance(out.get("tts"), dict) else {}
     out["tts"] = dict(tts)
 
-    # Compatibility: allow `speak.engine: xtts` as shorthand.
+    # Compatibility alias: allow `speak.engine: xtts` as shorthand.
     shorthand_engine = str(out.get("engine", "")).strip()
     if shorthand_engine:
         out["tts"]["engine"] = shorthand_engine

--- a/modules/speak/requirements.txt
+++ b/modules/speak/requirements.txt
@@ -1,9 +1,6 @@
 sounddevice>=0.4
 soundfile>=0.12
 numpy>=1.23
-# Optional for offline TTS
-pyttsx3>=2.90
 piper-tts>=1.2.0
-# Language detection for multi-language voice routing
 langdetect>=1.0.9
-# Piper ONNX modelleri: python tools/install_piper_models.py --turkish --glados
+requests>=2.31

--- a/modules/speak/services/tts.py
+++ b/modules/speak/services/tts.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
-import copy
+
 import base64
+import copy
+import inspect
+import io
 import logging
-from dataclasses import dataclass
-from typing import Any, Dict, Optional
+import os
 import threading
+import time
+import wave
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
 from .lang_detect import (
     has_piper_voice_for_language,
     normalize_lang,
@@ -14,12 +23,7 @@ from .lang_detect import (
 )
 from .pcm import PCM
 
-import io
-
-import requests
-
 logger = logging.getLogger("speak.tts")
-
 _synth_cancel = threading.Event()
 
 
@@ -33,7 +37,7 @@ def clear_synthesis_cancel() -> None:
 
 @dataclass
 class TTSConfig:
-    engine: str = "pyttsx3"  # pyttsx3 | dummy
+    engine: str = "piper"
     language: str = "tr"
     voice: Optional[str] = None
     rate: int = 170
@@ -41,326 +45,365 @@ class TTSConfig:
     samplerate: int = 22050
 
 
+class TTSUnavailableError(RuntimeError):
+    pass
+
+
 class TTSBackend:
-    def synthesize(self, text: str):  # returns PCM
+    def synthesize(self, text: str, **_: Any) -> PCM:
         raise NotImplementedError
 
+    def health(self) -> Dict[str, Any]:
+        return {"available": True, "backend": self.__class__.__name__}
 
-def _wav_bytes_to_pcm(wav_bytes: bytes) -> PCM:
-    import numpy as np
-    import soundfile as sf
 
-    with io.BytesIO(wav_bytes) as f:
-        data, sr = sf.read(f, dtype="float32")
-    ch = 1 if getattr(data, "ndim", 1) == 1 else int(data.shape[1])
-    if isinstance(data, np.ndarray) and data.dtype != np.float32:
-        data = data.astype(np.float32)
-    return PCM(data=data, samplerate=int(sr), channels=ch)
-class Pyttsx3Backend(TTSBackend):
-    def __init__(self, cfg: TTSConfig):
-        try:
-            import pyttsx3  # type: ignore
-        except Exception as e:
-            raise RuntimeError("pyttsx3 not installed. Add to requirements or choose 'dummy' engine.") from e
-        self.cfg = cfg
-        self.samplerate = cfg.samplerate
-        self._lock = threading.Lock()
+class UnavailableBackend(TTSBackend):
+    def __init__(self, cfg: TTSConfig, reason: str) -> None:
+        self.samplerate = int(cfg.samplerate)
+        self.engine = str(cfg.engine)
+        self.reason = str(reason or "tts backend unavailable")
 
-    def _make_engine(self):
-        import pyttsx3  # type: ignore
-        engine = pyttsx3.init()
-        if self.cfg.voice:
-            engine.setProperty('voice', self.cfg.voice)
-        engine.setProperty('rate', self.cfg.rate)
-        engine.setProperty('volume', self.cfg.volume)
-        return engine
+    def synthesize(self, text: str, **_: Any) -> PCM:
+        raise TTSUnavailableError(self.reason)
 
-    def synthesize(self, text: str):
-        # pyttsx3 doğrudan PCM verisi döndürmez; temp wav'e yazıp geri okuruz.
-        import tempfile, os
-        import soundfile as sf
-        import numpy as np
-        with self._lock:
-            engine = self._make_engine()
-            with tempfile.TemporaryDirectory() as d:
-                tmp = os.path.join(d, "out.wav")
-                engine.save_to_file(text, tmp)
-                engine.runAndWait()
-                engine.stop()
-                data, sr = sf.read(tmp, dtype='float32')
-        ch = 1 if data.ndim == 1 else data.shape[1]
-        return PCM(data=data, samplerate=sr, channels=ch)
+    def health(self) -> Dict[str, Any]:
+        return {
+            "available": False,
+            "backend": self.__class__.__name__,
+            "engine": self.engine,
+            "error": self.reason,
+        }
 
 
 class DummyBackend(TTSBackend):
-    def __init__(self, cfg: TTSConfig):
-        self.samplerate = cfg.samplerate
+    def __init__(self, cfg: TTSConfig) -> None:
+        self.samplerate = int(cfg.samplerate)
 
-    def synthesize(self, text: str):
-        # Basit bir placeholder: kısa bir beep dizisi üret
+    def synthesize(self, text: str, **_: Any) -> PCM:
         import numpy as np
-        sr = self.samplerate
-        secs = max(0.2, min(1.0, len(text) * 0.03))
-        t = np.linspace(0, secs, int(sr * secs), endpoint=False)
-        freq = 440.0
-        data = 0.2 * np.sin(2 * np.pi * freq * t).astype(np.float32)
-        return PCM(data=data, samplerate=sr, channels=1)
+
+        seconds = max(0.2, min(1.0, len(text) * 0.03))
+        t = np.linspace(0, seconds, int(self.samplerate * seconds), endpoint=False)
+        data = 0.2 * np.sin(2 * np.pi * 440.0 * t).astype(np.float32)
+        return PCM(data=data, samplerate=self.samplerate, channels=1)
 
 
-class _PiperModel:
-    """Single Piper ONNX voice runner."""
+def _wav_bytes_to_pcm(wav_bytes: bytes) -> PCM:
+    import soundfile as sf
 
-    def __init__(self, cfg: TTSConfig, piper_cfg: Dict, resolved: Dict[str, Any]):
-        self.bin_path = str(piper_cfg.get("bin_path", "piper"))
+    with io.BytesIO(wav_bytes) as file_obj:
+        data, samplerate = sf.read(file_obj, dtype="float32")
+    channels = 1 if getattr(data, "ndim", 1) == 1 else int(data.shape[1])
+    return PCM(data=data, samplerate=int(samplerate), channels=channels)
+
+
+def _int16_bytes_to_pcm(raw: bytes, samplerate: int, channels: int = 1) -> PCM:
+    import numpy as np
+
+    data = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    channels = max(1, int(channels))
+    if channels > 1 and data.size % channels == 0:
+        data = data.reshape((-1, channels))
+    return PCM(data=data, samplerate=int(samplerate), channels=channels)
+
+
+def _dummy_allowed(cfg: Dict[str, Any]) -> bool:
+    requested = bool(cfg.get("allow_dummy_fallback", False))
+    explicit_test = str(os.getenv("SENTRYBOT_ALLOW_TEST_TTS", "")).lower() in {"1", "true", "yes", "on"}
+    return requested and explicit_test
+
+
+def _load_piper_api() -> tuple[Any, Any]:
+    try:
+        from piper import PiperVoice  # type: ignore
+    except Exception:
+        try:
+            from piper.voice import PiperVoice  # type: ignore
+        except Exception as exc:
+            raise TTSUnavailableError("piper-tts Python package is not installed") from exc
+
+    try:
+        from piper import SynthesisConfig  # type: ignore
+    except Exception:
+        SynthesisConfig = None
+    return PiperVoice, SynthesisConfig
+
+
+class PersistentPiperModel:
+    def __init__(self, cfg: TTSConfig, piper_cfg: Dict[str, Any], resolved: Dict[str, Any]) -> None:
         self.model_path = str(resolved.get("model_path") or piper_cfg.get("model_path") or "").strip()
-        if not self.model_path:
-            raise ValueError("piper.model_path is required (or piper.voices.<voice>)")
-        if not Path(self.model_path).exists():
-            raise FileNotFoundError(f"piper.model_path not found: {self.model_path}")
         self.config_path = str(
             resolved.get("config_path") or piper_cfg.get("config_path") or f"{self.model_path}.json"
         ).strip()
-        if self.config_path and not Path(self.config_path).exists():
-            logger.warning("piper model config not found: %s", self.config_path)
-        self.samplerate = int(piper_cfg.get("samplerate", cfg.samplerate))
-        self.speaker = piper_cfg.get("speaker")
-        self.length_scale = piper_cfg.get("length_scale")
-        self.noise_scale = piper_cfg.get("noise_scale")
-        self.noise_w = piper_cfg.get("noise_w")
+        if not self.model_path:
+            raise TTSUnavailableError("piper model_path is required")
+        if not Path(self.model_path).is_file():
+            raise TTSUnavailableError(f"piper model not found: {self.model_path}")
+        if not self.config_path or not Path(self.config_path).is_file():
+            raise TTSUnavailableError(f"piper config not found: {self.config_path}")
 
-    def synthesize(self, text: str) -> PCM:
-        import subprocess, tempfile, os
-        import soundfile as sf
+        self.default_samplerate = int(piper_cfg.get("samplerate", cfg.samplerate))
+        self.default_speaker = piper_cfg.get("speaker")
+        self.default_length_scale = piper_cfg.get("length_scale")
+        self.default_noise_scale = piper_cfg.get("noise_scale")
+        self.default_noise_w = piper_cfg.get("noise_w")
+        self.default_volume = float(cfg.volume)
+        self._lock = threading.Lock()
 
-        def _append_long_options(cmd: list[str]) -> list[str]:
-            out = list(cmd)
-            if self.config_path and os.path.exists(self.config_path):
-                out += ["--config", self.config_path]
-            if self.speaker is not None:
-                out += ["--speaker", str(self.speaker)]
-            if self.length_scale is not None:
-                out += ["--length_scale", str(self.length_scale)]
-            if self.noise_scale is not None:
-                out += ["--noise_scale", str(self.noise_scale)]
-            if self.noise_w is not None:
-                out += ["--noise_w", str(self.noise_w)]
-            return out
+        PiperVoice, SynthesisConfig = _load_piper_api()
+        self._synthesis_config_type = SynthesisConfig
+        started = time.monotonic()
+        self.voice = PiperVoice.load(self.model_path, config_path=self.config_path, use_cuda=False)
+        self.model_load_ms = round((time.monotonic() - started) * 1000.0, 2)
+        voice_cfg = getattr(self.voice, "config", None)
+        self.samplerate = int(
+            getattr(voice_cfg, "sample_rate", None)
+            or getattr(voice_cfg, "sample_rate_hz", None)
+            or self.default_samplerate
+        )
+        logger.info("Persistent Piper model loaded in %.2f ms: %s", self.model_load_ms, self.model_path)
 
-        def _append_short_options(cmd: list[str]) -> list[str]:
-            out = list(cmd)
-            if self.speaker is not None:
-                out += ["-s", str(self.speaker)]
-            if self.length_scale is not None:
-                out += ["-l", str(self.length_scale)]
-            if self.noise_scale is not None:
-                out += ["-n", str(self.noise_scale)]
-            if self.noise_w is not None:
-                out += ["-e", str(self.noise_w)]
-            return out
+    def health(self) -> Dict[str, Any]:
+        return {
+            "available": True,
+            "backend": "PersistentPiperModel",
+            "model_path": self.model_path,
+            "config_path": self.config_path,
+            "samplerate": self.samplerate,
+            "model_load_ms": self.model_load_ms,
+        }
 
-        def _load_wav_from_path(path: str) -> Optional[PCM]:
-            if not os.path.exists(path):
-                return None
-            if os.path.getsize(path) <= 0:
-                return None
-            data, sr = sf.read(path, dtype='float32')
-            ch = 1 if data.ndim == 1 else data.shape[1]
-            return PCM(data=data, samplerate=sr, channels=ch)
+    def _runtime_values(self, runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        runtime = runtime if isinstance(runtime, dict) else {}
+        return {
+            "speaker": runtime.get("speaker", self.default_speaker),
+            "length_scale": runtime.get("length_scale", self.default_length_scale),
+            "noise_scale": runtime.get("noise_scale", self.default_noise_scale),
+            "noise_w": runtime.get("noise_w", self.default_noise_w),
+            "volume": runtime.get("volume", self.default_volume),
+        }
 
-        stdin_text = (text or "").strip()
-        if not stdin_text:
+    def _new_api_config(self, values: Dict[str, Any]) -> Any:
+        config_type = self._synthesis_config_type
+        if config_type is None:
+            return None
+        try:
+            params = inspect.signature(config_type).parameters
+        except Exception:
+            params = {}
+        candidates = {
+            "speaker_id": values.get("speaker"),
+            "length_scale": values.get("length_scale"),
+            "noise_scale": values.get("noise_scale"),
+            "noise_w_scale": values.get("noise_w"),
+            "volume": values.get("volume"),
+            "normalize_audio": False,
+        }
+        kwargs = {key: value for key, value in candidates.items() if key in params and value is not None}
+        try:
+            return config_type(**kwargs)
+        except Exception:
+            return None
+
+    def _synthesize_current_api(self, text: str, values: Dict[str, Any]) -> Optional[PCM]:
+        method = getattr(self.voice, "synthesize", None)
+        if method is None:
+            return None
+        try:
+            params = inspect.signature(method).parameters
+        except Exception:
+            params = {}
+        if "wav_file" in params:
+            return None
+
+        kwargs: Dict[str, Any] = {}
+        syn_config = self._new_api_config(values)
+        if syn_config is not None and "syn_config" in params:
+            kwargs["syn_config"] = syn_config
+
+        raw_parts: list[bytes] = []
+        samplerate = self.samplerate
+        channels = 1
+        for chunk in method(text, **kwargs):
+            if _synth_cancel.is_set():
+                raise RuntimeError("synthesis cancelled")
+            raw = getattr(chunk, "audio_int16_bytes", None)
+            if raw is None:
+                raw = getattr(chunk, "audio_bytes", None)
+            if raw:
+                raw_parts.append(bytes(raw))
+            samplerate = int(getattr(chunk, "sample_rate", samplerate) or samplerate)
+            channels = int(getattr(chunk, "sample_channels", channels) or channels)
+        if not raw_parts:
+            raise RuntimeError("Piper produced no audio")
+        return _int16_bytes_to_pcm(b"".join(raw_parts), samplerate, channels)
+
+    def _synthesize_legacy_stream(self, text: str, values: Dict[str, Any]) -> Optional[PCM]:
+        method = getattr(self.voice, "synthesize_stream_raw", None)
+        if method is None:
+            return None
+        kwargs = {
+            "speaker_id": values.get("speaker"),
+            "length_scale": values.get("length_scale"),
+            "noise_scale": values.get("noise_scale"),
+            "noise_w": values.get("noise_w"),
+        }
+        try:
+            params = inspect.signature(method).parameters
+            kwargs = {key: value for key, value in kwargs.items() if key in params and value is not None}
+        except Exception:
+            kwargs = {key: value for key, value in kwargs.items() if value is not None}
+        raw_parts: list[bytes] = []
+        for raw in method(text, **kwargs):
+            if _synth_cancel.is_set():
+                raise RuntimeError("synthesis cancelled")
+            raw_parts.append(bytes(raw))
+        if not raw_parts:
+            raise RuntimeError("Piper produced no audio")
+        return _int16_bytes_to_pcm(b"".join(raw_parts), self.samplerate, 1)
+
+    def _synthesize_legacy_wav(self, text: str, values: Dict[str, Any]) -> PCM:
+        output = io.BytesIO()
+        with wave.open(output, "wb") as wav_file:
+            kwargs = {
+                "speaker_id": values.get("speaker"),
+                "length_scale": values.get("length_scale"),
+                "noise_scale": values.get("noise_scale"),
+                "noise_w": values.get("noise_w"),
+            }
+            method = getattr(self.voice, "synthesize", None)
+            if method is None:
+                raise RuntimeError("unsupported Piper Python API")
+            try:
+                params = inspect.signature(method).parameters
+                kwargs = {key: value for key, value in kwargs.items() if key in params and value is not None}
+            except Exception:
+                kwargs = {key: value for key, value in kwargs.items() if value is not None}
+            method(text, wav_file, **kwargs)
+        return _wav_bytes_to_pcm(output.getvalue())
+
+    def synthesize(self, text: str, runtime: Optional[Dict[str, Any]] = None) -> PCM:
+        text = str(text or "").strip()
+        if not text:
             raise ValueError("text is empty")
-
-        with tempfile.TemporaryDirectory() as d:
-            wav_path = os.path.join(d, "out.wav")
-            cmd_variants = [
-                _append_long_options([self.bin_path, "--model", self.model_path, "--output_file", wav_path]),
-                _append_short_options([self.bin_path, "-m", self.model_path, "-w", wav_path]),
-            ]
-
-            last_error = ""
-            for cmd in cmd_variants:
-                if _synth_cancel.is_set():
-                    raise RuntimeError("synthesis cancelled")
-                proc = subprocess.Popen(
-                    cmd,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-                try:
-                    stdout_b, stderr_b = proc.communicate(
-                        input=(stdin_text + "\n").encode("utf-8"),
-                        timeout=120.0,
-                    )
-                except Exception:
-                    proc.kill()
-                    proc.communicate(timeout=1.0)
-                    if _synth_cancel.is_set():
-                        raise RuntimeError("synthesis cancelled")
-                    raise
-                if _synth_cancel.is_set():
-                    raise RuntimeError("synthesis cancelled")
-                stderr_txt = stderr_b.decode("utf-8", "ignore").strip()
-
-                if proc.returncode == 0:
-                    try:
-                        pcm = _load_wav_from_path(wav_path)
-                        if pcm is not None:
-                            return pcm
-                    except Exception as exc:
-                        last_error = f"wav read failed: {exc}"
-
-                    if stdout_b:
-                        try:
-                            return _wav_bytes_to_pcm(stdout_b)
-                        except Exception as exc:
-                            last_error = f"stdout wav parse failed: {exc}"
-                    else:
-                        last_error = "piper finished without producing readable WAV output"
-                else:
-                    last_error = f"exit={proc.returncode}; stderr={stderr_txt or '<empty>'}"
-
-            raise RuntimeError(f"piper failed: {last_error}")
+        values = self._runtime_values(runtime)
+        with self._lock:
+            if _synth_cancel.is_set():
+                raise RuntimeError("synthesis cancelled")
+            pcm = self._synthesize_current_api(text, values)
+            if pcm is None:
+                pcm = self._synthesize_legacy_stream(text, values)
+            if pcm is None:
+                pcm = self._synthesize_legacy_wav(text, values)
+            return pcm
 
 
 class PiperBackend(TTSBackend):
-    """Piper TTS with lazy-loaded per-voice models (language_voices / voices map)."""
-
-    def __init__(self, cfg: TTSConfig, piper_cfg: Dict):
+    def __init__(self, cfg: TTSConfig, piper_cfg: Dict[str, Any]) -> None:
         self.tcfg = cfg
         self.piper_cfg = copy.deepcopy(piper_cfg)
         self.default_voice = str(piper_cfg.get("voice", "tr")).strip().lower() or "tr"
-        self._models: Dict[str, _PiperModel] = {}
+        self._models: Dict[str, PersistentPiperModel] = {}
         self._ensure_model(self.default_voice)
+        preload = piper_cfg.get("preload_voices", [])
+        if isinstance(preload, list):
+            for voice_key in preload:
+                key = str(voice_key or "").strip().lower()
+                if key and key != self.default_voice:
+                    try:
+                        self._ensure_model(key)
+                    except Exception as exc:
+                        logger.warning("Piper preload skipped for voice=%s: %s", key, exc)
 
-    @staticmethod
-    def _resolve_voice_cfg(piper_cfg: Dict, voice_key: Optional[str] = None) -> Dict[str, Any]:
-        voices = piper_cfg.get("voices", {})
-        key = str(voice_key or piper_cfg.get("voice", "tr")).strip().lower() or "tr"
+    def _voice_cfg(self, voice_key: str) -> Dict[str, Any]:
+        voices = self.piper_cfg.get("voices", {})
         if not isinstance(voices, dict):
             return {}
-        entry = voices.get(key)
-        if isinstance(entry, dict):
-            return entry
-        return {}
+        entry = voices.get(voice_key)
+        return dict(entry) if isinstance(entry, dict) else {}
 
-    def _ensure_model(self, voice_key: str) -> _PiperModel:
+    def _ensure_model(self, voice_key: str) -> PersistentPiperModel:
         key = str(voice_key or self.default_voice).strip().lower() or self.default_voice
-        cached = self._models.get(key)
-        if cached is not None:
-            return cached
-        resolved = self._resolve_voice_cfg(self.piper_cfg, key)
+        model = self._models.get(key)
+        if model is not None:
+            return model
+        resolved = self._voice_cfg(key)
         try:
-            model = _PiperModel(self.tcfg, self.piper_cfg, resolved)
-        except FileNotFoundError:
+            model = PersistentPiperModel(self.tcfg, self.piper_cfg, resolved)
+        except Exception:
             if key != self.default_voice:
-                logger.warning("piper voice %s unavailable, falling back to %s", key, self.default_voice)
+                logger.warning("Piper voice %s unavailable; using %s", key, self.default_voice)
                 return self._ensure_model(self.default_voice)
             raise
         self._models[key] = model
         return model
 
-    def synthesize(self, text: str, voice_key: Optional[str] = None) -> PCM:
+    def synthesize(
+        self,
+        text: str,
+        voice_key: Optional[str] = None,
+        runtime: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> PCM:
         key = str(voice_key or self.default_voice).strip().lower() or self.default_voice
-        return self._ensure_model(key).synthesize(text)
+        return self._ensure_model(key).synthesize(text, runtime=runtime)
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "available": True,
+            "backend": self.__class__.__name__,
+            "default_voice": self.default_voice,
+            "loaded_voices": {key: model.health() for key, model in self._models.items()},
+        }
 
 
 class XTTSHttpBackend(TTSBackend):
-    """XTTS via external local HTTP service.
-
-    This backend is designed to let XTTS run in a separate Python env (often with CUDA),
-    while SentryBOT gateway keeps its own env lightweight.
-
-    Expected endpoint:
-      - POST {endpoint} (default: http://127.0.0.1:5002/synthesize)
-      - JSON: { text, speaker_wav?, language? }
-      - Response: audio/wav bytes
-    """
-
-    def __init__(self, cfg: TTSConfig, xtts_cfg: Dict):
+    def __init__(self, cfg: TTSConfig, xtts_cfg: Dict[str, Any]) -> None:
         self.samplerate = int(xtts_cfg.get("samplerate", cfg.samplerate))
-        self.endpoint = str(xtts_cfg.get("endpoint", "http://127.0.0.1:5002/synthesize")).strip()
+        self.endpoint = str(xtts_cfg.get("endpoint", "")).strip()
         self.timeout = float(xtts_cfg.get("timeout", 120.0))
         self.default_speaker_wav = xtts_cfg.get("speaker_wav")
         self.default_language = str(xtts_cfg.get("language", cfg.language))
-
         if not self.endpoint:
-            raise ValueError("xtts.endpoint is required")
+            raise TTSUnavailableError("xtts endpoint is required")
 
-    def synthesize(self, text: str, speaker_wav: Optional[str] = None, language: Optional[str] = None) -> PCM:
-        payload: Dict[str, object] = {
-            "text": text,
-            "language": language or self.default_language,
-        }
+    def synthesize(
+        self,
+        text: str,
+        speaker_wav: Optional[str] = None,
+        language: Optional[str] = None,
+        **_: Any,
+    ) -> PCM:
+        payload: Dict[str, Any] = {"text": text, "language": language or self.default_language}
         wav = speaker_wav or self.default_speaker_wav
         if wav:
             payload["speaker_wav"] = wav
-
-        resp = requests.post(self.endpoint, json=payload, timeout=self.timeout)
-        resp.raise_for_status()
-        return _wav_bytes_to_pcm(resp.content)
+        response = requests.post(self.endpoint, json=payload, timeout=self.timeout)
+        response.raise_for_status()
+        return _wav_bytes_to_pcm(response.content)
 
 
 class RemoteTTSHttpBackend(TTSBackend):
-    """Unified remote TTS backend for piper/xtts with a single endpoint.
-
-    Request payload:
-      {
-        "text": "...",
-        "engine": "piper" | "xtts",
-        "language": "tr",
-        "speaker_wav": "..."?,
-        "piper": {...},
-        "xtts": {...}
-      }
-    Response can be raw WAV bytes or JSON with base64 audio.
-    """
-
-    def __init__(self, cfg: TTSConfig, full_tts_cfg: Dict[str, Any]):
-        remote_cfg = full_tts_cfg.get("remote", {}) if isinstance(full_tts_cfg.get("remote", {}), dict) else {}
-        if not bool(remote_cfg.get("enabled", False)):
-            raise ValueError("tts.remote.enabled must be true for RemoteTTSHttpBackend")
-
-        endpoint = str(remote_cfg.get("endpoint", "")).strip()
-        if not endpoint:
-            raise ValueError("tts.remote.endpoint is required")
-
-        self.endpoint = endpoint
+    def __init__(self, cfg: TTSConfig, full_cfg: Dict[str, Any]) -> None:
+        remote_cfg = full_cfg.get("remote", {}) if isinstance(full_cfg.get("remote"), dict) else {}
+        self.endpoint = str(remote_cfg.get("endpoint", "")).strip()
         self.timeout = float(remote_cfg.get("timeout", 120.0))
         self.auth_token = str(remote_cfg.get("auth_token", "")).strip()
         self.engine = str(cfg.engine).strip().lower()
         self.default_language = str(cfg.language)
-        self.default_speaker_wav = (
-            full_tts_cfg.get("xtts", {}).get("speaker_wav")
-            if isinstance(full_tts_cfg.get("xtts", {}), dict)
-            else None
-        )
+        self.piper_cfg = copy.deepcopy(full_cfg.get("piper", {}))
+        self.xtts_cfg = copy.deepcopy(full_cfg.get("xtts", {}))
+        self.default_speaker_wav = self.xtts_cfg.get("speaker_wav")
+        if not bool(remote_cfg.get("enabled", False)) or not self.endpoint:
+            raise TTSUnavailableError("remote TTS is not configured")
 
-        self.piper_cfg = copy.deepcopy(full_tts_cfg.get("piper", {})) if isinstance(full_tts_cfg.get("piper", {}), dict) else {}
-        self.xtts_cfg = copy.deepcopy(full_tts_cfg.get("xtts", {})) if isinstance(full_tts_cfg.get("xtts", {}), dict) else {}
-
-    def _decode_response_audio(self, resp: requests.Response) -> bytes:
-        content_type = str(resp.headers.get("content-type", "")).lower()
-        if "application/json" in content_type:
-            data = resp.json() if resp.content else {}
-            if not isinstance(data, dict):
-                raise RuntimeError("remote TTS returned invalid JSON payload")
-
-            b64_value = (
-                data.get("wav_base64")
-                or data.get("audio_base64")
-                or data.get("data")
-                or ""
-            )
-            b64_text = str(b64_value or "").strip()
-            if not b64_text:
-                raise RuntimeError("remote TTS JSON response has no base64 audio field")
-            return base64.b64decode(b64_text)
-
-        return resp.content
-
-    def synthesize(self, text: str, speaker_wav: Optional[str] = None, language: Optional[str] = None) -> PCM:
+    def synthesize(
+        self,
+        text: str,
+        speaker_wav: Optional[str] = None,
+        language: Optional[str] = None,
+        **_: Any,
+    ) -> PCM:
         payload: Dict[str, Any] = {
             "text": text,
             "engine": self.engine,
@@ -368,143 +411,121 @@ class RemoteTTSHttpBackend(TTSBackend):
             "piper": self.piper_cfg,
             "xtts": self.xtts_cfg,
         }
-
-        resolved_speaker_wav = speaker_wav or self.default_speaker_wav
-        if resolved_speaker_wav:
-            payload["speaker_wav"] = resolved_speaker_wav
-
-        headers: Dict[str, str] = {}
-        if self.auth_token:
-            headers["Authorization"] = f"Bearer {self.auth_token}"
-
-        resp = requests.post(self.endpoint, json=payload, headers=headers, timeout=self.timeout)
-        resp.raise_for_status()
-
-        wav_bytes = self._decode_response_audio(resp)
-        if not wav_bytes:
-            raise RuntimeError("remote TTS response contains empty audio")
-        return _wav_bytes_to_pcm(wav_bytes)
+        wav = speaker_wav or self.default_speaker_wav
+        if wav:
+            payload["speaker_wav"] = wav
+        headers = {"Authorization": f"Bearer {self.auth_token}"} if self.auth_token else {}
+        response = requests.post(self.endpoint, json=payload, headers=headers, timeout=self.timeout)
+        response.raise_for_status()
+        content_type = str(response.headers.get("content-type", "")).lower()
+        if "application/json" in content_type:
+            data = response.json()
+            encoded = str(data.get("wav_base64") or data.get("audio_base64") or data.get("data") or "")
+            if not encoded:
+                raise RuntimeError("remote TTS returned no audio")
+            return _wav_bytes_to_pcm(base64.b64decode(encoded))
+        return _wav_bytes_to_pcm(response.content)
 
 
 class TextToSpeech:
-    def __init__(self, cfg: Dict):
+    def __init__(self, cfg: Dict[str, Any]) -> None:
         self._base_cfg = copy.deepcopy(cfg)
         self.backend = self._build_backend(self._base_cfg)
 
-    def _build_backend(self, cfg: Dict) -> TTSBackend:
-        tcfg = TTSConfig(
-            engine=str(cfg.get("engine", "pyttsx3")),
+    def _tts_config(self, cfg: Dict[str, Any]) -> TTSConfig:
+        return TTSConfig(
+            engine=str(cfg.get("engine", "piper")).strip().lower(),
             language=str(cfg.get("language", "tr")),
             voice=cfg.get("voice"),
             rate=int(cfg.get("rate", 170)),
             volume=float(cfg.get("volume", 1.0)),
             samplerate=int(cfg.get("samplerate", 22050)),
         )
-        remote_cfg = cfg.get("remote", {}) if isinstance(cfg.get("remote", {}), dict) else {}
-        if tcfg.engine in {"piper", "xtts"} and bool(remote_cfg.get("enabled", False)):
-            return RemoteTTSHttpBackend(tcfg, cfg)
-        if tcfg.engine == "piper":
-            try:
-                return PiperBackend(tcfg, cfg.get("piper", {}))
-            except (FileNotFoundError, ValueError, OSError) as exc:
-                logger.warning(
-                    "piper unavailable (install models: python tools/install_piper_models.py), "
-                    "falling back to dummy: %s",
-                    exc,
-                )
-                return DummyBackend(tcfg)
-        if tcfg.engine == "xtts":
-            return XTTSHttpBackend(tcfg, cfg.get("xtts", {}))
-        if tcfg.engine == "pyttsx3":
-            try:
-                return Pyttsx3Backend(tcfg)
-            except Exception as e:
-                logger.warning("pyttsx3 unavailable, falling back to dummy: %s", e)
-                return DummyBackend(tcfg)
-        return DummyBackend(tcfg)
 
-    def _merge_overrides(self, overrides: Dict | None) -> Optional[Dict]:
-        if not overrides:
-            return None
+    def _build_backend(self, cfg: Dict[str, Any]) -> TTSBackend:
+        tcfg = self._tts_config(cfg)
+        remote_cfg = cfg.get("remote", {}) if isinstance(cfg.get("remote"), dict) else {}
+        try:
+            if tcfg.engine == "dummy":
+                if _dummy_allowed(cfg):
+                    return DummyBackend(tcfg)
+                return UnavailableBackend(tcfg, "dummy TTS is disabled")
+            if tcfg.engine in {"piper", "xtts"} and bool(remote_cfg.get("enabled", False)):
+                return RemoteTTSHttpBackend(tcfg, cfg)
+            if tcfg.engine == "piper":
+                return PiperBackend(tcfg, cfg.get("piper", {}) if isinstance(cfg.get("piper"), dict) else {})
+            if tcfg.engine == "xtts":
+                return XTTSHttpBackend(tcfg, cfg.get("xtts", {}) if isinstance(cfg.get("xtts"), dict) else {})
+            return UnavailableBackend(tcfg, f"unsupported TTS engine: {tcfg.engine}")
+        except Exception as exc:
+            reason = str(exc)
+            if _dummy_allowed(cfg):
+                logger.warning("TTS unavailable (%s); explicit test dummy enabled", reason)
+                return DummyBackend(tcfg)
+            logger.warning("TTS unavailable: %s", reason)
+            return UnavailableBackend(tcfg, reason)
+
+    def is_available(self) -> bool:
+        return not isinstance(self.backend, UnavailableBackend)
+
+    def health(self) -> Dict[str, Any]:
+        health = self.backend.health()
+        health.setdefault("available", self.is_available())
+        health.setdefault("engine", str(self._base_cfg.get("engine", "")))
+        return health
+
+    def _merge(self, overrides: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         merged = copy.deepcopy(self._base_cfg)
-        if "piper" in overrides:
-            merged["piper"] = {**merged.get("piper", {}), **overrides.get("piper", {})}
-        if "xtts" in overrides:
-            merged["xtts"] = {**merged.get("xtts", {}), **overrides.get("xtts", {})}
+        if not isinstance(overrides, dict):
+            return merged
         for key, value in overrides.items():
-            if key == "piper":
-                continue
-            if key == "xtts":
-                continue
-            merged[key] = value
+            if key in {"piper", "xtts", "remote"} and isinstance(value, dict):
+                base = merged.get(key, {}) if isinstance(merged.get(key), dict) else {}
+                merged[key] = {**base, **value}
+            else:
+                merged[key] = value
         return merged
 
-    def _resolve_piper_language(
-        self,
-        text: str,
-        cfg: Dict,
-        overrides: Optional[Dict],
-    ) -> Optional[str]:
-        piper_cfg = cfg.get("piper", {})
-        if not isinstance(piper_cfg, dict) or not bool(piper_cfg.get("auto_language", True)):
+    def _resolve_piper_voice(self, text: str, cfg: Dict[str, Any], overrides: Optional[Dict[str, Any]]) -> Optional[str]:
+        piper_cfg = cfg.get("piper", {}) if isinstance(cfg.get("piper"), dict) else {}
+        if not bool(piper_cfg.get("auto_language", True)):
             return None
         explicit = overrides.get("language") if isinstance(overrides, dict) else None
-        lock_session = bool(piper_cfg.get("lock_session_language", True))
-        if explicit and str(explicit).strip() and lock_session:
-            return normalize_lang(explicit, fallback=str(cfg.get("language", "tr")))
-        return resolve_speak_language(
-            text,
-            explicit=explicit,
-            default=str(cfg.get("language", "tr")),
-            prefer_text=bool(piper_cfg.get("prefer_text_language", True)),
-        )
+        if explicit and bool(piper_cfg.get("lock_session_language", True)):
+            language = normalize_lang(explicit, fallback=str(cfg.get("language", "tr")))
+        else:
+            language = resolve_speak_language(
+                text,
+                explicit=explicit,
+                default=str(cfg.get("language", "tr")),
+                prefer_text=bool(piper_cfg.get("prefer_text_language", False)),
+            )
+        if not has_piper_voice_for_language(language, piper_cfg):
+            fallback_engine = str(piper_cfg.get("fallback_engine", "")).strip().lower()
+            if fallback_engine:
+                raise TTSUnavailableError(f"no Piper voice for language={language}; fallback={fallback_engine} is not active")
+        return piper_voice_for_language(language, piper_cfg)
 
-    def _piper_language_fallback_backend(self, cfg: Dict, lang: str) -> Optional[TTSBackend]:
-        """Build a substitute backend when no Piper voice exists for the language.
-
-        Reading e.g. German text with the Turkish Piper voice sounds broken, so
-        a generic engine (pyttsx3/xtts) configured via ``piper.fallback_engine``
-        takes over instead. Empty value disables the fallback (old behaviour).
-        """
-        piper_cfg = cfg.get("piper", {}) if isinstance(cfg.get("piper", {}), dict) else {}
-        fallback_engine = str(piper_cfg.get("fallback_engine", "")).strip().lower()
-        if not fallback_engine or fallback_engine == "piper":
-            return None
-        fb_cfg = copy.deepcopy(cfg)
-        fb_cfg["engine"] = fallback_engine
-        fb_cfg["language"] = lang
-        try:
-            backend = self._build_backend(fb_cfg)
-        except Exception as exc:
-            logger.warning("piper language fallback engine %s failed: %s", fallback_engine, exc)
-            return None
-        logger.info("no piper voice for language=%s, using %s fallback", lang, fallback_engine)
-        return backend
-
-    def synthesize(self, text: str, overrides: Optional[Dict] = None):
-        cfg = self._merge_overrides(overrides) if overrides else copy.deepcopy(self._base_cfg)
-        backend = self._build_backend(cfg) if overrides else self.backend
-        piper_voice = None
-        if str(cfg.get("engine", "")).strip().lower() == "piper":
-            lang = self._resolve_piper_language(text, cfg, overrides)
-            if lang is not None:
-                piper_cfg = cfg.get("piper", {}) if isinstance(cfg.get("piper", {}), dict) else {}
-                if isinstance(backend, PiperBackend) and not has_piper_voice_for_language(lang, piper_cfg):
-                    fb_backend = self._piper_language_fallback_backend(cfg, lang)
-                    if fb_backend is not None:
-                        if isinstance(fb_backend, (XTTSHttpBackend, RemoteTTSHttpBackend)):
-                            speaker_wav = overrides.get("speaker_wav") if isinstance(overrides, dict) else None
-                            return fb_backend.synthesize(text, speaker_wav=speaker_wav, language=lang)
-                        return fb_backend.synthesize(text)
-                piper_voice = piper_voice_for_language(lang, piper_cfg)
-                logger.debug("piper language=%s voice=%s", lang, piper_voice)
+    def synthesize(self, text: str, overrides: Optional[Dict[str, Any]] = None) -> PCM:
+        cfg = self._merge(overrides)
+        requested_engine = str(cfg.get("engine", "piper")).strip().lower()
+        base_engine = str(self._base_cfg.get("engine", "piper")).strip().lower()
+        backend = self.backend if requested_engine == base_engine else self._build_backend(cfg)
 
         if isinstance(backend, PiperBackend):
-            return backend.synthesize(text, voice_key=piper_voice)
+            voice_key = self._resolve_piper_voice(text, cfg, overrides)
+            runtime = cfg.get("piper", {}) if isinstance(cfg.get("piper"), dict) else {}
+            return backend.synthesize(text, voice_key=voice_key, runtime=runtime)
         if isinstance(backend, (XTTSHttpBackend, RemoteTTSHttpBackend)):
             speaker_wav = overrides.get("speaker_wav") if isinstance(overrides, dict) else None
             language = overrides.get("language") if isinstance(overrides, dict) else None
-            if not language and piper_voice:
-                language = piper_voice
             return backend.synthesize(text, speaker_wav=speaker_wav, language=language)
         return backend.synthesize(text)
+
+
+__all__ = [
+    "TextToSpeech",
+    "TTSUnavailableError",
+    "cancel_synthesis",
+    "clear_synthesis_cancel",
+]

--- a/modules/speak/xSpeakService.py
+++ b/modules/speak/xSpeakService.py
@@ -1,25 +1,31 @@
 from __future__ import annotations
+
 import argparse
 import logging
 import re
-from typing import Any, Dict, Optional
+import threading
+import time
+import uuid
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 try:
     import requests  # type: ignore
 except Exception:  # pragma: no cover
     requests = None  # type: ignore
 
-from modules.speak.config_loader import load_config
-from modules.speak.services.tts import TextToSpeech
-from modules.speak.services.player import AudioPlayer
 from fastapi import FastAPI
-from typing import TYPE_CHECKING
+
+from modules.common.latency_trace import latency_trace
+from modules.speak.config_loader import load_config
+from modules.speak.services.player import AudioPlayer
+from modules.speak.services.tts import TextToSpeech, TTSUnavailableError
 
 if TYPE_CHECKING:
     from modules.speak.api import get_router  # type: ignore
 
 try:
     from modules.logwrapper import init_logging as _init_global_logging  # type: ignore
+
     _init_global_logging()
 except Exception:
     pass
@@ -29,274 +35,82 @@ logger = logging.getLogger("speak")
 _TONE_PRESETS: Dict[str, Dict[str, float]] = {
     "neutral": {"rate": 170, "volume": 0.85},
     "joy": {"rate": 190, "volume": 1.0},
+    "happy": {"rate": 190, "volume": 1.0},
     "fast": {"rate": 190, "volume": 1.0},
-    "calm": {"rate": 170, "volume": 0.7},
+    "calm": {"rate": 160, "volume": 0.72},
     "excited": {"rate": 200, "volume": 1.0},
     "sadness": {"rate": 150, "volume": 0.75},
     "sad": {"rate": 150, "volume": 0.75},
     "curiosity": {"rate": 185, "volume": 0.9},
+    "curious": {"rate": 185, "volume": 0.9},
     "tired": {"rate": 140, "volume": 0.65},
     "fear": {"rate": 200, "volume": 0.9},
 }
 
 
 class SpeakService:
-    """Metni sese dönüştürüp MAX98357A üzerinden çalar."""
-
-    def __init__(self, config_path: Optional[str] = None):
-        import random
-
+    def __init__(self, config_path: Optional[str] = None) -> None:
         self.cfg = load_config(config_path)
         self.tts = TextToSpeech(self.cfg.get("tts", {}))
         self.player = AudioPlayer(self.cfg.get("audio_out", {}))
         self._liveliness_cfg = self.cfg.get("liveliness", {}) or {}
-        self._naturalness_cfg = self.cfg.get("naturalness", {}) or {}
-        self._rng = random.Random()
+        self._speech_lock = threading.RLock()
 
     @staticmethod
-    def _coerce_tone(tone: Any) -> Optional[dict]:
-        """Accept dict overrides or named presets (e.g. quiet-hours ``tone: calm``)."""
+    def _coerce_tone(tone: Any) -> Optional[Dict[str, Any]]:
         if tone is None:
             return None
         if isinstance(tone, dict):
             return dict(tone)
         if isinstance(tone, str):
-            key = tone.strip().lower()
-            if not key or key in {"default", "none"}:
-                return None
-            preset = _TONE_PRESETS.get(key)
-            if preset:
-                return dict(preset)
-            logger.debug("unknown tone label %r, ignoring", tone)
-            return None
-        logger.warning("unsupported tone type %s, ignoring", type(tone).__name__)
+            return dict(_TONE_PRESETS.get(tone.strip().lower(), {})) or None
         return None
 
     @staticmethod
-    def _pool_key_for_tone(tone: Any) -> str:
-        """Pick a filler-pool key from a tone (string emotion or rate/volume dict)."""
-        if isinstance(tone, str) and tone.strip():
-            try:
-                from modules.common.emotion_vocab import get_vocab
-
-                return get_vocab().canonical(tone)
-            except Exception:
-                return tone.strip().lower()
-        if isinstance(tone, dict):
-            rate = tone.get("rate")
-            if isinstance(rate, (int, float)):
-                if rate >= 195:
-                    return "excitement"
-                if rate <= 150:
-                    return "sadness"
-        return "default"
-
-    def _filler_pool(self, tone: Any) -> list:
-        cfg = getattr(self, "_naturalness_cfg", {}) or {}
-        pools = cfg.get("fillers", {}) if isinstance(cfg, dict) else {}
-        if not isinstance(pools, dict):
-            return []
-        key = self._pool_key_for_tone(tone)
-        pool = pools.get(key)
-        if isinstance(pool, list) and pool:
-            return list(pool)
-        return list(pools.get("default", []) or [])
-
-    def _enrich_text_for_speech(self, text: str, tone: Any = None, rng=None) -> str:
-        """Optionally prepend a natural filler so speech sounds less scripted.
-
-        Runs *after* :meth:`_clean_text_for_speech`, so fillers like "Hmm,"
-        are not stripped as meta-reasoning. Best-effort and probabilistic.
-        """
-        cfg = getattr(self, "_naturalness_cfg", {})
-        cfg = cfg if isinstance(cfg, dict) else {}
-        if not cfg.get("enabled", False):
-            return text
-        body = (text or "").strip()
-        if len(body) < int(cfg.get("min_chars", 12)):
-            return text
-        # Don't stack fillers if the line already opens with one.
-        first_word = re.match(r"^[^\W\d_]+", body, re.UNICODE)
-        if first_word and first_word.group(0).lower() in {"hmm", "şey", "sey", "yani", "eh", "of", "aa"}:
-            return text
-        pool = self._filler_pool(tone)
-        if not pool:
-            return text
-        roll = (rng or self._rng).random()
-        if roll >= float(cfg.get("filler_probability", 0.2)):
-            return text
-        filler = (rng or self._rng).choice(pool)
-        return f"{filler} {body}"
-
-    @staticmethod
-    def _tone_to_piper(tone: Optional[dict]) -> Optional[dict]:
-        """Translate a rate/volume tone into Piper prosody knobs.
-
-        Piper ignores pyttsx3-style ``rate``/``volume``; the only way emotion
-        actually colours Piper audio is via ``length_scale`` (pace) and
-        ``noise_w`` (expressiveness/variability). Baseline rate is 170.
-        """
+    def _tone_to_piper(tone: Optional[Dict[str, Any]]) -> Optional[Dict[str, float]]:
         if not isinstance(tone, dict):
             return None
         rate = tone.get("rate")
         if not isinstance(rate, (int, float)) or rate <= 0:
             return None
-        # Faster speech -> shorter length_scale. Clamp to a natural range.
-        length_scale = max(0.6, min(1.6, 170.0 / float(rate)))
-        # Livelier (faster) speech gets a touch more variability.
-        noise_w = max(0.4, min(1.1, 0.8 * (float(rate) / 170.0)))
-        return {
-            "length_scale": round(length_scale, 3),
-            "noise_w": round(noise_w, 3),
-        }
+        length_scale = max(0.62, min(1.55, 170.0 / float(rate)))
+        noise_w = max(0.45, min(1.05, 0.78 * (float(rate) / 170.0)))
+        return {"length_scale": round(length_scale, 3), "noise_w": round(noise_w, 3)}
 
-    def _post_interactions(self, endpoint: str, payload: dict) -> None:
-        if requests is None:
+    @staticmethod
+    def _clean_text_for_speech(text: str) -> str:
+        raw = str(text or "").strip()
+        if not raw:
+            return ""
+        raw = re.sub(r"```.*?```", " ", raw, flags=re.DOTALL)
+        raw = re.sub(r"`([^`]*)`", r"\1", raw)
+        clean: list[str] = []
+        for line in raw.splitlines():
+            value = line.strip()
+            if not value or re.match(r"^[#>*•-]\s*", value):
+                continue
+            low = value.lower()
+            if low.startswith(("analysis:", "reasoning:", "thinking:", "internal state:", "tool_call:")):
+                continue
+            clean.append(value.replace("*", ""))
+        return re.sub(r"\s+", " ", " ".join(clean)).strip()
+
+    def _expression_event(self, event_type: str, data: Optional[Dict[str, Any]] = None) -> None:
+        if requests is None or not bool(self._liveliness_cfg.get("enabled", True)):
             return
-        base = str(self._liveliness_cfg.get("interactions_base_url", "")).strip().rstrip("/")
+        base = str(self._liveliness_cfg.get("expression_base_url", "")).strip().rstrip("/")
         if not base:
             return
         try:
-            requests.post(f"{base}{endpoint}", json=payload, timeout=0.5)
-        except Exception:
-            pass
-
-    def _estimate_effect_duration_ms(self, text: str, tone: Optional[dict]) -> int:
-        cfg = (self._liveliness_cfg.get("speech_effect") or {}) if isinstance(self._liveliness_cfg, dict) else {}
-        cps = float(cfg.get("chars_per_second", 16.0))
-        min_ms = int(cfg.get("min_duration_ms", 400))
-        max_ms = int(cfg.get("max_duration_ms", 7000))
-        text_len = max(1, len((text or "").strip()))
-        duration_ms = int((text_len / max(1.0, cps)) * 1000.0)
-        if tone and isinstance(tone, dict):
-            rate = tone.get("rate")
-            if isinstance(rate, (int, float)) and rate > 0:
-                # 170 ~= neutral baseline in this project.
-                duration_ms = int(duration_ms * (170.0 / float(rate)))
-        return max(min_ms, min(max_ms, duration_ms))
-
-    @staticmethod
-    def _resolve_tone_key(tone: Optional[dict]) -> str:
-        if not isinstance(tone, dict):
-            return "neutral"
-        rate = tone.get("rate")
-        volume = tone.get("volume")
-        if isinstance(rate, (int, float)):
-            if rate >= 190:
-                return "fast"
-            if rate <= 145:
-                return "tired"
-        if isinstance(volume, (int, float)) and float(volume) <= 0.7:
-            return "calm"
-        return "neutral"
-
-    def _resolve_effect_name_for_tone(self, tone: Optional[dict]) -> str:
-        cfg = self._liveliness_cfg.get("speech_effect", {}) or {}
-        tone_map = cfg.get("tone_effect_map", {}) if isinstance(cfg.get("tone_effect_map", {}), dict) else {}
-        key = self._resolve_tone_key(tone)
-        return str(tone_map.get(key, cfg.get("name", "PULSE")))
-
-    def _emit_speech_liveliness_start(self, text: str, tone: Optional[dict]) -> None:
-        if not bool(self._liveliness_cfg.get("enabled", False)):
-            return
-        tone_key = self._resolve_tone_key(tone)
-        exclamations = str(text or "").count("!")
-        questions = str(text or "").count("?")
-        self._post_interactions(
-            "/event",
-            {
-                "type": "speech.start",
-                "data": {
-                    "text_len": len(text or ""),
-                    "tone_key": tone_key,
-                    "exclamations": exclamations,
-                    "questions": questions,
-                },
-            },
-        )
-        effect_cfg = self._liveliness_cfg.get("speech_effect", {}) or {}
-        force = bool(effect_cfg.get("force", False))
-        if not bool(self._liveliness_cfg.get("event_driven_effects", False)):
-            effect_name = self._resolve_effect_name_for_tone(tone)
-            duration_ms = self._estimate_effect_duration_ms(text, tone)
-            self._post_interactions(
-                "/effect",
-                {"name": effect_name, "duration_ms": duration_ms, "force": force},
+            requests.post(
+                f"{base}/event",
+                json={"type": event_type, "data": dict(data or {})},
+                timeout=float(self._liveliness_cfg.get("event_timeout_s", 0.35)),
             )
-        if bool(effect_cfg.get("stack_emphasis_effects", False)):
-            self._emit_speech_rhythm_beats(text, force=force)
-            emph_map = effect_cfg.get("emphasis_effect_map", {}) if isinstance(effect_cfg.get("emphasis_effect_map", {}), dict) else {}
-            if exclamations > 0:
-                name = str(emph_map.get("exclamation", "COMET"))
-                self._post_interactions("/effect", {"name": name, "duration_ms": 260, "force": force})
-            if questions > 0:
-                name = str(emph_map.get("question", "TWINKLE"))
-                self._post_interactions("/effect", {"name": name, "duration_ms": 240, "force": force})
+        except Exception:
+            logger.debug("expression event failed: %s", event_type, exc_info=True)
 
-    def _emit_speech_rhythm_beats(self, text: str, force: bool = False) -> None:
-        effect_cfg = self._liveliness_cfg.get("speech_effect", {}) or {}
-        rhythm = effect_cfg.get("rhythm", {}) if isinstance(effect_cfg.get("rhythm", {}), dict) else {}
-        if not bool(rhythm.get("enabled", False)):
-            return
-        raw_text = str(text or "")
-        words = len([w for w in raw_text.split() if w.strip()])
-        clauses = max(1, len([p for p in re.split(r"[,;:.!?]+", raw_text) if p.strip()]))
-        if words <= 0 and clauses <= 0:
-            return
-
-        mode = str(rhythm.get("mode", "words")).strip().lower()
-        words_per_beat = max(1, int(rhythm.get("words_per_beat", 3)))
-        clauses_per_beat = max(1, int(rhythm.get("clauses_per_beat", 1)))
-        max_beats = max(0, int(rhythm.get("max_beats", 4)))
-        if mode == "clauses":
-            beat_count = min(max_beats, max(0, clauses // clauses_per_beat))
-        else:
-            beat_count = min(max_beats, max(0, words // words_per_beat))
-        if beat_count <= 0:
-            return
-        beat_name = str(rhythm.get("effect", "PULSE"))
-        beat_duration_ms = max(80, int(rhythm.get("duration_ms", 160)))
-        for _ in range(beat_count):
-            self._post_interactions("/effect", {"name": beat_name, "duration_ms": beat_duration_ms, "force": force})
-
-        pause_map = rhythm.get("pause_effect_map", {}) if isinstance(rhythm.get("pause_effect_map", {}), dict) else {}
-        if not pause_map:
-            return
-        max_pause_marks = max(0, int(rhythm.get("max_pause_marks", 4)))
-        if max_pause_marks <= 0:
-            return
-        punctuation_counts = {
-            ",": raw_text.count(","),
-            ";": raw_text.count(";"),
-            ":": raw_text.count(":"),
-            ".": raw_text.count("."),
-        }
-        used = 0
-        for mark, count in punctuation_counts.items():
-            if count <= 0:
-                continue
-            effect_name = str(pause_map.get(mark, "")).strip()
-            if not effect_name:
-                continue
-            emit_count = min(count, max_pause_marks - used)
-            if emit_count <= 0:
-                break
-            for _ in range(emit_count):
-                self._post_interactions(
-                    "/effect",
-                    {"name": effect_name, "duration_ms": max(80, beat_duration_ms - 30), "force": force},
-                )
-            used += emit_count
-            if used >= max_pause_marks:
-                break
-
-    def _emit_speech_liveliness_end(self, duration_sec: float) -> None:
-        if not bool(self._liveliness_cfg.get("enabled", False)):
-            return
-        self._post_interactions("/event", {"type": "speech.end", "data": {"duration_sec": duration_sec}})
-
-    def stop_speaking(self) -> dict:
-        """Interrupt current TTS playback (wakeword barge-in)."""
+    def stop_speaking(self) -> Dict[str, Any]:
         try:
             from modules.speak.services.tts import cancel_synthesis
 
@@ -304,190 +118,139 @@ class SpeakService:
         except Exception:
             pass
         self.player.stop_playback()
+        self._expression_event("speak.finished", {"interrupted": True})
         return {"ok": True, "stopped": True}
-
-    # ── Meta-reasoning line starters to filter from TTS ──────────────
-    _THINK_STARTERS = (
-        "draft", "selection", "alternative", "let's ", "let me ",
-        "actually", "wait,", "wait ", "must be", "check ",
-        "checking", "final choice", "constraint", "role:",
-        "internal state", "happiness is", "boredom is", "energy is",
-        "time is", "happiness:", "energy:", "boredom:",
-        "last interaction:", "time:", "feeling:", "note:",
-        "option", "hmm", "analysis:", "sub-agent", "sub_agent",
-        "battery", "voltage", "temperature:", "sensor",
-        "i need to", "i should", "i'll ", "i will ",
-        "thinking", "reasoning", "approach:", "ldr:", "rssi:",
-        "cpu:", "memory:", "disk:", "uptime:", "current:",
-    )
-
-    _TELEMETRY_LABELS = frozenset({
-        "battery", "voltage", "current", "temperature",
-        "humidity", "distance", "ldr", "rssi", "status",
-        "cpu", "memory", "disk", "uptime", "level",
-    })
-
-    def _clean_text_for_speech(self, text: str) -> str:
-        """Remove LLM chain-of-thought, telemetry and formatting before TTS."""
-        if not text or not text.strip():
-            return ""
-
-        raw = str(text).strip()
-
-        # Fast path: single-line, no reasoning markers
-        if "\n" not in raw and not raw.startswith(("*", "-", ">", "#")):
-            return raw.replace("*", "").strip()
-
-        lines = raw.splitlines()
-        clean_lines: list[str] = []
-
-        for line in lines:
-            stripped = line.strip()
-            if not stripped:
-                continue
-
-            low = stripped.lower()
-
-            # ── Bullet points / list items ──
-            if re.match(r'^[\*\-\•\·\>\#]\s', stripped):
-                continue
-            # Indented bullets
-            if line != line.lstrip() and re.match(r'^\s+[\*\-\•]', line):
-                continue
-
-            # ── Meta-reasoning starters ──
-            if low.startswith(self._THINK_STARTERS):
-                continue
-
-            # ── Lines with word counts: (N words) ──
-            if re.search(r'\(\d+\s+words?\)', stripped):
-                continue
-
-            # ── Full-line evaluation in parens: (Strong, reflects...) ──
-            if re.match(r'^\(.*\)\.?$', stripped):
-                continue
-
-            # ── Fully-quoted draft lines ──
-            trimmed = stripped.rstrip(".").rstrip()
-            if len(trimmed) > 2 and trimmed[0] == '"' and trimmed[-1] == '"':
-                continue
-            if len(trimmed) > 2 and trimmed[0] == "'" and trimmed[-1] == "'":
-                continue
-
-            # ── Telemetry label: value lines ──
-            colon_match = re.match(r'^([A-Za-z][A-Za-z_ ]{0,25}):\s*(.*)$', stripped)
-            if colon_match:
-                label = colon_match.group(1).strip().lower()
-                value = colon_match.group(2).strip()
-                if label in self._TELEMETRY_LABELS:
-                    continue
-                # Short numeric values are likely telemetry
-                if len(value) < 15 and re.match(r'^[\d\.]+', value):
-                    continue
-
-            clean_lines.append(stripped)
-
-        # Fallback: take the last non-bullet, non-empty line
-        if not clean_lines:
-            for line in reversed(lines):
-                s = line.strip()
-                if s and not re.match(r'^[\*\-\>\#\•]', s):
-                    s = s.strip('"').strip("'").replace("*", "")
-                    s = re.sub(r'\(\d+\s+words?\)', '', s).strip()
-                    if s and len(s) > 3:
-                        clean_lines = [s]
-                        break
-
-        if not clean_lines:
-            return ""
-
-        # Remove asterisks and collapse whitespace
-        result = " ".join(clean_lines)
-        result = result.replace("*", "")
-        result = re.sub(r" +", " ", result).strip()
-        return result
 
     def speak(
         self,
         text: str,
         engine: Optional[str] = None,
-        tone: Optional[dict] | str = None,
+        tone: Optional[Dict[str, Any]] | str = None,
         speaker_wav: Optional[str] = None,
         language: Optional[str] = None,
-    ) -> dict:
-        """Metni sentezleyip oynatır; sonuç bilgisi döner.
-        engine: 'pyttsx3' | 'piper' | 'xtts' | None (config default)
-        """
-        if not text or not text.strip():
+        trace_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if not str(text or "").strip():
             raise ValueError("text is empty")
 
+        trace_id = latency_trace.ensure(trace_id, {"component": "speak", "language": language or ""})
+        latency_trace.mark(trace_id, "tts.request_received", {"chars": len(str(text))})
         cleaned_text = self._clean_text_for_speech(text)
-        if not cleaned_text or not cleaned_text.strip():
-            logger.info("Speech text is empty after cleaning thoughts/markdown. Skipping.")
-            return {"ok": True, "engine": engine or "default", "duration_sec": 0.0, "samplerate": 22050}
+        if not cleaned_text:
+            latency_trace.finish(trace_id, "skipped", {"reason": "empty_after_cleaning"})
+            return {"ok": True, "trace_id": trace_id, "duration_sec": 0.0, "skipped": True}
 
-        cleaned_text = self._enrich_text_for_speech(cleaned_text, tone=tone)
         tone_dict = self._coerce_tone(tone)
-        overrides = dict(tone_dict or {})
+        overrides: Dict[str, Any] = dict(tone_dict or {})
         if engine:
             overrides["engine"] = engine
         if speaker_wav:
             overrides["speaker_wav"] = speaker_wav
         if language:
             overrides["language"] = language
-        # Shape Piper audio from the emotion tone (rate/volume don't reach Piper).
-        active_engine = str(engine or self.cfg.get("tts", {}).get("engine", "")).strip().lower()
+
+        active_engine = str(engine or self.cfg.get("tts", {}).get("engine", "piper")).strip().lower()
         if active_engine == "piper":
-            piper_prosody = self._tone_to_piper(tone_dict)
-            if piper_prosody:
-                overrides["piper"] = {**overrides.get("piper", {}), **piper_prosody}
-        self._emit_speech_liveliness_start(cleaned_text, tone_dict)
-        try:
-            from modules.speak.services.tts import clear_synthesis_cancel
+            piper_tone = self._tone_to_piper(tone_dict)
+            if piper_tone:
+                overrides["piper"] = piper_tone
 
-            clear_synthesis_cancel()
-        except Exception:
-            pass
-        wav = self.tts.synthesize(cleaned_text, overrides=overrides or None)
-        dur = self.player.play_blocking(wav)
-        self._emit_speech_liveliness_end(dur)
         used_engine = overrides.get("engine") or self.cfg.get("tts", {}).get("engine")
-        return {"ok": True, "engine": used_engine, "duration_sec": dur, "samplerate": wav.samplerate}
+        with self._speech_lock:
+            try:
+                from modules.speak.services.tts import clear_synthesis_cancel
 
-    def play_wav(self, data: bytes) -> dict:
-        dur = self.player.play_wav_bytes(data)
-        return {"ok": True, "duration_sec": dur}
+                clear_synthesis_cancel()
+                synth_started = time.monotonic()
+                latency_trace.mark(trace_id, "tts.synthesis_start", {"engine": used_engine})
+                pcm = self.tts.synthesize(cleaned_text, overrides=overrides or None)
+                synthesis_ms = round((time.monotonic() - synth_started) * 1000.0, 2)
+                latency_trace.mark(
+                    trace_id,
+                    "tts.synthesis_done",
+                    {"engine": used_engine, "duration_ms": synthesis_ms, "samplerate": pcm.samplerate},
+                )
+            except TTSUnavailableError as exc:
+                latency_trace.finish(trace_id, "tts_unavailable", {"detail": str(exc)})
+                logger.warning("speech skipped: %s", exc)
+                return {
+                    "ok": False,
+                    "trace_id": trace_id,
+                    "engine": used_engine,
+                    "error": "tts_unavailable",
+                    "detail": str(exc),
+                    "duration_sec": 0.0,
+                }
+            except Exception as exc:
+                latency_trace.finish(trace_id, "tts_failed", {"detail": repr(exc)})
+                raise
+
+            self._expression_event(
+                "speak.started",
+                {"trace_id": trace_id, "tone": tone if isinstance(tone, str) else "", "chars": len(cleaned_text)},
+            )
+            latency_trace.mark(trace_id, "audio.play_start")
+            try:
+                duration_sec = self.player.play_blocking(pcm)
+            finally:
+                latency_trace.mark(trace_id, "audio.play_done")
+                self._expression_event("speak.finished", {"trace_id": trace_id})
+
+        latency_trace.finish(trace_id, "done", {"duration_sec": duration_sec})
+        snapshot = latency_trace.get(trace_id) or {}
+        return {
+            "ok": True,
+            "trace_id": trace_id,
+            "engine": used_engine,
+            "duration_sec": duration_sec,
+            "samplerate": pcm.samplerate,
+            "latency_ms": snapshot.get("elapsed_ms", 0.0),
+        }
+
+    def play_wav(self, data: bytes, trace_id: Optional[str] = None) -> Dict[str, Any]:
+        trace_id = latency_trace.ensure(trace_id, {"component": "speak.play_wav"})
+        self._expression_event("speak.started", {"trace_id": trace_id})
+        latency_trace.mark(trace_id, "audio.play_start")
+        try:
+            duration_sec = self.player.play_wav_bytes(data)
+        finally:
+            latency_trace.mark(trace_id, "audio.play_done")
+            self._expression_event("speak.finished", {"trace_id": trace_id})
+        latency_trace.finish(trace_id, "done", {"duration_sec": duration_sec})
+        return {"ok": True, "trace_id": trace_id, "duration_sec": duration_sec}
 
 
 def create_app(config_path: str | None = None) -> FastAPI:
     service = SpeakService(config_path)
     app = FastAPI()
-    from modules.speak.api import get_router  # local import to avoid circular
+    from modules.speak.api import get_router
+
     app.include_router(get_router(service))
     return app
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Speech output (TTS) service")
-    parser.add_argument("--config", type=str, default=None, help="Path to config.yml")
-    parser.add_argument("--api", action="store_true", help="Run FastAPI server using config server.host/port")
-    parser.add_argument("text", nargs="*", help="Text to speak (omit to start API)")
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Speech output service")
+    parser.add_argument("--config", type=str, default=None)
+    parser.add_argument("--api", action="store_true")
+    parser.add_argument("text", nargs="*")
     args = parser.parse_args()
-
     logging.basicConfig(level=logging.INFO)
 
     if args.api or not args.text:
         import uvicorn  # type: ignore
+
         cfg = load_config(args.config)
-        host = str(cfg.get("server", {}).get("host", "0.0.0.0"))
-        port = int(cfg.get("server", {}).get("port", 8083))
-        uvicorn.run(create_app(args.config), host=host, port=port, log_config=None)
+        server = cfg.get("server", {})
+        uvicorn.run(
+            create_app(args.config),
+            host=str(server.get("host", "0.0.0.0")),
+            port=int(server.get("port", 8083)),
+            log_config=None,
+        )
         return
 
-    service = SpeakService(args.config)
-    txt = " ".join(args.text)
-    res = service.speak(txt)
-    print(res)
+    print(SpeakService(args.config).speak(" ".join(args.text)))
 
 
 if __name__ == "__main__":

--- a/modules/speech/README.md
+++ b/modules/speech/README.md
@@ -35,8 +35,8 @@ svc.start_background(on_result=lambda r: print(r))
 ```
 
 ### CLI
-```powershell
-python -m modules.speech.xSpeechService --listen-once
+```bash
+python3 -m modules.speech.xSpeechService --listen-once
 # veya API
 python -m modules.speech.xSpeechService --api --config config/agent.yaml
 ```

--- a/modules/speech/api/router.py
+++ b/modules/speech/api/router.py
@@ -95,10 +95,14 @@ def get_router(service: SpeechService, gateway_base_url: str = "") -> APIRouter:
 
     @router.get("/speech/status")
     async def status():
+        stt = service.stt_status() if hasattr(service, "stt_status") else {}
         return {
+            "ok": bool(stt.get("available", False)),
             "listening": service.listening,
-            "model_ready": getattr(service, "recognizer", None) is not None,
+            "model_ready": bool(stt.get("available", False)),
+            "stt_available": bool(stt.get("available", False)),
             "stt_suppressed": bool(getattr(service, "is_stt_suppressed", lambda: False)()),
+            "stt": stt,
         }
 
     last: dict | None = {"text": None, "language": getattr(service, "source_language", "tr"), "ts": 0.0}
@@ -221,6 +225,14 @@ def get_router(service: SpeechService, gateway_base_url: str = "") -> APIRouter:
     async def start():
         was_listening = service.listening
         logger.info("speech start requested (was_listening=%s)", was_listening)
+        stt = service.stt_status() if hasattr(service, "stt_status") else {}
+        if not stt.get("available", False):
+            logger.warning(
+                "speech start rejected: stt unavailable primary_language=%s reason=%s",
+                stt.get("primary_language"),
+                stt.get("reason"),
+            )
+            return {"ok": False, "listening": False, "reason": "stt_unavailable", "stt": stt}
         if hasattr(service, "clear_utterance_buffer"):
             service.clear_utterance_buffer()
         service.start_background(on_result=_cb)
@@ -228,7 +240,7 @@ def get_router(service: SpeechService, gateway_base_url: str = "") -> APIRouter:
         logger.info("speech start handled (listening=%s)", service.listening)
         if not was_listening:
             _emit_speech_event("speech.listen.start")
-        return {"ok": True, "listening": service.listening}
+        return {"ok": True, "listening": service.listening, "stt": stt}
 
     @router.post("/speech/stop")
     async def stop():

--- a/modules/speech/services/recognizer.py
+++ b/modules/speech/services/recognizer.py
@@ -70,6 +70,44 @@ class Recognizer:
         }
         return mapping.get(lang, mapping.get("en", "models/vosk-en"))
 
+    def resolved_model_path(self) -> str:
+        """Return the absolute model path that this recognizer would load."""
+        model_path = self._resolve_model_path()
+        if not os.path.isabs(model_path):
+            module_root = Path(__file__).resolve().parents[1]
+            model_path = str((module_root / model_path).resolve())
+        return str(model_path)
+
+    def status(self) -> dict:
+        """Cheap readiness check; never loads the heavy Vosk model."""
+        model_path = self.resolved_model_path()
+        vosk_available = True
+        vosk_error = ""
+        try:
+            import vosk  # type: ignore  # noqa: F401
+        except Exception as exc:
+            vosk_available = False
+            vosk_error = str(exc)
+        model_exists = os.path.isdir(model_path)
+        error_parts = []
+        if not vosk_available:
+            error_parts.append("vosk package unavailable")
+        if not model_exists:
+            error_parts.append("model directory missing")
+        return {
+            "ok": bool(vosk_available and model_exists),
+            "language": self.cfg.language or "tr",
+            "model_path": model_path,
+            "model_exists": bool(model_exists),
+            "model_loaded": bool(self._model is not None),
+            "vosk_available": bool(vosk_available),
+            "vosk_error": vosk_error,
+            "error": "; ".join(error_parts),
+        }
+
+    def is_available(self) -> bool:
+        return bool(self.status().get("ok"))
+
     def _ensure_model(self):
         global Model, KaldiRecognizer, webrtcvad
         if Model is None or KaldiRecognizer is None:
@@ -82,11 +120,7 @@ class Recognizer:
             Model = _Model
             KaldiRecognizer = _KaldiRecognizer
         if self._model is None:
-            model_path = self._resolve_model_path()
-            # resolve relative to module root
-            if not os.path.isabs(model_path):
-                module_root = Path(__file__).resolve().parents[1]
-                model_path = str((module_root / model_path).resolve())
+            model_path = self.resolved_model_path()
             if not os.path.isdir(model_path):
                 raise FileNotFoundError(f"Vosk model directory not found: {model_path}")
             self._model = Model(model_path)

--- a/modules/speech/xSpeechService.py
+++ b/modules/speech/xSpeechService.py
@@ -131,12 +131,21 @@ class SpeechService:
                 alt_cfg["language"] = lang_key
                 alt_cfg.pop("model_path", None)
                 try:
-                    self._extra_recognizers[lang] = Recognizer(alt_cfg)
-                    try:
-                        self._extra_recognizers[lang]._ensure_model()
-                        logger.info("%s Vosk model pre-loaded for dual-decode STT", lang.upper())
-                    except Exception as warm_exc:
-                        logger.warning("%s Vosk model pre-warm failed (will lazy-load): %s", lang.upper(), warm_exc)
+                    alt_recognizer = Recognizer(alt_cfg)
+                    self._extra_recognizers[lang] = alt_recognizer
+                    alt_status = alt_recognizer.status()
+                    if alt_status.get("ok"):
+                        try:
+                            alt_recognizer._ensure_model()
+                            logger.info("%s Vosk model pre-loaded for dual-decode STT", lang.upper())
+                        except Exception as warm_exc:
+                            logger.warning("%s Vosk model pre-warm failed: %s", lang.upper(), warm_exc)
+                    else:
+                        logger.info(
+                            "%s Vosk model not installed; dual-decode disabled until model exists: %s",
+                            lang.upper(),
+                            alt_status.get("model_path"),
+                        )
                 except Exception as exc:
                     logger.warning("%s Vosk model unavailable for auto STT: %s", lang.upper(), exc)
             # Backward-compatible single secondary pointer (first extra)
@@ -164,6 +173,52 @@ class SpeechService:
         with self._stt_suppress_lock:
             return bool(self._stt_suppressed)
 
+    def stt_status(self) -> dict:
+        """Return truthful STT model/package readiness without opening the microphone."""
+        primary = self.recognizer.status() if self.recognizer is not None else {"ok": False, "error": "recognizer missing"}
+        languages: dict[str, dict] = {}
+        rec_cfg = self.cfg.get("recognition", {}) if isinstance(self.cfg.get("recognition", {}), dict) else {}
+        language_models = rec_cfg.get("language_models") if isinstance(rec_cfg.get("language_models"), dict) else {}
+        primary_lang = str(primary.get("language") or rec_cfg.get("language") or self.source_language or "tr").split("-", 1)[0].lower()
+        languages[primary_lang] = primary
+        for lang, recognizer in self._extra_recognizers.items():
+            try:
+                languages[str(lang).split("-", 1)[0].lower()] = recognizer.status()
+            except Exception as exc:
+                languages[str(lang).split("-", 1)[0].lower()] = {"ok": False, "error": str(exc)}
+        for lang in language_models.keys():
+            key = str(lang).split("-", 1)[0].lower()
+            if key in languages:
+                continue
+            cfg = copy.deepcopy(rec_cfg)
+            cfg["language"] = lang
+            cfg.pop("model_path", None)
+            try:
+                languages[key] = Recognizer(cfg).status()
+            except Exception as exc:
+                languages[key] = {"ok": False, "language": key, "error": str(exc)}
+        ready_languages = sorted([lang for lang, st in languages.items() if st.get("ok")])
+        missing_languages = sorted([lang for lang, st in languages.items() if not st.get("ok")])
+        available = bool(primary.get("ok"))
+        return {
+            "available": available,
+            "model_ready": available,
+            "listening": self.listening,
+            "suppressed": self.is_stt_suppressed(),
+            "primary_language": primary_lang,
+            "default_language": self._default_language,
+            "auto_language": bool(self._auto_language),
+            "auto_switch_model": bool(self._auto_switch_model),
+            "primary": primary,
+            "languages": languages,
+            "ready_languages": ready_languages,
+            "missing_languages": missing_languages,
+            "reason": "ready" if available else (primary.get("error") or "primary model unavailable"),
+        }
+
+    def is_stt_available(self) -> bool:
+        return bool(self.stt_status().get("available"))
+
     def start(self, on_result: Optional[Callable[[RecognitionResult], None]] = None) -> None:
         """Start capturing and recognition in the same thread using a generator pipeline.
 
@@ -178,6 +233,16 @@ class SpeechService:
                 self._on_result_cb = on_result
         self._stop_event.clear()
         try:
+            stt_status = self.stt_status()
+            if not stt_status.get("available"):
+                primary = stt_status.get("primary", {}) if isinstance(stt_status.get("primary"), dict) else {}
+                logger.warning(
+                    "speech stt unavailable: primary_language=%s model_path=%s reason=%s",
+                    stt_status.get("primary_language"),
+                    primary.get("model_path"),
+                    stt_status.get("reason"),
+                )
+                return
             stream: Iterable[bytes] = self.capture.stream()
             for result in self.recognizer.run(self._direction_wrapper(stream)):
                 if self.is_stt_suppressed():

--- a/modules/wakeword/xWakewordService.py
+++ b/modules/wakeword/xWakewordService.py
@@ -75,7 +75,7 @@ def _get_json(url: str, timeout: float = 0.2) -> dict:
 
 def _resolve_model_paths(rec_cfg: dict) -> dict:
     cfg = dict(rec_cfg or {})
-    module_root = Path(__file__).resolve().parent
+    module_root = Path(__file__).resolve().parents[1] / "speech"
     model_path = cfg.get("model_path")
     if model_path and not os.path.isabs(str(model_path)):
         cfg["model_path"] = str((module_root / str(model_path)).resolve())
@@ -350,15 +350,26 @@ class WakewordService:
             return self._listening
 
     def status(self) -> dict:
+        recognizer_status = None
+        if self._recognizer is not None and hasattr(self._recognizer, "status"):
+            try:
+                recognizer_status = self._recognizer.status()
+            except Exception as exc:
+                recognizer_status = {"ok": False, "error": str(exc)}
+        engine_ready = bool(self._openwakeword is not None or (recognizer_status or {}).get("ok"))
         with self._lock:
             return {
+                "ok": bool(engine_ready and not self._degraded_reason),
                 "listening": self._listening,
                 "active_window": self._active_window,
                 "last_trigger_ts": self._last_trigger_ts,
                 "wakewords": list(self.detector.cfg.words),
                 "engine": self.engine,
+                "engine_ready": bool(engine_ready),
                 "degraded": bool(self._degraded_reason),
                 "degraded_reason": self._degraded_reason,
+                "recognizer": recognizer_status,
+                "openwakeword_ready": bool(self._openwakeword is not None),
             }
 
 

--- a/tests/modules/ollama/test_base_url_truth_pc.py
+++ b/tests/modules/ollama/test_base_url_truth_pc.py
@@ -1,0 +1,50 @@
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from modules.ollama.api.health import get_health_router
+from modules.ollama.config_loader import _normalize_base_url
+from modules.ollama.services.clients import OllamaClient
+
+
+def test_config_loader_rejects_gateway_self_url_for_ollama_daemon():
+    assert _normalize_base_url("http://127.0.0.1:8080") == "http://127.0.0.1:11434"
+    assert _normalize_base_url("http://localhost:8080/ollama/chat") == "http://127.0.0.1:11434"
+    assert _normalize_base_url("@gateway/ollama/chat") == "http://127.0.0.1:11434"
+
+
+def test_config_loader_keeps_real_ollama_url():
+    assert _normalize_base_url("http://127.0.0.1:11434") == "http://127.0.0.1:11434"
+    assert _normalize_base_url("http://192.168.1.50:11434") == "http://192.168.1.50:11434"
+
+
+def test_ollama_client_rejects_gateway_self_url():
+    client = OllamaClient("http://127.0.0.1:8080", "qwen3.5:9b")
+    assert client.base_url == "http://127.0.0.1:11434"
+
+
+class ResponseStub:
+    status_code = 200
+    content = b"{}"
+
+    def json(self):
+        return {"models": [{"name": "qwen3.5:9b"}]}
+
+
+def test_health_corrects_gateway_self_url_before_probe(monkeypatch):
+    seen = {}
+
+    def fake_get(url, timeout):
+        seen["url"] = url
+        return ResponseStub()
+
+    monkeypatch.setattr("modules.ollama.api.health.requests.get", fake_get)
+    app = FastAPI()
+    app.include_router(get_health_router({"ollama": {"base_url": "http://127.0.0.1:8080"}}, "ollama", "qwen3.5:9b"), prefix="/ollama")
+
+    data = TestClient(app).get("/ollama/healthz").json()
+
+    assert seen["url"] == "http://127.0.0.1:11434/api/tags"
+    assert data["base_url"] == "http://127.0.0.1:11434"
+    assert data["configured_base_url"] == "http://127.0.0.1:8080"
+    assert data["base_url_corrected"] is True
+    assert data["ok"] is True

--- a/tests/modules/ollama/test_chat_routes_unavailable.py
+++ b/tests/modules/ollama/test_chat_routes_unavailable.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from modules.ollama.api.chat_routes import get_chat_router
+
+
+class MissingModelChat:
+    def chat(self, query):
+        raise RuntimeError('{"detail":"Not Found"} (status code: 404)')
+
+
+class TranslatorStub:
+    BRIDGE_LANG = "en"
+
+    class Cfg:
+        enabled = False
+        default_source_lang = "tr"
+
+    cfg = Cfg()
+
+    def normalize_lang(self, value, fallback="tr"):
+        return value or fallback
+
+    def detect_language(self, query):
+        return "tr"
+
+    def to_bridge(self, query, source):
+        return query
+
+    def from_bridge(self, answer, target):
+        return answer
+
+
+def test_chat_returns_ok_false_for_missing_ollama_model_without_500():
+    app = FastAPI()
+    app.include_router(get_chat_router(
+        MissingModelChat(),
+        TranslatorStub(),
+        "missing-model:latest",
+        "ollama",
+        "sentry",
+        "",
+        1.0,
+        False,
+    ), prefix="/ollama")
+    client = TestClient(app)
+
+    resp = client.post("/ollama/chat", params={"query": "Merhaba"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["error"] == "llm_model_unavailable"
+    assert data["answer"] == ""

--- a/tests/modules/ollama/test_health_model_truth.py
+++ b/tests/modules/ollama/test_health_model_truth.py
@@ -1,0 +1,46 @@
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from modules.ollama.api.health import get_health_router
+
+
+class ResponseStub:
+    status_code = 200
+    content = b"{}"
+
+    def __init__(self, models):
+        self._models = models
+
+    def json(self):
+        return {"models": [{"name": name} for name in self._models]}
+
+
+def test_ollama_health_reports_missing_model(monkeypatch):
+    def fake_get(url, timeout):
+        return ResponseStub(["llama3.2:3b"])
+
+    monkeypatch.setattr("modules.ollama.api.health.requests.get", fake_get)
+    app = FastAPI()
+    app.include_router(get_health_router({"ollama": {"base_url": "http://127.0.0.1:11434"}}, "ollama", "qwen3.5:9b"), prefix="/ollama")
+
+    data = TestClient(app).get("/ollama/healthz").json()
+
+    assert data["daemon_ok"] is True
+    assert data["model_available"] is False
+    assert data["ok"] is False
+    assert data["error"] == "ollama_model_missing"
+
+
+def test_ollama_health_accepts_available_model(monkeypatch):
+    def fake_get(url, timeout):
+        return ResponseStub(["qwen3.5:9b"])
+
+    monkeypatch.setattr("modules.ollama.api.health.requests.get", fake_get)
+    app = FastAPI()
+    app.include_router(get_health_router({"ollama": {"base_url": "http://127.0.0.1:11434"}}, "ollama", "qwen3.5:9b"), prefix="/ollama")
+
+    data = TestClient(app).get("/ollama/healthz").json()
+
+    assert data["daemon_ok"] is True
+    assert data["model_available"] is True
+    assert data["ok"] is True

--- a/tests/modules/speak/test_config_loader_compatibility_contract.py
+++ b/tests/modules/speak/test_config_loader_compatibility_contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from modules.speak.config_loader import (
+    SPEAK_CONFIG_COMPATIBILITY_CONTRACT,
+    SPEAK_CONFIG_COMPATIBILITY_ROLE,
+    _normalize_speak_section,
+)
+
+
+def test_speak_engine_shorthand_maps_to_tts_engine_without_local_config():
+    cfg = _normalize_speak_section({
+        "engine": "piper",
+        "tts": {
+            "engine": "pyttsx3",
+            "piper": {"model_path": "data/piper_models/test.onnx"},
+        },
+    })
+    assert SPEAK_CONFIG_COMPATIBILITY_CONTRACT is True
+    assert SPEAK_CONFIG_COMPATIBILITY_ROLE == "agent_yaml_shorthand_alias_normalizer"
+    assert cfg["tts"]["engine"] == "piper"
+    assert cfg["tts"]["piper"]["model_path"].endswith("data\\piper_models\\test.onnx") or cfg["tts"]["piper"]["model_path"].endswith("data/piper_models/test.onnx")
+
+
+def test_speak_tts_section_is_preserved_when_no_shorthand_engine():
+    cfg = _normalize_speak_section({"tts": {"engine": "remote", "timeout": 5}})
+    assert cfg["tts"]["engine"] == "remote"
+    assert cfg["tts"]["timeout"] == 5
+
+
+def test_non_dict_piper_section_normalizes_safely():
+    cfg = _normalize_speak_section({"engine": "piper", "tts": {"piper": "bad"}})
+    assert cfg["tts"]["engine"] == "piper"
+    assert cfg["tts"].get("piper") == "bad"

--- a/tests/modules/speak/test_tts_truth.py
+++ b/tests/modules/speak/test_tts_truth.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from modules.speak.services.tts import DummyBackend, TextToSpeech, TTSUnavailableError, UnavailableBackend
+
+
+def test_missing_piper_model_is_unavailable_not_dummy_by_default() -> None:
+    tts = TextToSpeech({"engine": "piper", "piper": {"model_path": "data/piper_models/__missing__/model.onnx"}})
+    assert isinstance(tts.backend, UnavailableBackend)
+    assert not tts.health()["available"]
+    try:
+        tts.synthesize("Merhaba")
+    except TTSUnavailableError as exc:
+        assert "piper model unavailable" in str(exc)
+    else:
+        raise AssertionError("missing Piper model must not synthesize dummy audio")
+
+
+def test_dummy_backend_requires_explicit_allow_dummy_fallback_on_pc_dev(monkeypatch) -> None:
+    monkeypatch.setenv("SENTRYBOT_RUNTIME_TARGET", "pc")
+    monkeypatch.delenv("SENTRYBOT_ALLOW_TEST_TTS", raising=False)
+    tts = TextToSpeech({
+        "engine": "piper",
+        "allow_dummy_fallback": True,
+        "piper": {"model_path": "data/piper_models/__missing__/model.onnx"},
+    })
+    assert isinstance(tts.backend, DummyBackend)
+    assert tts.health()["dummy_enabled"] is True
+
+
+def test_pi_robot_target_blocks_dummy_fallback_even_when_requested(monkeypatch) -> None:
+    monkeypatch.setenv("SENTRYBOT_RUNTIME_TARGET", "pi")
+    monkeypatch.delenv("SENTRYBOT_ALLOW_TEST_TTS", raising=False)
+    monkeypatch.delenv("SENTRYBOT_ALLOW_TEST_TONE_TTS", raising=False)
+    tts = TextToSpeech({
+        "engine": "piper",
+        "allow_dummy_fallback": True,
+        "piper": {"model_path": "data/piper_models/__missing__/model.onnx"},
+    })
+    assert isinstance(tts.backend, UnavailableBackend)
+    health = tts.health()
+    assert health["available"] is False
+    assert health["dummy_enabled"] is False
+    assert "dummy/test-tone TTS is disabled" in health["error"]
+
+
+def test_pi_robot_target_blocks_explicit_dummy_engine(monkeypatch) -> None:
+    monkeypatch.setenv("SENTRYBOT_RUNTIME_TARGET", "robot")
+    monkeypatch.delenv("SENTRYBOT_ALLOW_TEST_TTS", raising=False)
+    tts = TextToSpeech({"engine": "dummy", "allow_dummy_fallback": True})
+    assert isinstance(tts.backend, UnavailableBackend)
+    assert tts.health()["dummy_enabled"] is False
+
+
+def test_pi_robot_target_allows_test_tone_only_with_explicit_env(monkeypatch) -> None:
+    monkeypatch.setenv("SENTRYBOT_RUNTIME_TARGET", "pi")
+    monkeypatch.setenv("SENTRYBOT_ALLOW_TEST_TTS", "1")
+    tts = TextToSpeech({"engine": "dummy", "allow_dummy_fallback": True})
+    assert isinstance(tts.backend, DummyBackend)
+    assert tts.health()["dummy_enabled"] is True
+
+
+def test_speak_status_reports_unavailable_tts() -> None:
+    tts = TextToSpeech({"engine": "piper", "piper": {"model_path": "data/piper_models/__missing__/model.onnx"}})
+    health = tts.health()
+    assert health["available"] is False
+    assert health["backend"] == "UnavailableBackend"
+    assert "piper model unavailable" in health["error"]

--- a/tests/modules/speech/test_stt_truth_status.py
+++ b/tests/modules/speech/test_stt_truth_status.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import yaml
+
+
+def test_recognizer_status_reports_missing_model(tmp_path: Path) -> None:
+    from modules.speech.services.recognizer import Recognizer
+
+    missing = tmp_path / "missing-vosk"
+    rec = Recognizer({"language": "tr", "language_models": {"tr": str(missing)}})
+    status = rec.status()
+
+    assert status["ok"] is False
+    assert status["model_exists"] is False
+    assert status["model_path"] == str(missing)
+    assert "model" in status["error"]
+
+
+def test_speech_service_status_rejects_missing_primary_model(tmp_path: Path) -> None:
+    from modules.speech.xSpeechService import SpeechService
+
+    cfg = {
+        "audio": {"device": None, "samplerate": 16000, "channels": 1, "dtype": "int16", "frame_ms": 30},
+        "recognition": {
+            "language": "tr",
+            "default_language": "tr",
+            "source_language": "tr",
+            "auto_language": True,
+            "auto_switch_model": True,
+            "dual_decode_languages": ["tr", "en"],
+            "language_models": {"tr": str(tmp_path / "vosk-tr"), "en": str(tmp_path / "vosk-en")},
+            "samplerate": 16000,
+            "vad": {"enabled": False},
+        },
+        "direction": {"enabled": False},
+    }
+    config_path = tmp_path / "speech.yml"
+    config_path.write_text(yaml.safe_dump({"speech": cfg}), encoding="utf-8")
+
+    service = SpeechService(str(config_path))
+    status = service.stt_status()
+
+    assert status["available"] is False
+    assert status["model_ready"] is False
+    assert status["primary_language"] == "tr"
+    assert "tr" in status["missing_languages"]
+
+
+def test_speech_router_start_returns_stt_unavailable(tmp_path: Path) -> None:
+    from modules.speech.xSpeechService import SpeechService
+    from modules.speech.api.router import get_router
+
+    cfg = {
+        "audio": {"device": None, "samplerate": 16000, "channels": 1, "dtype": "int16", "frame_ms": 30},
+        "recognition": {
+            "language": "tr",
+            "default_language": "tr",
+            "source_language": "tr",
+            "auto_language": False,
+            "auto_switch_model": False,
+            "language_models": {"tr": str(tmp_path / "vosk-tr")},
+            "samplerate": 16000,
+            "vad": {"enabled": False},
+        },
+        "direction": {"enabled": False},
+    }
+    config_path = tmp_path / "speech.yml"
+    config_path.write_text(yaml.safe_dump({"speech": cfg}), encoding="utf-8")
+    service = SpeechService(str(config_path))
+    router = get_router(service)
+    start_route = next(route for route in router.routes if getattr(route, "path", "") == "/speech/start")
+
+    result = asyncio.run(start_route.endpoint())
+
+    assert result["ok"] is False
+    assert result["reason"] == "stt_unavailable"
+    assert result["stt"]["available"] is False


### PR DESCRIPTION
## Summary
- Harden speak TTS service/config and speech STT status truth.
- Tighten Ollama base URL/health model reporting.
- Align wakeword service with external model assets.

## Change type
- [x] Feature / chore / docs (see title)
- [ ] Bug fix

## Affected modules
`modules/speak`, `modules/speech`, `modules/ollama`, `modules/wakeword`

## Test plan
- [ ] Speak TTS truth tests pass
- [ ] Speech STT status tests pass
- [ ] Ollama health/chat unavailable contracts pass

## Notes
- Stacked PR: merge order is 1 → 9. Base is `feat/vision-budget-and-camera-truth` until the previous PR lands; then retarget to `dev`.
- Gateway API keys from local WIP were intentionally not committed (kept empty).
- Backup snapshot: `backup/pre-split-20260718` / `refs/backup/pre-split-20260718`

## Risk / rollback
Revert this branch or close the PR; no production deploy assumed until Pi deploy PR is merged and tested.