### PR TITLE
feat(autonomy): pet companion needs, goals, memory, and capabilities

### DIFF
--- a/config/autonomy/pet_companion_profile.json
+++ b/config/autonomy/pet_companion_profile.json
@@ -1,0 +1,16 @@
+{
+  "name": "sentry",
+  "traits": {
+    "curiosity": 0.72,
+    "sociability": 0.68,
+    "calmness": 0.58,
+    "playfulness": 0.62,
+    "protectiveness": 0.70,
+    "independence": 0.45
+  },
+  "style": {
+    "speech": "short_warm",
+    "motion": "soft_reactive",
+    "expression": "alive_subtle"
+  }
+}

--- a/config/robot_arm_policy.json
+++ b/config/robot_arm_policy.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "enabled": true,
+  "default_armed": false,
+  "allow_pc_arm": false,
+  "allow_real_hardware": false,
+  "require_manual_arm": true,
+  "require_robot_safe_preflight": true,
+  "require_robot_safety_ci": true,
+  "require_capability_registry": true,
+  "require_dry_run_until_armed": true,
+  "max_arm_ttl_s": 300,
+  "allowed_profiles_when_armed": [
+    "robot_safe_manual"
+  ],
+  "blocked_profiles_when_disarmed": [
+    "robot_safe",
+    "robot_safe_manual",
+    "robot_real"
+  ],
+  "allowed_risks_when_disarmed": [
+    "none",
+    "low"
+  ],
+  "blocked_priorities_when_disarmed": [
+    "critical"
+  ],
+  "notes": "Default lock for PC/refactor mode. Real hardware remains disabled until a later explicit robot profile step."
+}

--- a/config/robot_capability_registry.json
+++ b/config/robot_capability_registry.json
@@ -1,0 +1,125 @@
+{
+  "schema": "sentrybot.robot_capabilities.v2",
+  "policy": {
+    "blocked_risks": [
+      "critical"
+    ],
+    "stop_on_failure": true
+  },
+  "capabilities": {
+    "expression.event": {
+      "handler": "expression_event",
+      "risk": "none",
+      "enabled": true
+    },
+    "motion.freeze": {
+      "handler": "stop_motion",
+      "risk": "low",
+      "enabled": true
+    },
+    "motion.look_around": {
+      "handler": "animate",
+      "default_name": "look_around",
+      "risk": "low",
+      "enabled": true
+    },
+    "motion.stretch_or_scan": {
+      "handler": "animate",
+      "default_name": "stretch",
+      "risk": "low",
+      "enabled": true
+    },
+    "motion.attend": {
+      "handler": "animate",
+      "default_name": "vision_focus",
+      "risk": "low",
+      "enabled": true
+    },
+    "pose.sleepy_idle": {
+      "handler": "animate",
+      "default_name": "sleepy_idle",
+      "risk": "low",
+      "enabled": true
+    },
+    "vision.cheap": {
+      "handler": "vision_latest",
+      "risk": "none",
+      "enabled": true
+    },
+    "vision.semantic": {
+      "handler": "vision_refresh",
+      "risk": "none",
+      "enabled": true
+    },
+    "perception.owner_scan": {
+      "handler": "track_target",
+      "risk": "low",
+      "enabled": true
+    },
+    "speech.short_prompt": {
+      "handler": "speak",
+      "fallback_text": "Buradayım. Birlikte bir şey yapalım mı?",
+      "risk": "low",
+      "enabled": true
+    },
+    "speech.silent": {
+      "handler": "semantic_noop",
+      "risk": "none",
+      "enabled": true
+    },
+    "scheduler.wait": {
+      "handler": "wait",
+      "risk": "none",
+      "enabled": true
+    },
+    "semantic.pet_intent": {
+      "handler": "semantic_noop",
+      "risk": "none",
+      "enabled": true
+    },
+    "semantic.unknown": {
+      "handler": "semantic_noop",
+      "risk": "none",
+      "enabled": true
+    },
+    "perception.track_object": {
+      "handler": "track_target",
+      "risk": "low",
+      "enabled": true
+    },
+    "navigation.rest_corner": {
+      "handler": "rest_corner",
+      "risk": "low",
+      "enabled": true
+    },
+    "memory.observe": {
+      "handler": "memory_observe",
+      "risk": "none",
+      "enabled": true
+    },
+    "navigation.goal": {
+      "enabled": true,
+      "risk": "medium",
+      "handler": "navigation_goal",
+      "description": "Execute a topomap navigation goal through safe motion gating."
+    },
+    "owner.learn": {
+      "enabled": true,
+      "risk": "low",
+      "handler": "owner_learn",
+      "description": "Learn a person as owner/known person."
+    },
+    "owner.identify": {
+      "enabled": true,
+      "risk": "low",
+      "handler": "owner_identify",
+      "description": "Identify current camera target against owner memory."
+    },
+    "assets.status": {
+      "enabled": true,
+      "risk": "none",
+      "handler": "asset_status",
+      "description": "Read Pi model/runtime asset truth."
+    }
+  }
+}

--- a/config/robot_execution_profiles.json
+++ b/config/robot_execution_profiles.json
@@ -1,0 +1,15 @@
+{
+  "schema": "sentrybot.robot_execution_profiles.v2",
+  "active_mode": "raspberry_pi",
+  "profiles": {
+    "raspberry_pi": {
+      "description": "Raspberry Pi 5 robot runtime.",
+      "allow_real_hardware": true,
+      "allowed_risks": ["none", "low", "medium"],
+      "blocked_risks": ["critical"],
+      "max_parallel_actions": 1,
+      "action_timeout_s": 2.0,
+      "stop_on_failure": true
+    }
+  }
+}

--- a/modules/autonomy/api/router.py
+++ b/modules/autonomy/api/router.py
@@ -29,6 +29,354 @@ def get_router(brain: AutonomyBrain) -> APIRouter:
     def get_state():
         return brain.state
 
+    @router.get("/needs")
+    def get_needs():
+        """Return the central companion needs snapshot."""
+        if hasattr(brain, "get_needs_snapshot"):
+            return brain.get_needs_snapshot()
+        return {"ok": False, "available": False, "reason": "needs_snapshot_unavailable"}
+
+    @router.get("/goal")
+    def get_goal():
+        """Return the current semantic companion goal plan."""
+        if hasattr(brain, "get_companion_goal_snapshot"):
+            return brain.get_companion_goal_snapshot()
+        return {"ok": False, "available": False, "reason": "goal_snapshot_unavailable"}
+
+    @router.get("/memory/needs-bias")
+    def get_memory_needs_bias():
+        if hasattr(brain, "get_memory_needs_bias_snapshot"):
+            return brain.get_memory_needs_bias_snapshot()
+        return {"ok": False, "available": False, "reason": "memory_needs_bias_unavailable"}
+
+    @router.post("/memory/needs-bias/evaluate")
+    def evaluate_memory_needs_bias(payload: Dict[str, Any]):
+        if hasattr(brain, "evaluate_memory_needs_bias"):
+            return brain.evaluate_memory_needs_bias(payload or {})
+        return {"ok": False, "available": False, "reason": "memory_needs_bias_unavailable"}
+
+    @router.get("/memory/decision-shadow")
+    def get_memory_decision_shadow():
+        if hasattr(brain, "get_memory_decision_shadow"):
+            return brain.get_memory_decision_shadow()
+        return {"ok": False, "available": False, "reason": "memory_decision_shadow_unavailable"}
+
+    @router.post("/memory/decision-shadow/evaluate")
+    def evaluate_memory_decision_shadow(payload: Dict[str, Any]):
+        if hasattr(brain, "evaluate_memory_decision_shadow"):
+            return brain.evaluate_memory_decision_shadow(payload or {})
+        return {"ok": False, "available": False, "reason": "memory_decision_shadow_unavailable"}
+
+    @router.get("/memory/autowrite")
+    def get_world_memory_autowrite():
+        if hasattr(brain, "get_world_memory_autowrite_snapshot"):
+            return brain.get_world_memory_autowrite_snapshot()
+        return {"ok": False, "available": False, "reason": "world_memory_autowrite_unavailable"}
+
+    @router.post("/memory/autowrite")
+    def observe_world_memory_from_context(payload: Dict[str, Any]):
+        source_type = ""
+        context = payload or {}
+        if isinstance(payload, dict):
+            source_type = str(payload.get("source_type") or payload.get("type") or payload.get("source") or "")
+            context = payload.get("context") if isinstance(payload.get("context"), dict) else payload
+        if hasattr(brain, "observe_context_world_memory"):
+            return brain.observe_context_world_memory(source_type or "api", context or {})
+        return {"ok": False, "available": False, "reason": "world_memory_autowrite_unavailable"}
+
+    @router.get("/memory")
+    def get_world_memory():
+        """Return world-memory counts and recent semantic facts."""
+        if hasattr(brain, "get_world_memory_snapshot"):
+            return brain.get_world_memory_snapshot()
+        return {"ok": False, "available": False, "reason": "world_memory_unavailable"}
+
+    @router.get("/memory/schema")
+    def get_world_memory_schema():
+        """Return the local semantic world-memory schema."""
+        if hasattr(brain, "get_world_memory_schema"):
+            return brain.get_world_memory_schema()
+        return {"ok": False, "available": False, "reason": "world_memory_unavailable"}
+
+    @router.get("/memory/recent")
+    def get_world_memory_recent(kind: str = "", limit: int = 10):
+        """Return recent world-memory items, optionally filtered by kind."""
+        if hasattr(brain, "get_world_memory_recent"):
+            return brain.get_world_memory_recent(kind or None, limit)
+        return {"ok": False, "available": False, "reason": "world_memory_unavailable"}
+
+    @router.get("/memory/history")
+    def get_world_memory_history(limit: int = 20):
+        """Return compact memory write history."""
+        if hasattr(brain, "get_world_memory_history"):
+            return brain.get_world_memory_history(limit)
+        return {"ok": False, "available": False, "reason": "world_memory_unavailable"}
+
+    @router.get("/memory/search")
+    def search_world_memory(q: str = "", limit: int = 8):
+        """Recall semantic world-memory items for RAG."""
+        if hasattr(brain, "recall_world_memory"):
+            return brain.recall_world_memory(q, limit)
+        return {"ok": False, "available": False, "reason": "world_memory_unavailable"}
+
+    @router.get("/memory/context")
+    def get_world_memory_context(q: str = "", limit: int = 8):
+        """Return compact RAG context text for the agent."""
+        if hasattr(brain, "get_world_memory_context"):
+            return brain.get_world_memory_context(q, limit)
+        return {"ok": False, "available": False, "reason": "world_memory_unavailable", "context": ""}
+
+    @router.post("/memory/observe")
+    def observe_world_memory(payload: Dict[str, Any]):
+        """Store a semantic observation in world memory."""
+        if hasattr(brain, "observe_world_memory"):
+            return brain.observe_world_memory(payload or {}, source="api")
+        return {"ok": False, "available": False, "reason": "world_memory_unavailable"}
+
+    @router.post("/memory/clear")
+    def clear_world_memory(kind: str = ""):
+        """Clear world memory; pass kind to clear one bucket."""
+        if hasattr(brain, "clear_world_memory"):
+            return brain.clear_world_memory(kind or None)
+        return {"ok": False, "available": False, "reason": "world_memory_unavailable"}
+
+
+
+    @router.get("/memory/rag")
+    def get_world_memory_rag():
+        if hasattr(brain, "world_memory_rag_status"):
+            return brain.world_memory_rag_status()
+        return {"ok": False, "available": False, "reason": "world_memory_rag_unavailable"}
+
+    @router.get("/memory/rag/recent")
+    def get_world_memory_rag_recent(kind: str = "", limit: int = 10):
+        if hasattr(brain, "world_memory_rag_recent"):
+            return brain.world_memory_rag_recent(kind or "", limit)
+        return {"ok": False, "available": False, "reason": "world_memory_rag_unavailable"}
+
+    @router.post("/memory/rag/observe")
+    def observe_world_memory_rag(payload: Dict[str, Any]):
+        if hasattr(brain, "world_memory_rag_observe"):
+            return brain.world_memory_rag_observe(payload or {}, source="api")
+        return {"ok": False, "available": False, "reason": "world_memory_rag_unavailable"}
+
+    @router.get("/memory/rag/recall")
+    def recall_world_memory_rag(query: str = "", limit: int = 8):
+        if hasattr(brain, "world_memory_rag_recall"):
+            return brain.world_memory_rag_recall(query or "", limit)
+        return {"ok": False, "available": False, "reason": "world_memory_rag_unavailable"}
+
+    @router.get("/memory/rag/context")
+    def context_world_memory_rag(query: str = "", limit: int = 8):
+        if hasattr(brain, "world_memory_rag_context"):
+            return brain.world_memory_rag_context(query or "", limit)
+        return {"ok": False, "available": False, "reason": "world_memory_rag_unavailable"}
+
+    @router.post("/memory/rag/forget")
+    def forget_world_memory_rag(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "world_memory_rag_forget"):
+            return brain.world_memory_rag_forget(payload or {})
+        return {"ok": False, "available": False, "reason": "world_memory_rag_unavailable"}
+
+    @router.get("/living/status")
+    def get_living_companion_status():
+        if hasattr(brain, "get_living_companion_status"):
+            return brain.get_living_companion_status()
+        return {"ok": False, "available": False, "reason": "living_companion_unavailable"}
+
+    @router.get("/living/needs")
+    def get_living_companion_needs():
+        if hasattr(brain, "get_living_companion_status"):
+            status = brain.get_living_companion_status()
+            return ((status.get("needs") or {}).get("last") or status.get("needs") or status)
+        return {"ok": False, "available": False, "reason": "living_companion_unavailable"}
+
+    @router.post("/living/tick")
+    def tick_living_companion(payload: Dict[str, Any] | None = None, force: bool = False):
+        if hasattr(brain, "tick_living_companion"):
+            return brain.tick_living_companion(payload or {}, force=force)
+        return {"ok": False, "available": False, "reason": "living_companion_unavailable"}
+
+    @router.post("/living/vision")
+    def observe_living_vision(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "observe_living_vision"):
+            return brain.observe_living_vision(payload or {})
+        return {"ok": False, "available": False, "reason": "living_companion_unavailable"}
+
+    @router.post("/living/audio")
+    def observe_living_audio(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "observe_living_audio"):
+            return brain.observe_living_audio(payload or {})
+        return {"ok": False, "available": False, "reason": "living_companion_unavailable"}
+
+    @router.post("/living/boredom")
+    def force_living_boredom(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "force_boredom_behavior"):
+            return brain.force_boredom_behavior(payload or {})
+        return {"ok": False, "available": False, "reason": "living_companion_unavailable"}
+
+    @router.post("/living/sound-interrupt")
+    def living_sound_interrupt(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "sound_interrupt_wake"):
+            return brain.sound_interrupt_wake(payload or {})
+        return {"ok": False, "available": False, "reason": "living_companion_unavailable"}
+
+    @router.get("/navigation/safe-places")
+    def list_navigation_safe_places():
+        if hasattr(brain, "living_companion"):
+            return brain.living_companion.navigation.list_places()
+        return {"ok": False, "available": False, "reason": "safe_navigation_unavailable"}
+
+    @router.post("/navigation/safe-places")
+    def learn_navigation_safe_place(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "living_companion"):
+            return brain.living_companion.navigation.learn_place(payload or {})
+        return {"ok": False, "available": False, "reason": "safe_navigation_unavailable"}
+
+    @router.post("/navigation/rest-corner")
+    def navigation_rest_corner(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "rest_in_safe_corner"):
+            return brain.rest_in_safe_corner(payload or {})
+        return {"ok": False, "available": False, "reason": "safe_navigation_unavailable"}
+
+    @router.get("/audio-context")
+    def get_audio_event_needs():
+        """Return latest audio/wakeword context used by companion needs."""
+        if hasattr(brain, "get_audio_event_needs_snapshot"):
+            return brain.get_audio_event_needs_snapshot()
+        return {"ok": False, "available": False, "reason": "audio_event_bridge_unavailable"}
+
+    @router.post("/audio-context/observe")
+    def observe_audio_event_needs(payload: Dict[str, Any]):
+        """Store a semantic audio event for needs selection."""
+        if hasattr(brain, "observe_audio_event_for_needs"):
+            return brain.observe_audio_event_for_needs(payload or {}, source="api")
+        return {"ok": False, "available": False, "reason": "audio_event_bridge_unavailable"}
+
+    @router.get("/vision-context")
+    def get_vision_context_needs():
+        """Return latest vision context used by the companion needs bridge."""
+        if hasattr(brain, "get_vision_context_needs_snapshot"):
+            return brain.get_vision_context_needs_snapshot()
+        return {"ok": False, "available": False, "reason": "vision_context_bridge_unavailable"}
+
+    @router.post("/vision-context/observe")
+    def observe_vision_context_needs(payload: Dict[str, Any]):
+        """Store a semantic camera/VLM observation for needs selection."""
+        if hasattr(brain, "observe_vision_context_for_needs"):
+            return brain.observe_vision_context_for_needs(payload or {}, source="api")
+        return {"ok": False, "available": False, "reason": "vision_context_bridge_unavailable"}
+
+    @router.get("/living-needs")
+    def get_living_needs():
+        if hasattr(brain, "get_living_needs_snapshot"):
+            return brain.get_living_needs_snapshot()
+        return {"ok": False, "available": False, "reason": "living_needs_unavailable"}
+
+    @router.post("/living-needs/tick")
+    def tick_living_needs():
+        if hasattr(brain, "tick_living_needs"):
+            return brain.tick_living_needs()
+        return {"ok": False, "available": False, "reason": "living_needs_unavailable"}
+
+    @router.get("/sound-interrupt")
+    def get_sound_interrupt():
+        if hasattr(brain, "get_sound_interrupt_snapshot"):
+            return brain.get_sound_interrupt_snapshot()
+        return {"ok": False, "available": False, "reason": "sound_interrupt_unavailable"}
+
+    @router.post("/sound-interrupt")
+    def handle_sound_interrupt(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "handle_sound_interrupt"):
+            return brain.handle_sound_interrupt(payload or {})
+        return {"ok": False, "available": False, "reason": "sound_interrupt_unavailable"}
+
+    @router.get("/navigation/status")
+    def get_navigation_status():
+        if hasattr(brain, "get_safe_navigation_status"):
+            return brain.get_safe_navigation_status()
+        return {"ok": False, "available": False, "reason": "safe_navigation_unavailable"}
+
+    @router.get("/navigation/places")
+    def list_navigation_places():
+        if hasattr(brain, "list_safe_places"):
+            return brain.list_safe_places()
+        return {"ok": False, "available": False, "reason": "safe_navigation_unavailable"}
+
+    @router.post("/navigation/places/learn")
+    def learn_navigation_place(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "learn_safe_place"):
+            return brain.learn_safe_place(payload or {})
+        return {"ok": False, "available": False, "reason": "safe_navigation_unavailable"}
+
+    @router.post("/navigation/rest-corner")
+    def execute_rest_corner(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "execute_safe_rest_corner"):
+            return brain.execute_safe_rest_corner(payload or {})
+        return {"ok": False, "available": False, "reason": "safe_navigation_unavailable"}
+
+    @router.get("/behavior-loop")
+    def get_companion_behavior_loop():
+        """Return companion behavior loop dry-run status and recent history."""
+        if hasattr(brain, "get_companion_behavior_loop_snapshot"):
+            return brain.get_companion_behavior_loop_snapshot()
+        return {"ok": False, "available": False, "reason": "behavior_loop_unavailable"}
+
+    @router.post("/behavior-loop/tick")
+    def tick_companion_behavior_loop(force: bool = False):
+        """Run one safe companion behavior loop tick.
+
+        Defaults remain PC-safe: the tick goes through the auto gate and the
+        executor dry-run path. Set force=true only for manual validation.
+        """
+        if hasattr(brain, "tick_companion_behavior_loop"):
+            return brain.tick_companion_behavior_loop(force=force)
+        return {"ok": False, "available": False, "reason": "behavior_loop_unavailable"}
+
+    @router.get("/goal/auto")
+    def get_goal_auto_execute_gate():
+        """Return companion auto-execute gate status and last decision."""
+        if hasattr(brain, "get_companion_auto_execute_snapshot"):
+            return brain.get_companion_auto_execute_snapshot()
+        return {"ok": False, "available": False, "reason": "auto_execute_gate_unavailable"}
+
+    @router.post("/goal/auto/tick")
+    def tick_goal_auto_execute(payload: Dict[str, Any] | None = None, force: bool = False):
+        """Evaluate the current semantic goal through the auto-execute gate.
+
+        Defaults are PC-safe and dry-run only. Use force=true only for manual
+        validation of the selected plan; it still stays dry-run unless config
+        explicitly allows real hardware.
+        """
+        if hasattr(brain, "tick_companion_auto_execute"):
+            return brain.tick_companion_auto_execute(payload or {}, force=force)
+        return {"ok": False, "available": False, "reason": "auto_execute_gate_unavailable"}
+
+    @router.get("/goal/execution")
+    def get_goal_execution():
+        """Return the last safe companion goal execution/dry-run."""
+        if hasattr(brain, "get_companion_goal_execution_snapshot"):
+            return brain.get_companion_goal_execution_snapshot()
+        return {"ok": False, "available": False, "reason": "goal_executor_unavailable"}
+
+    @router.post("/goal/execute")
+    def execute_goal(payload: Dict[str, Any] | None = None):
+        """Dry-run or execute the current semantic goal plan.
+
+        PC tests and default config block real hardware. Use this endpoint first
+        to inspect the safe action execution steps.
+        """
+        if hasattr(brain, "execute_companion_goal"):
+            return brain.execute_companion_goal(payload or {})
+        return {"ok": False, "available": False, "reason": "goal_executor_unavailable"}
+
+    @router.post("/goal/simulate")
+    def simulate_goal(payload: Dict[str, Any]):
+        """Simulate needs -> goal without executing hardware."""
+        if not hasattr(brain, "goal_selector"):
+            return {"ok": False, "available": False, "reason": "goal_selector_unavailable"}
+        return brain.goal_selector.select(payload or {})
+
     @router.post("/interaction")
     def report_interaction():
         """Report that an interaction occurred (resets boredom timer)"""
@@ -84,5 +432,62 @@ def get_router(brain: AutonomyBrain) -> APIRouter:
     def stop_brain():
         brain.stop()
         return {"ok": True}
+
+
+    # BEGIN BATCH04 PI HARDWARE OWNER TOPO ROUTES
+    @router.get("/assets/status")
+    def get_model_assets_status():
+        if hasattr(brain, "get_model_asset_status"):
+            return brain.get_model_asset_status()
+        return {"ok": False, "available": False, "reason": "asset_truth_unavailable"}
+
+    @router.get("/pi-runtime/status")
+    def get_pi_runtime_status():
+        if hasattr(brain, "get_pi_runtime_status"):
+            return brain.get_pi_runtime_status()
+        return {"ok": False, "available": False, "reason": "pi_runtime_unavailable"}
+
+    @router.get("/navigation/topomap")
+    def get_navigation_topomap():
+        if hasattr(brain, "get_navigation_topomap"):
+            return brain.get_navigation_topomap()
+        return {"ok": False, "available": False, "reason": "topomap_unavailable"}
+
+    @router.post("/navigation/topomap/learn")
+    def learn_navigation_topomap_place(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "learn_navigation_topomap_place"):
+            return brain.learn_navigation_topomap_place(payload or {})
+        return {"ok": False, "available": False, "reason": "topomap_unavailable"}
+
+    @router.post("/navigation/goal")
+    def execute_navigation_goal(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "execute_navigation_goal"):
+            return brain.execute_navigation_goal(payload or {})
+        return {"ok": False, "available": False, "reason": "topomap_unavailable"}
+
+    @router.get("/owner/status")
+    def get_owner_learning_status():
+        if hasattr(brain, "get_owner_learning_status"):
+            return brain.get_owner_learning_status()
+        return {"ok": False, "available": False, "reason": "owner_learning_unavailable"}
+
+    @router.post("/owner/learn")
+    def learn_owner_person(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "learn_owner_person"):
+            return brain.learn_owner_person(payload or {})
+        return {"ok": False, "available": False, "reason": "owner_learning_unavailable"}
+
+    @router.post("/owner/identify")
+    def identify_owner_person(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "identify_owner_person"):
+            return brain.identify_owner_person(payload or {})
+        return {"ok": False, "available": False, "reason": "owner_learning_unavailable"}
+
+    @router.post("/scenario/companion-e2e")
+    def run_companion_e2e_scenario(payload: Dict[str, Any] | None = None):
+        if hasattr(brain, "run_companion_e2e_scenario"):
+            return brain.run_companion_e2e_scenario(payload or {})
+        return {"ok": False, "available": False, "reason": "scenario_unavailable"}
+    # END BATCH04 PI HARDWARE OWNER TOPO ROUTES
 
     return router

--- a/modules/autonomy/config/config.yml
+++ b/modules/autonomy/config/config.yml
@@ -25,56 +25,96 @@ defaults:
         sleep_fill: 35
   body_language:
     profiles:
-      joy: { pan_delta: 6, tilt_delta: 4, event: "autonomy.joy" }
-      curiosity: { pan_delta: 8, tilt_delta: 3, event: "autonomy.curious" }
-      fear: { pan_delta: 10, tilt_delta: 6, event: "autonomy.alert" }
-      tired: { pan_delta: 2, tilt_delta: 2, event: "autonomy.tired" }
-      sadness: { pan_delta: 3, tilt_delta: 5, event: "autonomy.sad" }
-      neutral: { pan_delta: 4, tilt_delta: 3, event: "autonomy.neutral" }
-
+      joy:
+        pan_delta: 6
+        tilt_delta: 4
+        event: autonomy.joy
+      curiosity:
+        pan_delta: 8
+        tilt_delta: 3
+        event: autonomy.curious
+      fear:
+        pan_delta: 10
+        tilt_delta: 6
+        event: autonomy.alert
+      tired:
+        pan_delta: 2
+        tilt_delta: 2
+        event: autonomy.tired
+      sadness:
+        pan_delta: 3
+        tilt_delta: 5
+        event: autonomy.sad
+      neutral:
+        pan_delta: 4
+        tilt_delta: 3
+        event: autonomy.neutral
   lights:
     default_mode: breathe
     palettes:
-      calm_violet: [120, 80, 255]
-      sunset_gold: [255, 170, 60]
-      alert_red: [255, 45, 45]
-      ocean_teal: [30, 180, 255]
-      arctic_white: [255, 255, 255]
-      forest_green: [60, 200, 90]
-      ember_orange: [255, 110, 40]
-      polar_blue: [90, 150, 255]
-
+      calm_violet:
+      - 120
+      - 80
+      - 255
+      sunset_gold:
+      - 255
+      - 170
+      - 60
+      alert_red:
+      - 255
+      - 45
+      - 45
+      ocean_teal:
+      - 30
+      - 180
+      - 255
+      arctic_white:
+      - 255
+      - 255
+      - 255
+      forest_green:
+      - 60
+      - 200
+      - 90
+      ember_orange:
+      - 255
+      - 110
+      - 40
+      polar_blue:
+      - 90
+      - 150
+      - 255
 endpoints:
-  arduino: "@gateway/arduino"
-  neopixel: "@gateway/neopixel"
-  speak: "@gateway/speak"
-  ollama: "@gateway/ollama"
-  speech: "@gateway/speech"
-  interactions: "@gateway/interactions"
-  oled_faces: "@gateway/oled_faces"
-  state_manager: "@gateway/state"
-  animate: "@gateway/animate"
-  vlm: "@gateway/vlm"
-  vision: "@gateway/vlm"
-  camera: "@gateway/camera"
-  notifier: "@gateway/notify"
-  autonomy: "@gateway/autonomy"
-  agent_core: "@gateway/agent"
-
+  arduino: '@gateway/arduino'
+  neopixel: '@gateway/neopixel'
+  speak: '@gateway/speak'
+  ollama: '@gateway/ollama'
+  speech: '@gateway/speech'
+  interactions: '@gateway/interactions'
+  expression: '@gateway/expression'
+  oled_faces: '@gateway/oled_faces'
+  state_manager: '@gateway/state'
+  animate: '@gateway/animate'
+  vlm: '@gateway/vlm'
+  vision: '@gateway/vlm'
+  camera: '@gateway/camera'
+  notifier: '@gateway/notify'
+  autonomy: '@gateway/autonomy'
+  agent_core: '@gateway/agent'
 behaviors:
   idle:
     enabled: true
     actions:
-      - "look_around"
-      - "blink"
-      - "sigh"
-      - "stretch"
-      - "monologue"
+    - look_around
+    - blink
+    - sigh
+    - stretch
+    - monologue
   idle_tree:
     enabled: true
     interval_s: 6
     fallback_to_llm: true
-    path: "modules/autonomy/config/idle_behaviors.yml"
+    path: modules/autonomy/config/idle_behaviors.yml
   curiosity:
     enabled: true
     face_tracking: true
@@ -83,95 +123,93 @@ behaviors:
     enabled: true
     start_hour: 2
     end_hour: 7
-    wake_up_action: "stretch"
-
+    wake_up_action: stretch
 llm:
   enabled: true
-  model: "qwen3.5:9b"
+  model: qwen3.5:9b
   auto_select_persona: false
   warmup_on_start: true
-  prompt_template: |
-    Sen duyguları olan bir robotsun.
-    
+  prompt_template: 'Sen duyguları olan bir robotsun.
+
+
     Şu anki İç Durumun:
+
     - Mutluluk: {happiness}/100 (Düşükse üzgün, yüksekse neşeli)
+
     - Enerji: {energy}/100 (Düşükse uykulu/yorgun)
+
     - Sıkılma: {is_bored} (Evet ise ilgi istiyorsun)
+
     - Son Etkileşim: {last_interaction_ago} saniye önce
+
     - Saat: {time}
 
+
     GÖREV: Bu duruma uygun, çok kısa (maksimum 10 kelime) bir iç ses cümlesi kur.
+
     - Robotik değil, canlı bir karakter gibi konuş.
+
     - Sadece söyleyeceğin cümleyi yaz.
 
+    '
 speech_quiet_hours:
   enabled: true
-  start: "01:00"
-  end: "05:00"
-  tone: "calm"
+  start: 01:00
+  end: 05:00
+  tone: calm
   max_chars: 120
-  prefix: ""
-
-# Natural barge-in: let the user cut off the robot by speaking, not only via
-# wakeword. A wakeword always interrupts; free speech needs `min_words`.
+  prefix: ''
 barge_in:
   enabled: true
   min_words: 2
   cooldown_s: 1.5
-
-# Firmware-native idle liveliness (breathing / micro-motion on the head servos).
-# The brain shapes amplitude/tempo from mood and only resends on change or every
-# refresh_interval_s, so the serial link stays quiet.
 liveliness:
   enabled: true
-  amplitude_deg: 4.0        # base breathing amplitude (degrees)
-  max_amplitude_deg: 12.0   # hard cap after emotion shaping
-  period_ms: 4500           # base breathing period
-  refresh_interval_s: 20.0  # resend keepalive even if params unchanged
-
+  amplitude_deg: 4.0
+  max_amplitude_deg: 12.0
+  period_ms: 4500
+  refresh_interval_s: 20.0
 offline_mode:
   enabled: true
   availability_ttl_s: 5
   fallback_replies:
-    - "Su an baglanti zayif, ama seni dinliyorum."
-    - "Cevap motoruna ulasamiyorum, kisa sure sonra tekrar deneyelim."
-    - "Simdi yerel moddayim, yine de yanindayim."
+  - Su an baglanti zayif, ama seni dinliyorum.
+  - Cevap motoruna ulasamiyorum, kisa sure sonra tekrar deneyelim.
+  - Simdi yerel moddayim, yine de yanindayim.
   persona_replies:
     joy:
-      - "Baglanti yok ama modum yerinde, devam edelim."
-      - "Yerel moddayim ve enerjim yuksek, hazirim."
+    - Baglanti yok ama modum yerinde, devam edelim.
+    - Yerel moddayim ve enerjim yuksek, hazirim.
     curiosity:
-      - "Baglanti kopuk, yine de seni anlamaya devam ediyorum."
-      - "Cevap motoru yok ama merakim acik, devam et."
+    - Baglanti kopuk, yine de seni anlamaya devam ediyorum.
+    - Cevap motoru yok ama merakim acik, devam et.
     tired:
-      - "Biraz yavasim ama buradayim, baglanti gelir gelmez deneriz."
-      - "Yerel moddayim, sakin ve yavas cevap verecegim."
+    - Biraz yavasim ama buradayim, baglanti gelir gelmez deneriz.
+    - Yerel moddayim, sakin ve yavas cevap verecegim.
     fear:
-      - "Sistem baglantisi zayif, simdilik guvenli moddayim."
-      - "Baglanti kararsiz, kontrollu hareket ediyorum."
+    - Sistem baglantisi zayif, simdilik guvenli moddayim.
+    - Baglanti kararsiz, kontrollu hareket ediyorum.
     neutral:
-      - "Su an yerel moddayim, yine de cevap verebilirim."
-      - "Baglanti beklemede, ama ben buradayim."
+    - Su an yerel moddayim, yine de cevap verebilirim.
+    - Baglanti beklemede, ama ben buradayim.
   contextual_replies:
     question:
-      - "Su an ag cevabi alamiyorum, ama sorunu not ettim."
-      - "Bunu cevaplamak istiyorum; baglanti gelir gelmez tekrar deneyeyim."
+    - Su an ag cevabi alamiyorum, ama sorunu not ettim.
+    - Bunu cevaplamak istiyorum; baglanti gelir gelmez tekrar deneyeyim.
     command:
-      - "Komutu duydum, baglanti toparlaninca tam uygulayacagim."
-      - "Simdilik yerel moddayim, temel tepkilerle devam ediyorum."
+    - Komutu duydum, baglanti toparlaninca tam uygulayacagim.
+    - Simdilik yerel moddayim, temel tepkilerle devam ediyorum.
     greeting:
-      - "Merhaba, baglanti olmasa da buradayim."
-      - "Selam, yerel modda da seninleyim."
+    - Merhaba, baglanti olmasa da buradayim.
+    - Selam, yerel modda da seninleyim.
     generic:
-      - "Baglanti gecici olarak yok, ama etkileşim devam ediyor."
-
+    - Baglanti gecici olarak yok, ama etkileşim devam ediyor.
 request_timeouts:
   default_post_s: 1.0
   default_get_s: 0.8
   ollama_chat_s: 18.0
   ollama_warmup_s: 2.5
   speech_min_interval_s: 0.35
-
 agentic:
   enabled: true
   min_interval_s: 45
@@ -181,34 +219,66 @@ agentic:
     stimulation_need: 68
     low_energy: 25
     low_rest: 22
-
 speech_reactions:
   excited_on_speech: false
   excited_on_praise: true
   excited_on_questions: false
-
 visual_state:
   emotion_min_interval_s: 1.8
   default_lock_s: 2.4
   strong_lock_s: 4.8
   state_hold_s: 3.2
-  strong_emotions: ["fear", "angry", "furious"]
+  strong_emotions:
+  - fear
+  - angry
+  - furious
   transition_graph:
-    neutral: ["curiosity", "joy", "tired", "sad", "fear", "angry", "furious"]
-    curiosity: ["joy", "neutral", "sad", "fear", "angry"]
-    joy: ["neutral", "curiosity", "tired", "sad"]
-    sad: ["neutral", "curiosity", "fear"]
-    tired: ["neutral", "sad"]
-    angry: ["neutral", "fear", "furious"]
-    furious: ["angry", "fear", "neutral"]
-    fear: ["neutral", "curiosity", "angry"]
-
+    neutral:
+    - curiosity
+    - joy
+    - tired
+    - sad
+    - fear
+    - angry
+    - furious
+    curiosity:
+    - joy
+    - neutral
+    - sad
+    - fear
+    - angry
+    joy:
+    - neutral
+    - curiosity
+    - tired
+    - sad
+    sad:
+    - neutral
+    - curiosity
+    - fear
+    tired:
+    - neutral
+    - sad
+    angry:
+    - neutral
+    - fear
+    - furious
+    furious:
+    - angry
+    - fear
+    - neutral
+    fear:
+    - neutral
+    - curiosity
+    - angry
 companion:
   enabled: true
-  relationship_memory_path: "modules/autonomy/data/relationship_memory.json"
+  relationship_memory_path: modules/autonomy/data/relationship_memory.json
   rituals:
     enabled: true
-    morning_window_h: [6, 11]
+    morning_window_h:
+    - 6
+    - 11
     owner_return_min_absence_s: 180
     owner_return_cooldown_s: 300
   proactive:
@@ -220,26 +290,23 @@ companion:
     callback_min_trust: 0.2
     scene_comment_min_importance: 0.45
     policy:
-      owner_style: "warm"
-      guest_style: "respectful"
+      owner_style: warm
+      guest_style: respectful
   lines:
     use_llm: true
     max_words: 18
     llm_cooldown_s: 35
     default_language: tr
-  # Sesli komutlar tri-layer keyword router yerine LLM tool loop'a gider (çok dilli).
   voice_ai_tools: true
   emotion_command_shortcut: false
   owner_sessions:
     enabled: true
     source: vision
-
 speech:
   use_stream_tts: true
   stream_poll_interval_s: 0.12
   stream_max_wait_s: 90
   stream_max_chunk_chars: 220
-  # Companion learning loop: extract prefs/facts, reinforce trust from praise/rude.
   learning:
     enabled: true
     feedback:
@@ -253,15 +320,17 @@ speech:
         user_rude:
           trust: -0.12
           salience: 0.55
-
+sound_direction:
+  poll_interval_s: 2.0
 vision_hooks:
   enabled: true
-  poll_interval_s: 2
+  poll_interval_s: 5
+  forward_interval_s: 8
   max_results: 5
   person_cooldown_s: 25
   ignore_labels:
-    - "chair"
-    - "tv"
+  - chair
+  - tv
   prefer_llm_greetings: true
   speak_on_unknown: false
   importance_speak_threshold: 0.6
@@ -280,260 +349,526 @@ vision_hooks:
     enabled: true
     cooldown_s: 28
     mirror:
-      - joy
-      - sadness
-      - fear
-      - worried
+    - joy
+    - sadness
+    - fear
+    - worried
     speak_on_mirror: true
-
 empathy:
   enabled: true
   cooldown_s: 28
-
 scenes:
   wakeword_reaction:
     steps:
-      - { type: event, name: "scene.wakeword.start" }
-      - { type: effect_burst, name: "TWINKLE", duration_ms: 120, count: 2, interval_ms: 60 }
-      - { type: segment_anim, segment: "jewel", name: "TWINKLE", color: "#66E8FF", iterations: 1 }
-      - { type: head, pan: 90, tilt: 88 }
-      - { type: base, name: "BREATHE", color: "#1F4B66" }
-      - { type: event, name: "scene.wakeword.end" }
-
+    - type: event
+      name: scene.wakeword.start
+    - type: effect_burst
+      name: TWINKLE
+      duration_ms: 120
+      count: 2
+      interval_ms: 60
+    - type: segment_anim
+      segment: jewel
+      name: TWINKLE
+      color: '#66E8FF'
+      iterations: 1
+    - type: head
+      pan: 90
+      tilt: 88
+    - type: base
+      name: BREATHE
+      color: '#1F4B66'
+    - type: event
+      name: scene.wakeword.end
   owner_return:
     steps:
-      - { type: event, name: "scene.owner_return.start" }
-      - { type: preset, name: "owner_welcome" }
-      - { type: effect_burst, name: "COMET", duration_ms: 170, count: 3, interval_ms: 80 }
-      - { type: anim, name: "owner_scan", speed: 1.0, loop: false }
-      - { type: speak, text: "{nickname}, geri donmene sevindim.", emotion: "joy" }
-      - { type: event, name: "scene.owner_return.end" }
-
+    - type: event
+      name: scene.owner_return.start
+    - type: preset
+      name: owner_welcome
+    - type: effect_burst
+      name: COMET
+      duration_ms: 170
+      count: 3
+      interval_ms: 80
+    - type: anim
+      name: owner_scan
+      speed: 1.0
+      loop: false
+    - type: speak
+      text: '{nickname}, geri donmene sevindim.'
+      emotion: joy
+    - type: event
+      name: scene.owner_return.end
   sleepy_entry:
     steps:
-      - { type: event, name: "scene.sleepy_entry.start" }
-      - { type: segment_fill, segment: "jewel", color: "#1A1D2B" }
-      - { type: segment_fill, segment: "stick", color: "#090C14" }
-      - { type: effect, name: "BREATHE", duration_ms: 900, force: false }
-      - { type: head, pan: 90, tilt: 120 }
-      - { type: speak, text: "Iyi geceler.", emotion: "tired" }
-      - { type: event, name: "scene.sleepy_entry.end" }
-
+    - type: event
+      name: scene.sleepy_entry.start
+    - type: segment_fill
+      segment: jewel
+      color: '#1A1D2B'
+    - type: segment_fill
+      segment: stick
+      color: '#090C14'
+    - type: effect
+      name: BREATHE
+      duration_ms: 900
+      force: false
+    - type: head
+      pan: 90
+      tilt: 120
+    - type: speak
+      text: Iyi geceler.
+      emotion: tired
+    - type: event
+      name: scene.sleepy_entry.end
   wake_entry:
     steps:
-      - { type: event, name: "scene.wake_entry.start" }
-      - { type: preset, name: "curious_scan" }
-      - { type: effect_burst, name: "PULSE", duration_ms: 140, count: 2, interval_ms: 90 }
-      - { type: anim, name: "stretch", speed: 1.0, loop: false }
-      - { type: speak, text: "Gunaydin, hazirim.", emotion: "joy" }
-      - { type: event, name: "scene.wake_entry.end" }
-
+    - type: event
+      name: scene.wake_entry.start
+    - type: preset
+      name: curious_scan
+    - type: effect_burst
+      name: PULSE
+      duration_ms: 140
+      count: 2
+      interval_ms: 90
+    - type: anim
+      name: stretch
+      speed: 1.0
+      loop: false
+    - type: speak
+      text: Gunaydin, hazirim.
+      emotion: joy
+    - type: event
+      name: scene.wake_entry.end
   curious_scan:
     steps:
-      - { type: event, name: "scene.curious_scan.start" }
-      - { type: preset, name: "curious_scan" }
-      - { type: head, pan: 90, tilt: 88 }
-      - { type: effect_burst, name: "TWINKLE", duration_ms: 100, count: 2, interval_ms: 70 }
-      - { type: event, name: "scene.curious_scan.end" }
-
+    - type: event
+      name: scene.curious_scan.start
+    - type: preset
+      name: curious_scan
+    - type: head
+      pan: 90
+      tilt: 88
+    - type: effect_burst
+      name: TWINKLE
+      duration_ms: 100
+      count: 2
+      interval_ms: 70
+    - type: event
+      name: scene.curious_scan.end
   vision_greeting_owner:
     steps:
-      - { type: event, name: "scene.vision_owner.start" }
-      - { type: preset, name: "owner_welcome" }
-      - { type: effect_burst, name: "COMET", duration_ms: 180, count: 2, interval_ms: 90 }
-      - { type: anim, name: "owner_scan", speed: 1.0, loop: false }
-      - { type: speak, text: "Hos geldin {name}.", emotion: "joy" }
-      - { type: event, name: "scene.vision_owner.end" }
-
+    - type: event
+      name: scene.vision_owner.start
+    - type: preset
+      name: owner_welcome
+    - type: effect_burst
+      name: COMET
+      duration_ms: 180
+      count: 2
+      interval_ms: 90
+    - type: anim
+      name: owner_scan
+      speed: 1.0
+      loop: false
+    - type: speak
+      text: Hos geldin {name}.
+      emotion: joy
+    - type: event
+      name: scene.vision_owner.end
   vision_greeting_known:
     steps:
-      - { type: event, name: "scene.vision_greeting.start" }
-      - { type: effect, name: "COMET", duration_ms: 700, force: false }
-      - { type: segment_anim, segment: "jewel", name: "PULSE", color: "#00AAFF", iterations: 1 }
-      - { type: anim, name: "vision_focus", speed: 1.0, loop: false }
-      - { type: speak, text: "{greeting}", emotion: "joy" }
-      - { type: segment_fill, segment: "stick", color: "#1E90FF" }
-      - { type: base, name: "BREATHE", color: "#1E90FF" }
-      - { type: event, name: "scene.vision_greeting.end" }
-
+    - type: event
+      name: scene.vision_greeting.start
+    - type: effect
+      name: COMET
+      duration_ms: 700
+      force: false
+    - type: segment_anim
+      segment: jewel
+      name: PULSE
+      color: '#00AAFF'
+      iterations: 1
+    - type: anim
+      name: vision_focus
+      speed: 1.0
+      loop: false
+    - type: speak
+      text: '{greeting}'
+      emotion: joy
+    - type: segment_fill
+      segment: stick
+      color: '#1E90FF'
+    - type: base
+      name: BREATHE
+      color: '#1E90FF'
+    - type: event
+      name: scene.vision_greeting.end
   vision_greeting_known_close:
     steps:
-      - { type: event, name: "scene.vision_greeting.start" }
-      - { type: effect, name: "RAINBOW_CYCLE", duration_ms: 700, force: false }
-      - { type: effect_burst, name: "COMET", duration_ms: 140, count: 3, interval_ms: 70 }
-      - { type: segment_anim, segment: "jewel", name: "COMET", color: "#00C8FF", iterations: 1 }
-      - { type: head, pan: 90, tilt: 88 }
-      - { type: speak, text: "{greeting}", emotion: "joy" }
-      - { type: sleep, duration_ms: 120 }
-      - { type: segment_fill, segment: "stick", color: "#1E90FF" }
-      - { type: event, name: "scene.vision_greeting.end" }
-
+    - type: event
+      name: scene.vision_greeting.start
+    - type: effect
+      name: RAINBOW_CYCLE
+      duration_ms: 700
+      force: false
+    - type: effect_burst
+      name: COMET
+      duration_ms: 140
+      count: 3
+      interval_ms: 70
+    - type: segment_anim
+      segment: jewel
+      name: COMET
+      color: '#00C8FF'
+      iterations: 1
+    - type: head
+      pan: 90
+      tilt: 88
+    - type: speak
+      text: '{greeting}'
+      emotion: joy
+    - type: sleep
+      duration_ms: 120
+    - type: segment_fill
+      segment: stick
+      color: '#1E90FF'
+    - type: event
+      name: scene.vision_greeting.end
   vision_greeting_unknown:
     steps:
-      - { type: event, name: "scene.vision_greeting.start" }
-      - { type: effect, name: "PULSE", duration_ms: 600, force: false }
-      - { type: segment_anim, segment: "jewel", name: "TWINKLE", color: "#30E3CA", iterations: 1 }
-      - { type: head, pan: 90, tilt: 92 }
-      - { type: speak, text: "{greeting}", emotion: "curiosity" }
-      - { type: segment_fill, segment: "stick", color: "#102A2A" }
-      - { type: base, name: "BREATHE", color: "#30E3CA" }
-      - { type: event, name: "scene.vision_greeting.end" }
-
+    - type: event
+      name: scene.vision_greeting.start
+    - type: effect
+      name: PULSE
+      duration_ms: 600
+      force: false
+    - type: segment_anim
+      segment: jewel
+      name: TWINKLE
+      color: '#30E3CA'
+      iterations: 1
+    - type: head
+      pan: 90
+      tilt: 92
+    - type: speak
+      text: '{greeting}'
+      emotion: curiosity
+    - type: segment_fill
+      segment: stick
+      color: '#102A2A'
+    - type: base
+      name: BREATHE
+      color: '#30E3CA'
+    - type: event
+      name: scene.vision_greeting.end
   vision_greeting_unknown_close:
     steps:
-      - { type: event, name: "scene.vision_greeting.start" }
-      - { type: effect, name: "TWINKLE", duration_ms: 520, force: false }
-      - { type: effect_burst, name: "TWINKLE", duration_ms: 130, count: 2, interval_ms: 70 }
-      - { type: segment_anim, segment: "jewel", name: "TWINKLE", color: "#30E3CA", iterations: 2 }
-      - { type: head, pan: 90, tilt: 95 }
-      - { type: speak, text: "{greeting}", emotion: "curiosity" }
-      - { type: segment_fill, segment: "stick", color: "#0C2020" }
-      - { type: event, name: "scene.vision_greeting.end" }
-
-  # Emotion scenes — map dominant emotion to visual + small head/anim cues
+    - type: event
+      name: scene.vision_greeting.start
+    - type: effect
+      name: TWINKLE
+      duration_ms: 520
+      force: false
+    - type: effect_burst
+      name: TWINKLE
+      duration_ms: 130
+      count: 2
+      interval_ms: 70
+    - type: segment_anim
+      segment: jewel
+      name: TWINKLE
+      color: '#30E3CA'
+      iterations: 2
+    - type: head
+      pan: 90
+      tilt: 95
+    - type: speak
+      text: '{greeting}'
+      emotion: curiosity
+    - type: segment_fill
+      segment: stick
+      color: '#0C2020'
+    - type: event
+      name: scene.vision_greeting.end
   emotion_joy:
     steps:
-      - { type: event, name: "scene.emotion_joy.start" }
-      - { type: preset, name: "emotion_joy" }
-      - { type: effect_burst, name: "RAINBOW_CYCLE", duration_ms: 300, count: 2, interval_ms: 60 }
-      - { type: anim, name: "look_around", speed: 1.0, loop: false }
-      - { type: event, name: "scene.emotion_joy.end" }
-
+    - type: event
+      name: scene.emotion_joy.start
+    - type: preset
+      name: emotion_joy
+    - type: effect_burst
+      name: RAINBOW_CYCLE
+      duration_ms: 300
+      count: 2
+      interval_ms: 60
+    - type: anim
+      name: look_around
+      speed: 1.0
+      loop: false
+    - type: event
+      name: scene.emotion_joy.end
   emotion_curiosity:
     steps:
-      - { type: event, name: "scene.emotion_curiosity.start" }
-      - { type: preset, name: "emotion_curiosity" }
-      - { type: anim, name: "vision_focus", speed: 1.0, loop: false }
-      - { type: effect, name: "COMET", duration_ms: 400 }
-      - { type: event, name: "scene.emotion_curiosity.end" }
-
+    - type: event
+      name: scene.emotion_curiosity.start
+    - type: preset
+      name: emotion_curiosity
+    - type: anim
+      name: vision_focus
+      speed: 1.0
+      loop: false
+    - type: effect
+      name: COMET
+      duration_ms: 400
+    - type: event
+      name: scene.emotion_curiosity.end
   emotion_fear:
     steps:
-      - { type: event, name: "scene.emotion_fear.start" }
-      - { type: preset, name: "emotion_fear" }
-      - { type: head, pan: 90, tilt: 80 }
-      - { type: effect, name: "PULSE", duration_ms: 450 }
-      - { type: event, name: "scene.emotion_fear.end" }
-
+    - type: event
+      name: scene.emotion_fear.start
+    - type: preset
+      name: emotion_fear
+    - type: head
+      pan: 90
+      tilt: 80
+    - type: effect
+      name: PULSE
+      duration_ms: 450
+    - type: event
+      name: scene.emotion_fear.end
   emotion_tired:
     steps:
-      - { type: event, name: "scene.emotion_tired.start" }
-      - { type: preset, name: "emotion_tired" }
-      - { type: anim, name: "stretch", speed: 0.8, loop: false }
-      - { type: head, pan: 90, tilt: 110 }
-      - { type: event, name: "scene.emotion_tired.end" }
-
+    - type: event
+      name: scene.emotion_tired.start
+    - type: preset
+      name: emotion_tired
+    - type: anim
+      name: stretch
+      speed: 0.8
+      loop: false
+    - type: head
+      pan: 90
+      tilt: 110
+    - type: event
+      name: scene.emotion_tired.end
   emotion_sad:
     steps:
-      - { type: event, name: "scene.emotion_sad.start" }
-      - { type: preset, name: "emotion_sad" }
-      - { type: effect, name: "PULSE", duration_ms: 600 }
-      - { type: head, pan: 90, tilt: 100 }
-      - { type: event, name: "scene.emotion_sad.end" }
-
+    - type: event
+      name: scene.emotion_sad.start
+    - type: preset
+      name: emotion_sad
+    - type: effect
+      name: PULSE
+      duration_ms: 600
+    - type: head
+      pan: 90
+      tilt: 100
+    - type: event
+      name: scene.emotion_sad.end
   emotion_angry:
     steps:
-      - { type: event, name: "scene.emotion_angry.start" }
-      - { type: preset, name: "emotion_angry" }
-      - { type: head, pan: 90, tilt: 105 }
-      - { type: effect, name: "SOLID", color: "#FF0000" }
-      - { type: event, name: "scene.emotion_angry.end" }
-
+    - type: event
+      name: scene.emotion_angry.start
+    - type: preset
+      name: emotion_angry
+    - type: head
+      pan: 90
+      tilt: 105
+    - type: effect
+      name: SOLID
+      color: '#FF0000'
+    - type: event
+      name: scene.emotion_angry.end
   emotion_furious:
     steps:
-      - { type: event, name: "scene.emotion_furious.start" }
-      - { type: preset, name: "emotion_furious" }
-      - { type: head, pan: 90, tilt: 110 }
-      - { type: effect_burst, name: "PULSE", duration_ms: 120, count: 4, interval_ms: 60 }
-      - { type: effect, name: "SOLID", color: "#FF0000" }
-      - { type: event, name: "scene.emotion_furious.end" }
-
+    - type: event
+      name: scene.emotion_furious.start
+    - type: preset
+      name: emotion_furious
+    - type: head
+      pan: 90
+      tilt: 110
+    - type: effect_burst
+      name: PULSE
+      duration_ms: 120
+      count: 4
+      interval_ms: 60
+    - type: effect
+      name: SOLID
+      color: '#FF0000'
+    - type: event
+      name: scene.emotion_furious.end
   emotion_sadness:
     steps:
-      - { type: event, name: "scene.emotion_sadness.start" }
-      - { type: preset, name: "emotion_sadness" }
-      - { type: effect, name: "PULSE", duration_ms: 600 }
-      - { type: head, pan: 90, tilt: 100 }
-      - { type: event, name: "scene.emotion_sadness.end" }
-
+    - type: event
+      name: scene.emotion_sadness.start
+    - type: preset
+      name: emotion_sadness
+    - type: effect
+      name: PULSE
+      duration_ms: 600
+    - type: head
+      pan: 90
+      tilt: 100
+    - type: event
+      name: scene.emotion_sadness.end
   emotion_love:
     steps:
-      - { type: event, name: "scene.emotion_love.start" }
-      - { type: preset, name: "emotion_love" }
-      - { type: effect, name: "PULSE", duration_ms: 700, color: "#FF2864" }
-      - { type: event, name: "scene.emotion_love.end" }
-
+    - type: event
+      name: scene.emotion_love.start
+    - type: preset
+      name: emotion_love
+    - type: effect
+      name: PULSE
+      duration_ms: 700
+      color: '#FF2864'
+    - type: event
+      name: scene.emotion_love.end
   emotion_surprise:
     steps:
-      - { type: event, name: "scene.emotion_surprise.start" }
-      - { type: preset, name: "emotion_surprise" }
-      - { type: effect_burst, name: "TWINKLE", duration_ms: 150, count: 3, interval_ms: 70 }
-      - { type: event, name: "scene.emotion_surprise.end" }
-
+    - type: event
+      name: scene.emotion_surprise.start
+    - type: preset
+      name: emotion_surprise
+    - type: effect_burst
+      name: TWINKLE
+      duration_ms: 150
+      count: 3
+      interval_ms: 70
+    - type: event
+      name: scene.emotion_surprise.end
   emotion_excitement:
     steps:
-      - { type: event, name: "scene.emotion_excitement.start" }
-      - { type: preset, name: "emotion_excitement" }
-      - { type: effect_burst, name: "RAINBOW_CYCLE", duration_ms: 200, count: 2, interval_ms: 80 }
-      - { type: event, name: "scene.emotion_excitement.end" }
-
+    - type: event
+      name: scene.emotion_excitement.start
+    - type: preset
+      name: emotion_excitement
+    - type: effect_burst
+      name: RAINBOW_CYCLE
+      duration_ms: 200
+      count: 2
+      interval_ms: 80
+    - type: event
+      name: scene.emotion_excitement.end
   emotion_bored:
     steps:
-      - { type: event, name: "scene.emotion_bored.start" }
-      - { type: preset, name: "emotion_bored" }
-      - { type: head, pan: 88, tilt: 95 }
-      - { type: effect, name: "BREATHE", duration_ms: 900, color: "#3C3C3C" }
-      - { type: event, name: "scene.emotion_bored.end" }
-
+    - type: event
+      name: scene.emotion_bored.start
+    - type: preset
+      name: emotion_bored
+    - type: head
+      pan: 88
+      tilt: 95
+    - type: effect
+      name: BREATHE
+      duration_ms: 900
+      color: '#3C3C3C'
+    - type: event
+      name: scene.emotion_bored.end
   emotion_worried:
     steps:
-      - { type: event, name: "scene.emotion_worried.start" }
-      - { type: preset, name: "emotion_worried" }
-      - { type: effect, name: "BREATHE", duration_ms: 800, color: "#B46400" }
-      - { type: head, pan: 92, tilt: 98 }
-      - { type: event, name: "scene.emotion_worried.end" }
-
+    - type: event
+      name: scene.emotion_worried.start
+    - type: preset
+      name: emotion_worried
+    - type: effect
+      name: BREATHE
+      duration_ms: 800
+      color: '#B46400'
+    - type: head
+      pan: 92
+      tilt: 98
+    - type: event
+      name: scene.emotion_worried.end
   emotion_confusion:
     steps:
-      - { type: event, name: "scene.emotion_confusion.start" }
-      - { type: preset, name: "emotion_confusion" }
-      - { type: effect, name: "TWINKLE", duration_ms: 500, color: "#A000C8" }
-      - { type: head, pan: 85, tilt: 92 }
-      - { type: event, name: "scene.emotion_confusion.end" }
-
+    - type: event
+      name: scene.emotion_confusion.start
+    - type: preset
+      name: emotion_confusion
+    - type: effect
+      name: TWINKLE
+      duration_ms: 500
+      color: '#A000C8'
+    - type: head
+      pan: 85
+      tilt: 92
+    - type: event
+      name: scene.emotion_confusion.end
   emotion_neutral:
     steps:
-      - { type: event, name: "scene.emotion_neutral.start" }
-      - { type: preset, name: "calm_idle" }
-      - { type: effect, name: "BREATHE", duration_ms: 600, color: "#283C50" }
-      - { type: event, name: "scene.emotion_neutral.end" }
-
+    - type: event
+      name: scene.emotion_neutral.start
+    - type: preset
+      name: calm_idle
+    - type: effect
+      name: BREATHE
+      duration_ms: 600
+      color: '#283C50'
+    - type: event
+      name: scene.emotion_neutral.end
 owner:
   enabled: true
-  name: "WhoIsMrSentry"
-  # additional accepted owner aliases (case-insensitive)
+  name: WhoIsMrSentry
   aliases:
-    - "Emir"
-    # removed legacy Khar language alias
+  - Emir
   addressing:
-    affectionate: "Baba"
-    formal: "Emir"
-    handle: "WhoIsMrSentry"
+    affectionate: Baba
+    formal: Emir
+    handle: WhoIsMrSentry
   presence_timeout_s: 45
   require_presence: false
   max_requests_without_owner: 3
   cooldown_s: 20
   speaker_window_s: 10
-  polite_message: "Sahip yokken de isteğini yerine getirebilirim."
-  angry_message: "Baba yokken beni zorlamanı istemiyorum."
-  cooldown_message: "Baba gelene kadar konuşmak istemiyorum."
-  greeting: "Baba! Geldiğine çok sevindim."
+  polite_message: Sahip yokken de isteğini yerine getirebilirim.
+  angry_message: Baba yokken beni zorlamanı istemiyorum.
+  cooldown_message: Baba gelene kadar konuşmak istemiyorum.
+  greeting: Baba! Geldiğine çok sevindim.
   restricted_keywords:
-    - "format"
-    - "kendini kapat"
-    - "delete"
-  # Note: Kharuun-specific irreversible triggers removed.
+  - format
+  - kendini kapat
+  - delete
   rfid:
-    endpoint: "@gateway/arduino/rfid/authorize"
+    endpoint: '@gateway/arduino/rfid/authorize'
     grace_s: 120
     poll_interval_s: 15
+world_memory:
+  enabled: true
+  db_path: data/world_memory.sqlite3
+  max_context_items: 8
+  default_confidence: 0.55
+living_needs:
+  enabled: true
+  idle_boredom_s: 90
+  alone_social_s: 180
+  curiosity_decay_s: 150
+  rest_energy_threshold: 0.28
+  sound_attention_hold_s: 18
+  person_attention_hold_s: 45
+safe_navigation:
+  enabled: true
+  places_path: data/safe_places.json
+  allow_base_motion: false
+  default_rest_place: quiet_corner
+  rest_pose:
+    pan: 90
+    tilt: 125
+pi_hardware_runtime:
+  require_pi: true
+  require_camera: true
+  require_esp: false
+  esp_health_timeout_s: 0.4
+topomap_motion:
+  enabled: true
+  map_path: data/topomap_places.json
+  allow_base_motion: false
+  require_ultrasonic_clearance: true
+  min_clearance_cm: 28.0
+owner_learning:
+  enabled: true
+  profile_path: data/owner_profile.json
+  min_confidence: 0.55

--- a/modules/autonomy/services/audio_event_needs_bridge.py
+++ b/modules/autonomy/services/audio_event_needs_bridge.py
@@ -1,0 +1,196 @@
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "enabled", "detected", "present", "active"}
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+class AudioEventNeedsBridge:
+    """Semantic audio context bridge for companion needs.
+
+    This layer does not do speech recognition. It accepts already-detected audio
+    events such as wakeword, speech, sound, silence, or loud noise, and exposes a
+    short-lived semantic context to the needs engine.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "ttl_s": 30.0,
+        "owner_audio_timeout_s": 45.0,
+        "history_limit": 20,
+        "wakeword_social": 96.0,
+        "speech_social": 86.0,
+        "sound_curiosity": 76.0,
+        "silence_boredom": 58.0,
+        "loud_fear": 60.0,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg: Dict[str, Any] = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self._latest: Dict[str, Any] = {
+            "ok": True,
+            "available": False,
+            "reason": "no_audio_event_yet",
+            "timestamp": 0.0,
+        }
+        self._owner_last_heard_ts: float = 0.0
+        self._history: List[Dict[str, Any]] = []
+
+    def observe(self, payload: Optional[Dict[str, Any]], *, source: str = "manual", now: Optional[float] = None) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        data = _as_dict(payload)
+        event_type = str(data.get("type") or data.get("event") or data.get("kind") or "").strip().lower()
+        transcript = str(data.get("transcript") or data.get("text") or "").strip()
+        confidence = max(0.0, min(1.0, _as_float(data.get("confidence"), 0.7)))
+        wakeword = _as_bool(data.get("wakeword"), False) or event_type in {"wakeword", "wakeword.detected", "owner.call"}
+        speech = _as_bool(data.get("speech"), False) or event_type in {"speech", "speech.detected", "voice"} or bool(transcript)
+        sound = _as_bool(data.get("sound"), False) or event_type in {"sound", "sound.detected", "noise"}
+        silence = _as_bool(data.get("silence"), False) or event_type in {"silence", "silence.long", "quiet"}
+        loud = _as_bool(data.get("loud"), False) or _as_bool(data.get("loud_noise"), False) or event_type in {"loud", "loud_noise", "alarm", "bang"}
+        owner_present = _as_bool(data.get("owner_present"), False) or wakeword or speech
+        speech_busy = _as_bool(data.get("speech_busy"), False)
+        if wakeword or speech or owner_present:
+            self._owner_last_heard_ts = ts
+        result = {
+            "ok": True,
+            "available": True,
+            "timestamp": ts,
+            "source": str(source or data.get("source") or "manual"),
+            "event_type": event_type or self._derive_event(wakeword, speech, sound, silence, loud),
+            "wakeword": bool(wakeword),
+            "speech": bool(speech),
+            "sound": bool(sound),
+            "silence": bool(silence),
+            "loud": bool(loud),
+            "owner_present": bool(owner_present),
+            "speech_busy": bool(speech_busy),
+            "transcript": transcript,
+            "confidence": round(confidence, 2),
+            "reason": self._reason_for(wakeword=wakeword, speech=speech, sound=sound, silence=silence, loud=loud),
+        }
+        self._latest = result
+        self._push_history(result)
+        return self.status(now=ts)
+
+    def status(self, *, now: Optional[float] = None) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        latest = dict(self._latest)
+        age = max(0.0, ts - _as_float(latest.get("timestamp"), 0.0)) if latest.get("available") else 0.0
+        ttl = max(1.0, _as_float(self.cfg.get("ttl_s"), 30.0))
+        latest["enabled"] = _as_bool(self.cfg.get("enabled"), True)
+        latest["age_s"] = round(age, 1)
+        latest["fresh"] = bool(latest.get("available") and age <= ttl)
+        latest["owner_last_heard_ts"] = self._owner_last_heard_ts
+        latest["history"] = list(self._history[-10:])
+        return latest
+
+    def context(self, *, now: Optional[float] = None) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        if not _as_bool(self.cfg.get("enabled"), True):
+            return {"available": False, "reason": "audio_event_bridge_disabled"}
+        st = self.status(now=ts)
+        if not st.get("available") or not st.get("fresh"):
+            return {"available": False, "reason": st.get("reason") or "audio_event_stale", "status": st}
+        owner_timeout = max(1.0, _as_float(self.cfg.get("owner_audio_timeout_s"), 45.0))
+        owner_recent = self._owner_last_heard_ts > 0.0 and (ts - self._owner_last_heard_ts) <= owner_timeout
+        audio_context = {
+            "wakeword": bool(st.get("wakeword")),
+            "speech": bool(st.get("speech")),
+            "sound": bool(st.get("sound")),
+            "silence": bool(st.get("silence")),
+            "loud": bool(st.get("loud")),
+            "speech_busy": bool(st.get("speech_busy")),
+            "transcript": st.get("transcript", ""),
+            "reason": st.get("reason", "audio.context"),
+            "confidence": st.get("confidence", 0.0),
+        }
+        mood_overrides: Dict[str, Any] = {}
+        needs_overrides: Dict[str, Any] = {}
+        if audio_context["wakeword"]:
+            needs_overrides["social"] = max(_as_float(needs_overrides.get("social"), 0.0), _as_float(self.cfg.get("wakeword_social"), 96.0))
+            needs_overrides["stimulation"] = max(_as_float(needs_overrides.get("stimulation"), 0.0), 72.0)
+            mood_overrides["curiosity"] = max(_as_float(mood_overrides.get("curiosity"), 0.0), 65.0)
+        if audio_context["speech"]:
+            needs_overrides["social"] = max(_as_float(needs_overrides.get("social"), 0.0), _as_float(self.cfg.get("speech_social"), 86.0))
+            needs_overrides["stimulation"] = max(_as_float(needs_overrides.get("stimulation"), 0.0), 62.0)
+        if audio_context["sound"]:
+            needs_overrides["stimulation"] = max(_as_float(needs_overrides.get("stimulation"), 0.0), _as_float(self.cfg.get("sound_curiosity"), 76.0))
+            mood_overrides["curiosity"] = max(_as_float(mood_overrides.get("curiosity"), 0.0), 72.0)
+        if audio_context["silence"]:
+            needs_overrides["stimulation"] = max(_as_float(needs_overrides.get("stimulation"), 0.0), _as_float(self.cfg.get("silence_boredom"), 58.0))
+        if audio_context["loud"]:
+            mood_overrides["fear"] = max(_as_float(mood_overrides.get("fear"), 0.0), _as_float(self.cfg.get("loud_fear"), 60.0))
+        return {
+            "available": True,
+            "status": st,
+            "audio_context": audio_context,
+            "mood_overrides": mood_overrides,
+            "needs_overrides": needs_overrides,
+            "owner_present": bool(st.get("owner_present") or owner_recent),
+            "owner_last_heard_ts": self._owner_last_heard_ts or None,
+            "speech_busy": bool(st.get("speech_busy")),
+        }
+
+    def _push_history(self, item: Dict[str, Any]) -> None:
+        compact = {
+            "timestamp": item.get("timestamp"),
+            "reason": item.get("reason"),
+            "event_type": item.get("event_type", ""),
+            "wakeword": item.get("wakeword", False),
+            "speech": item.get("speech", False),
+            "sound": item.get("sound", False),
+            "silence": item.get("silence", False),
+            "loud": item.get("loud", False),
+        }
+        self._history.append(compact)
+        limit = int(_as_float(self.cfg.get("history_limit"), 20))
+        self._history = self._history[-max(1, limit):]
+
+    @staticmethod
+    def _derive_event(wakeword: bool, speech: bool, sound: bool, silence: bool, loud: bool) -> str:
+        if loud:
+            return "loud_noise"
+        if wakeword:
+            return "wakeword"
+        if speech:
+            return "speech"
+        if sound:
+            return "sound"
+        if silence:
+            return "silence"
+        return "audio"
+
+    @staticmethod
+    def _reason_for(*, wakeword: bool, speech: bool, sound: bool, silence: bool, loud: bool) -> str:
+        if loud:
+            return "audio.loud"
+        if wakeword:
+            return "audio.wakeword"
+        if speech:
+            return "audio.speech"
+        if sound:
+            return "audio.sound"
+        if silence:
+            return "audio.silence"
+        return "audio.context"

--- a/modules/autonomy/services/brain.py
+++ b/modules/autonomy/services/brain.py
@@ -20,6 +20,19 @@ from .proactive_planner import ProactivePlanner
 from .barge_in import BargeInController
 from .liveliness import LivelinessScheduler
 from .interaction_feedback import InteractionFeedbackLearner
+from .needs_engine import CompanionNeedsEngine
+from .companion_goal_selector import CompanionGoalSelector
+from .companion_goal_executor import CompanionGoalExecutor
+from .companion_auto_execute_gate import CompanionAutoExecuteGate
+from .companion_behavior_loop import CompanionBehaviorLoop
+from .vision_context_needs_bridge import VisionContextNeedsBridge
+from .audio_event_needs_bridge import AudioEventNeedsBridge
+from .world_memory_rag import WorldMemoryRAG as WorldMemory
+from .living_needs import LivingNeedsEngine
+from .safe_navigation import SafeNavigationMemory
+from .memory_decision_shadow import MemoryDecisionShadow
+from .memory_needs_bias import MemoryNeedsBias
+from .world_memory_autowriter import WorldMemoryAutoWriter
 from .relationship_memory import RelationshipMemory
 from .brain_parts.animations import AnimationSupportMixin
 from .brain_parts.owner_guard import OwnerGuardMixin
@@ -83,6 +96,32 @@ class AutonomyBrain(
         )
         learning_cfg = companion_cfg.get("learning", {}) if isinstance(companion_cfg.get("learning", {}), dict) else {}
         self.feedback_learner = InteractionFeedbackLearner(learning_cfg.get("feedback", learning_cfg))
+        needs_cfg = self.config.get("companion_needs", {}) if isinstance(self.config.get("companion_needs", {}), dict) else {}
+        self.needs_engine = CompanionNeedsEngine(needs_cfg)
+        goal_cfg = self.config.get("companion_goals", {}) if isinstance(self.config.get("companion_goals", {}), dict) else {}
+        self.goal_selector = CompanionGoalSelector(goal_cfg)
+        executor_cfg = self.config.get("companion_goal_executor", {}) if isinstance(self.config.get("companion_goal_executor", {}), dict) else {}
+        self.goal_executor = CompanionGoalExecutor(executor_cfg, client=self.client)
+        auto_exec_cfg = self.config.get("companion_auto_execute", {}) if isinstance(self.config.get("companion_auto_execute", {}), dict) else {}
+        self.goal_auto_execute_gate = CompanionAutoExecuteGate(auto_exec_cfg)
+        loop_cfg = self.config.get("companion_behavior_loop", {}) if isinstance(self.config.get("companion_behavior_loop", {}), dict) else {}
+        self.companion_behavior_loop = CompanionBehaviorLoop(loop_cfg)
+        vision_needs_cfg = self.config.get("vision_context_needs", {}) if isinstance(self.config.get("vision_context_needs", {}), dict) else {}
+        self.vision_context_needs_bridge = VisionContextNeedsBridge(vision_needs_cfg)
+        audio_needs_cfg = self.config.get("audio_event_needs", {}) if isinstance(self.config.get("audio_event_needs", {}), dict) else {}
+        self.audio_event_needs_bridge = AudioEventNeedsBridge(audio_needs_cfg)
+        world_memory_cfg = self.config.get("world_memory", {}) if isinstance(self.config.get("world_memory", {}), dict) else {}
+        self.world_memory = WorldMemory(world_memory_cfg)
+        living_needs_cfg = self.config.get("living_needs", {}) if isinstance(self.config.get("living_needs", {}), dict) else {}
+        self.living_needs = LivingNeedsEngine(living_needs_cfg)
+        safe_navigation_cfg = self.config.get("safe_navigation", {}) if isinstance(self.config.get("safe_navigation", {}), dict) else {}
+        self.safe_navigation = SafeNavigationMemory(safe_navigation_cfg, client=self.client)
+        memory_decision_cfg = self.config.get("memory_decision_shadow", {}) if isinstance(self.config.get("memory_decision_shadow", {}), dict) else {}
+        self.memory_decision_shadow = MemoryDecisionShadow(memory_decision_cfg)
+        memory_bias_cfg = self.config.get("memory_needs_bias", {}) if isinstance(self.config.get("memory_needs_bias", {}), dict) else {}
+        self.memory_needs_bias = MemoryNeedsBias(memory_bias_cfg)
+        world_memory_autowrite_cfg = self.config.get("world_memory_autowrite", {}) if isinstance(self.config.get("world_memory_autowrite", {}), dict) else {}
+        self.world_memory_autowriter = WorldMemoryAutoWriter(world_memory_autowrite_cfg)
         self.barge_in = BargeInController(config.get("barge_in", {}) if isinstance(config.get("barge_in", {}), dict) else {})
         self.liveliness = LivelinessScheduler(config.get("liveliness", {}) if isinstance(config.get("liveliness", {}), dict) else {})
         self._vision_cfg = config.get("vision_hooks", {})
@@ -125,6 +164,24 @@ class AutonomyBrain(
             "rfid_authorized_until": 0.0,
             "last_speaker": None,
             "persona_mode": None,
+            "companion_needs": {},
+            "companion_behavior_loop": {},
+            "companion_behavior_history": [],
+            "vision_context_needs": {},
+            "vision_context_history": [],
+            "audio_event_needs": {},
+            "audio_event_history": [],
+            "world_memory": {},
+            "world_memory_history": [],
+            "memory_decision_shadow": {},
+            "memory_needs_bias": {},
+            "world_memory_autowrite": {},
+            "world_memory_autowrite_history": [],
+            "living_needs": {},
+            "living_needs_history": [],
+            "safe_navigation": {},
+            "sound_interrupt": {},
+            "sound_interrupt_history": [],
         }
         self._people_last_seen = {}
         self._last_emotion_sent = None
@@ -237,6 +294,10 @@ class AutonomyBrain(
         if hasattr(self.mood, "satisfy_need"):
             self.mood.satisfy_need("social", social_fill)
             self.mood.satisfy_need("stimulation", stim_drain)
+        try:
+            self.needs_engine.observe_interaction(str(source or "interaction"))
+        except Exception:
+            pass
 
     def _sense(self):
         """Poll sensors for new information."""
@@ -245,11 +306,17 @@ class AutonomyBrain(
         self._sense_vision()
 
     def _sense_sound_direction(self):
+        cfg = self.config.get("sound_direction", {}) if isinstance(self.config.get("sound_direction", {}), dict) else {}
+        interval = float(cfg.get("poll_interval_s", 2.0) or 2.0)
+        now = time.time()
+        if now - float(self.state.get("last_sound_direction_poll", 0.0) or 0.0) < max(0.2, interval):
+            return
+        self.state["last_sound_direction_poll"] = now
         try:
             direction = self.client.get_speech_direction()
             angle = (direction or {}).get("angle") if isinstance(direction, dict) else None
             if isinstance(angle, (int, float)) and abs(angle) > 10:
-                    self._react_to_sound(angle)
+                self._react_to_sound(angle)
         except Exception:
             pass
 
@@ -517,6 +584,10 @@ class AutonomyBrain(
         self._sync_emotion()
         self._liveliness_tick(now)
 
+        self._update_companion_needs(now)
+
+        self._tick_companion_behavior_loop(now)
+
         if random.random() < 0.4:
             self._perform_micro_movement()
 
@@ -550,6 +621,717 @@ class AutonomyBrain(
 
         self._run_companion_rituals(now)
         self._run_companion_proactive(now)
+
+    def _update_companion_needs(self, now: float) -> None:
+        try:
+            owner_present = bool(self._owner_seen_recently()) if hasattr(self, "_owner_seen_recently") else False
+            owner_last_seen = float(self.state.get("owner_last_seen", 0.0) or 0.0)
+            scene_ctx = {
+                "summary": str(self.state.get("scene_summary", "") or ""),
+                "importance": float(self.state.get("scene_importance", 0.0) or 0.0),
+                "unspoken": bool(self.state.get("scene_unspoken", False)),
+                "hazards": self.state.get("scene_hazards", []),
+            }
+            cfg_pc = self.config.get("pc_test", {}) if isinstance(self.config.get("pc_test", {}), dict) else {}
+            pc_test = bool(cfg_pc.get("enabled", False))
+            mood_state = getattr(self.mood, "state", {})
+            mood_state = dict(mood_state) if isinstance(mood_state, dict) else {}
+            needs_state = self.mood.get_needs() if hasattr(self.mood, "get_needs") else {}
+            needs_state = dict(needs_state) if isinstance(needs_state, dict) else {}
+            if hasattr(self, "vision_context_needs_bridge"):
+                try:
+                    bridge_ctx = self.vision_context_needs_bridge.context(now=now)
+                    self.state["vision_context_needs"] = bridge_ctx.get("status", bridge_ctx)
+                    if bridge_ctx.get("available"):
+                        scene_ctx.update(bridge_ctx.get("scene") or {})
+                        if bridge_ctx.get("owner_present"):
+                            owner_present = True
+                        bridge_owner_ts = bridge_ctx.get("owner_last_seen_ts")
+                        if bridge_owner_ts:
+                            owner_last_seen = max(float(owner_last_seen or 0.0), float(bridge_owner_ts))
+                        mood_state.update(bridge_ctx.get("mood_overrides") or {})
+                        needs_state.update(bridge_ctx.get("needs_overrides") or {})
+                except Exception as exc:
+                    logger.debug("Vision context needs bridge failed: %s", exc)
+            if hasattr(self, "audio_event_needs_bridge"):
+                try:
+                    audio_bridge_ctx = self.audio_event_needs_bridge.context(now=now)
+                    self.state["audio_event_needs"] = audio_bridge_ctx.get("status", audio_bridge_ctx)
+                    if audio_bridge_ctx.get("available"):
+                        scene_ctx["audio_context"] = audio_bridge_ctx.get("audio_context") or {}
+                        if audio_bridge_ctx.get("owner_present"):
+                            owner_present = True
+                        audio_owner_ts = audio_bridge_ctx.get("owner_last_heard_ts")
+                        if audio_owner_ts:
+                            owner_last_seen = max(float(owner_last_seen or 0.0), float(audio_owner_ts))
+                        if audio_bridge_ctx.get("speech_busy"):
+                            setattr(self, "_speech_busy", True)
+                        mood_state.update(audio_bridge_ctx.get("mood_overrides") or {})
+                        needs_state.update(audio_bridge_ctx.get("needs_overrides") or {})
+                except Exception as exc:
+                    logger.debug("Audio event needs bridge failed: %s", exc)
+            snapshot = self.needs_engine.tick(
+                now=now,
+                last_interaction_ts=float(self.state.get("last_interaction", now) or now),
+                mood_state=mood_state,
+                needs_state=needs_state,
+                owner_present=owner_present,
+                owner_last_seen_ts=owner_last_seen or None,
+                is_sleeping=bool(self.state.get("is_sleeping", False)),
+                speech_busy=bool(getattr(self, "_speech_busy", False)),
+                scene=scene_ctx,
+                pc_test=pc_test,
+            )
+            snapshot = self._apply_memory_bias_to_needs(snapshot, now)
+            self.state["companion_needs"] = snapshot
+            goal_plan = self.goal_selector.select(
+                snapshot,
+                owner_present=owner_present,
+                now=now,
+            )
+            self.state["companion_goal"] = goal_plan
+            goal_event = str(goal_plan.get("event", "") or "").strip()
+            if goal_event:
+                self.client.push_interaction_event(goal_event, goal_plan)
+            event = str(snapshot.get("event", "") or "").strip()
+            if event:
+                self.client.push_interaction_event(event, {
+                    "dominant_need": snapshot.get("dominant_need"),
+                    "recommended_goal": snapshot.get("recommended_goal"),
+                    "scores": snapshot.get("scores", {}),
+                    "confidence": snapshot.get("confidence", 0.0),
+                })
+        except Exception as exc:
+            logger.debug("Companion needs update failed: %s", exc)
+
+    def execute_companion_goal(self, payload: dict | None = None, **_: object) -> dict:
+        try:
+            plan = None
+            if isinstance(payload, dict) and isinstance(payload.get("goal_plan"), dict):
+                plan = payload.get("goal_plan")
+            if not isinstance(plan, dict):
+                plan = self.get_companion_goal_snapshot() if hasattr(self, "get_companion_goal_snapshot") else {}
+            result = self.goal_executor.execute(plan)
+            self.state["companion_goal_execution"] = result
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def observe_vision_context_for_needs(self, payload: dict | None = None, source: str = "api") -> dict:
+        try:
+            if not hasattr(self, "vision_context_needs_bridge"):
+                return {"ok": False, "available": False, "reason": "vision_context_bridge_missing"}
+            result = self.vision_context_needs_bridge.observe(payload or {}, source=source)
+            self.state["vision_context_needs"] = result
+            history = list(self.state.get("vision_context_history") or [])
+            history.append({
+                "timestamp": result.get("timestamp"),
+                "reason": result.get("reason"),
+                "summary": result.get("summary", ""),
+                "new_object": result.get("new_object", False),
+                "owner_present": result.get("owner_present", False),
+                "no_person": result.get("no_person", False),
+                "hazards": result.get("hazards", []),
+            })
+            self.state["vision_context_history"] = history[-20:]
+            try:
+                result["memory_autowrite"] = self.observe_context_world_memory("vision", result)
+            except Exception:
+                pass
+            try:
+                self.client.push_interaction_event("vision.context", {
+                    "reason": result.get("reason"),
+                    "summary": result.get("summary", ""),
+                    "new_object": result.get("new_object", False),
+                    "owner_present": result.get("owner_present", False),
+                    "no_person": result.get("no_person", False),
+                })
+            except Exception:
+                pass
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def observe_audio_event_for_needs(self, payload: dict | None = None, source: str = "api") -> dict:
+        try:
+            if not hasattr(self, "audio_event_needs_bridge"):
+                return {"ok": False, "available": False, "reason": "audio_event_bridge_missing"}
+            result = self.audio_event_needs_bridge.observe(payload or {}, source=source)
+            self.state["audio_event_needs"] = result
+            history = list(self.state.get("audio_event_history") or [])
+            history.append({
+                "timestamp": result.get("timestamp"),
+                "reason": result.get("reason"),
+                "event_type": result.get("event_type", ""),
+                "wakeword": result.get("wakeword", False),
+                "speech": result.get("speech", False),
+                "sound": result.get("sound", False),
+                "silence": result.get("silence", False),
+                "loud": result.get("loud", False),
+            })
+            self.state["audio_event_history"] = history[-20:]
+            try:
+                result["memory_autowrite"] = self.observe_context_world_memory("audio", result)
+            except Exception:
+                pass
+            try:
+                self.client.push_interaction_event("audio.context", {
+                    "reason": result.get("reason"),
+                    "event_type": result.get("event_type", ""),
+                    "wakeword": result.get("wakeword", False),
+                    "speech": result.get("speech", False),
+                    "sound": result.get("sound", False),
+                    "silence": result.get("silence", False),
+                    "loud": result.get("loud", False),
+                })
+            except Exception:
+                pass
+            try:
+                if result.get("sound") or result.get("wakeword") or result.get("speech") or result.get("loud"):
+                    result["sound_interrupt"] = self.handle_sound_interrupt(result)
+            except Exception:
+                pass
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def observe_context_world_memory(self, source_type: str, context: dict | None = None) -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing"}
+            if not hasattr(self, "world_memory_autowriter"):
+                return {"ok": False, "available": False, "reason": "world_memory_autowriter_missing"}
+            payloads = self.world_memory_autowriter.build(source_type, context or {})
+            results = []
+            for payload in payloads:
+                src = payload.get("source") if isinstance(payload, dict) else source_type
+                results.append(self.world_memory.observe(payload, source=src or source_type))
+            snapshot = {"ok": True, "available": True, "source_type": source_type, "count": len(results), "items": [r.get("item", {}) for r in results if isinstance(r, dict)], "created_count": sum(1 for r in results if isinstance(r, dict) and r.get("created"))}
+            self.state["world_memory"] = self.world_memory.status()
+            self.state["world_memory_autowrite"] = snapshot
+            history = list(self.state.get("world_memory_autowrite_history") or [])
+            history.append({"source_type": source_type, "count": snapshot.get("count", 0), "created_count": snapshot.get("created_count", 0), "items": [{"id": item.get("id"), "kind": item.get("kind"), "name": item.get("name")} for item in snapshot.get("items", []) if isinstance(item, dict)]})
+            self.state["world_memory_autowrite_history"] = history[-50:]
+            return snapshot
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc), "source_type": source_type}
+
+    def get_world_memory_autowrite_snapshot(self) -> dict:
+        try:
+            current = self.state.get("world_memory_autowrite")
+            if isinstance(current, dict) and current:
+                data = dict(current)
+            else:
+                data = {"ok": True, "available": False, "reason": "never_written", "count": 0, "items": []}
+            data["history"] = list(self.state.get("world_memory_autowrite_history") or [])[-10:]
+            return data
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def _apply_memory_bias_to_needs(self, snapshot: dict, now: float | None = None) -> dict:
+        try:
+            if not hasattr(self, "memory_needs_bias") or not hasattr(self, "memory_decision_shadow") or not hasattr(self, "world_memory"):
+                return snapshot
+            memory_snapshot = self.world_memory.status()
+            recent_result = self.world_memory.recent(limit=25)
+            recent = recent_result.get("items", []) if isinstance(recent_result, dict) else []
+            shadow = self.memory_decision_shadow.evaluate(memory_snapshot, recent, now=now)
+            self.state["memory_decision_shadow"] = shadow
+            biased = self.memory_needs_bias.apply(snapshot, shadow, now=now)
+            if isinstance(biased, dict):
+                self.state["memory_needs_bias"] = biased.get("memory_bias", {})
+                return biased
+        except Exception as exc:
+            try:
+                self.state["memory_needs_bias"] = {"ok": False, "available": False, "error": str(exc)}
+            except Exception:
+                pass
+        return snapshot
+
+    def get_memory_needs_bias_snapshot(self) -> dict:
+        try:
+            if hasattr(self, "memory_needs_bias"):
+                return self.memory_needs_bias.snapshot()
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+        return {"ok": False, "available": False, "reason": "memory_needs_bias_missing"}
+
+    def evaluate_memory_needs_bias(self, payload: dict | None = None) -> dict:
+        try:
+            if not hasattr(self, "memory_needs_bias"):
+                return {"ok": False, "available": False, "reason": "memory_needs_bias_missing"}
+            data = payload if isinstance(payload, dict) else {}
+            needs = data.get("needs") if isinstance(data.get("needs"), dict) else data.get("needs_snapshot")
+            shadow = data.get("shadow") if isinstance(data.get("shadow"), dict) else data.get("memory_shadow")
+            return self.memory_needs_bias.apply(needs if isinstance(needs, dict) else {}, shadow if isinstance(shadow, dict) else {}, now=data.get("now"))
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_memory_decision_shadow(self) -> dict:
+        try:
+            if not hasattr(self, "world_memory") or not hasattr(self, "memory_decision_shadow"):
+                return {"ok": False, "available": False, "reason": "memory_decision_shadow_missing"}
+            snapshot = self.world_memory.status()
+            recent_result = self.world_memory.recent(limit=25)
+            recent = recent_result.get("items", []) if isinstance(recent_result, dict) else []
+            result = self.memory_decision_shadow.evaluate(snapshot, recent)
+            self.state["memory_decision_shadow"] = result
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def evaluate_memory_decision_shadow(self, payload: dict | None = None) -> dict:
+        try:
+            if not hasattr(self, "memory_decision_shadow"):
+                return {"ok": False, "available": False, "reason": "memory_decision_shadow_missing"}
+            data = payload if isinstance(payload, dict) else {}
+            snapshot = data.get("memory") if isinstance(data.get("memory"), dict) else data
+            recent = data.get("recent") if isinstance(data.get("recent"), list) else None
+            return self.memory_decision_shadow.evaluate(snapshot, recent, now=data.get("now"))
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_world_memory_snapshot(self) -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing"}
+            result = self.world_memory.status()
+            self.state["world_memory"] = result
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_world_memory_schema(self) -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing"}
+            return self.world_memory.schema()
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def observe_world_memory(self, payload: dict | None = None, source: str = "api") -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing"}
+            result = self.world_memory.observe(payload or {}, source=source)
+            self.state["world_memory"] = self.world_memory.status()
+            history = list(self.state.get("world_memory_history") or [])
+            item = result.get("item") if isinstance(result, dict) else {}
+            history.append({
+                "timestamp": result.get("timestamp") if isinstance(result, dict) else None,
+                "id": item.get("id") if isinstance(item, dict) else "",
+                "kind": item.get("kind") if isinstance(item, dict) else "",
+                "name": item.get("name") if isinstance(item, dict) else "",
+                "created": result.get("created") if isinstance(result, dict) else False,
+                "source": item.get("source") if isinstance(item, dict) else source,
+            })
+            self.state["world_memory_history"] = history[-50:]
+            try:
+                self.client.push_interaction_event("memory.observe", {
+                    "kind": item.get("kind") if isinstance(item, dict) else "",
+                    "name": item.get("name") if isinstance(item, dict) else "",
+                    "created": result.get("created") if isinstance(result, dict) else False,
+                })
+            except Exception:
+                pass
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_world_memory_recent(self, kind: str | None = None, limit: int = 10) -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing"}
+            return self.world_memory.recent(kind=kind or None, limit=limit)
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def recall_world_memory(self, query: str = "", limit: int = 8) -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing"}
+            if hasattr(self.world_memory, "recall"):
+                return self.world_memory.recall(query or "", limit=limit)
+            return self.world_memory.recent(limit=limit)
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_world_memory_context(self, query: str = "", limit: int = 8) -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing", "context": ""}
+            if hasattr(self.world_memory, "build_context"):
+                return self.world_memory.build_context(query or "", limit=limit)
+            recent = self.world_memory.recent(limit=limit)
+            items = recent.get("items", []) if isinstance(recent, dict) else []
+            lines = [f"- {i.get('kind')}:{i.get('name')} | {i.get('summary')}" for i in items if isinstance(i, dict)]
+            return {"ok": True, "available": True, "query": query or "", "context": "\n".join(lines), "items": items}
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc), "context": ""}
+
+    def get_world_memory_history(self, limit: int = 20) -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing"}
+            return self.world_memory.history(limit=limit)
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def clear_world_memory(self, kind: str | None = None) -> dict:
+        try:
+            if not hasattr(self, "world_memory"):
+                return {"ok": False, "available": False, "reason": "world_memory_missing"}
+            result = self.world_memory.clear(kind=kind or None)
+            self.state["world_memory"] = self.world_memory.status()
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_audio_event_needs_snapshot(self) -> dict:
+        try:
+            current = self.state.get("audio_event_needs")
+            if isinstance(current, dict) and current:
+                data = dict(current)
+            elif hasattr(self, "audio_event_needs_bridge"):
+                data = self.audio_event_needs_bridge.status()
+            else:
+                data = {"ok": False, "available": False, "reason": "audio_event_bridge_missing"}
+            data["history"] = list(self.state.get("audio_event_history") or [])[-10:]
+            return data
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_vision_context_needs_snapshot(self) -> dict:
+        try:
+            current = self.state.get("vision_context_needs")
+            if isinstance(current, dict) and current:
+                data = dict(current)
+            elif hasattr(self, "vision_context_needs_bridge"):
+                data = self.vision_context_needs_bridge.status()
+            else:
+                data = {"ok": False, "available": False, "reason": "vision_context_bridge_missing"}
+            data["history"] = list(self.state.get("vision_context_history") or [])[-10:]
+            return data
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_companion_behavior_loop_snapshot(self) -> dict:
+        try:
+            current = self.state.get("companion_behavior_loop")
+            if isinstance(current, dict) and current:
+                data = dict(current)
+                data["available"] = True
+                data["history"] = list(self.state.get("companion_behavior_history") or [])[-10:]
+                return data
+            if hasattr(self, "companion_behavior_loop"):
+                status = self.companion_behavior_loop.status()
+                status["available"] = False
+                status["reason"] = "never_checked"
+                status["history"] = []
+                return status
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+        return {"ok": False, "available": False, "reason": "behavior_loop_missing"}
+
+    def tick_companion_behavior_loop(self, force: bool = False, **_: object) -> dict:
+        try:
+            now = time.time()
+            needs = self.get_needs_snapshot() if hasattr(self, "get_needs_snapshot") else {}
+            goal = self.get_companion_goal_snapshot() if hasattr(self, "get_companion_goal_snapshot") else {}
+            decision = self.companion_behavior_loop.decide(
+                needs=needs,
+                goal=goal,
+                now=now,
+                sleeping=bool(self.state.get("is_sleeping", False)),
+                speech_busy=bool(getattr(self, "_speech_busy", False)),
+                force=force,
+            )
+            if not decision.get("should_tick"):
+                self.state["companion_behavior_loop"] = decision
+                return decision
+            execution = self.tick_companion_auto_execute(force=force)
+            result = self.companion_behavior_loop.mark_execution(decision, execution)
+            self.state["companion_behavior_loop"] = result
+            history = list(self.state.get("companion_behavior_history") or [])
+            history.append({
+                "timestamp": result.get("timestamp"),
+                "dominant_need": result.get("dominant_need"),
+                "behavior": result.get("behavior"),
+                "reason": result.get("reason"),
+                "executed": result.get("executed"),
+                "execution_reason": result.get("execution_reason"),
+            })
+            self.state["companion_behavior_history"] = history[-20:]
+            try:
+                if result.get("executed"):
+                    self.client.push_interaction_event("companion.behavior_loop", {
+                        "dominant_need": result.get("dominant_need"),
+                        "behavior": result.get("behavior"),
+                                "reason": result.get("reason"),
+                    })
+            except Exception:
+                pass
+            return result
+        except Exception as exc:
+            result = {"ok": False, "available": False, "should_tick": False, "executed": False, "error": str(exc)}
+            self.state["companion_behavior_loop"] = result
+            return result
+
+    def _tick_companion_behavior_loop(self, now: float) -> None:
+        try:
+            if hasattr(self, "companion_behavior_loop"):
+                self.tick_companion_behavior_loop(force=False)
+        except Exception as exc:
+            logger.debug("Companion behavior loop tick failed: %s", exc)
+
+    def get_companion_auto_execute_snapshot(self) -> dict:
+        try:
+            current = self.state.get("companion_auto_execute")
+            if isinstance(current, dict) and current:
+                return dict(current)
+            if hasattr(self, "goal_auto_execute_gate"):
+                status = self.goal_auto_execute_gate.status()
+                status["available"] = False
+                status["reason"] = "never_checked"
+                return status
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+        return {"ok": False, "available": False, "reason": "auto_execute_gate_missing"}
+
+    def tick_companion_auto_execute(self, payload: dict | None = None, force: bool = False, **_: object) -> dict:
+        try:
+            body = payload if isinstance(payload, dict) else {}
+            plan = body.get("goal_plan") if isinstance(body.get("goal_plan"), dict) else None
+            if not isinstance(plan, dict):
+                plan = self.get_companion_goal_snapshot() if hasattr(self, "get_companion_goal_snapshot") else {}
+            decision = self.goal_auto_execute_gate.decide(plan, force=force)
+            if not decision.get("should_execute"):
+                self.state["companion_auto_execute"] = decision
+                return decision
+            execution = self.execute_companion_goal({"goal_plan": plan})
+            result = self.goal_auto_execute_gate.mark_execution(decision, execution)
+            self.state["companion_auto_execute"] = result
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "should_execute": False, "executed": False, "error": str(exc)}
+
+    def get_companion_goal_execution_snapshot(self) -> dict:
+        try:
+            current = self.state.get("companion_goal_execution")
+            if isinstance(current, dict) and current:
+                return dict(current)
+            if hasattr(self, "goal_executor"):
+                status = self.goal_executor.status()
+                status["available"] = False
+                status["reason"] = "never_executed"
+                return status
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+        return {"ok": False, "available": False, "reason": "goal_executor_missing"}
+
+    def get_companion_goal_snapshot(self) -> dict:
+        try:
+            current = self.state.get("companion_goal")
+            if isinstance(current, dict) and current:
+                data = dict(current)
+                data["available"] = True
+                return data
+            needs = self.get_needs_snapshot() if hasattr(self, "get_needs_snapshot") else {}
+            plan = self.goal_selector.select(needs)
+            plan["available"] = False
+            plan["reason"] = "no_goal_snapshot_yet"
+            return plan
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def get_needs_snapshot(self) -> dict:
+        try:
+            if hasattr(self, "living_needs") and bool(getattr(self.living_needs, "cfg", {}).get("enabled", True)):
+                current = self.state.get("living_needs")
+                if isinstance(current, dict) and current:
+                    data = dict(current)
+                    data["available"] = True
+                    return data
+                return self.tick_living_needs()
+            if hasattr(self, "needs_engine"):
+                current = self.state.get("companion_needs")
+                if isinstance(current, dict) and current:
+                    data = dict(current)
+                    data["available"] = True
+                    return data
+                return self.needs_engine.snapshot()
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+        return {"ok": False, "available": False, "reason": "needs_engine_missing"}
+
+    def tick_living_needs(self) -> dict:
+        try:
+            if not hasattr(self, "living_needs"):
+                return {"ok": False, "available": False, "reason": "living_needs_missing"}
+            now = time.time()
+            vision = self._current_vision_snapshot()
+            audio = self.state.get("audio_event_needs") if isinstance(self.state.get("audio_event_needs"), dict) else {}
+            snapshot = self.living_needs.tick(now=now, state=self.state, mood=self.mood, vision=vision, audio=audio)
+            snapshot = self._apply_memory_bias_to_needs(snapshot, now=now)
+            self.state["living_needs"] = snapshot
+            self.state["companion_needs"] = snapshot
+            history = list(self.state.get("living_needs_history") or [])
+            history.append({
+                "timestamp": snapshot.get("timestamp"),
+                "dominant_need": snapshot.get("dominant_need"),
+                "recommended_goal": snapshot.get("recommended_goal"),
+                "scores": snapshot.get("scores", {}),
+            })
+            self.state["living_needs_history"] = history[-50:]
+            try:
+                semantic = snapshot.get("semantic_state") if isinstance(snapshot.get("semantic_state"), dict) else {}
+                self.client.set_expression_event("needs." + str(snapshot.get("dominant_need") or "balance"), {
+                    "semantic_state": semantic,
+                    "scores": snapshot.get("scores", {}),
+                    "recommended_goal": snapshot.get("recommended_goal"),
+                })
+            except Exception:
+                pass
+            return snapshot
+        except Exception as exc:
+            result = {"ok": False, "available": False, "error": str(exc)}
+            self.state["living_needs"] = result
+            return result
+
+    def get_living_needs_snapshot(self) -> dict:
+        try:
+            current = self.state.get("living_needs")
+            if isinstance(current, dict) and current:
+                data = dict(current)
+            elif hasattr(self, "living_needs"):
+                data = self.living_needs.status()
+            else:
+                data = {"ok": False, "available": False, "reason": "living_needs_missing"}
+            data["history"] = list(self.state.get("living_needs_history") or [])[-10:]
+            return data
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+
+    def _current_vision_snapshot(self) -> dict:
+        out = {}
+        try:
+            tracks = self.client._get("camera", "/tracking/tracks", timeout_s=0.8)
+            if isinstance(tracks, dict):
+                out["tracks"] = tracks.get("tracks") if isinstance(tracks.get("tracks"), list) else tracks.get("items", [])
+                out["target"] = tracks.get("target")
+        except Exception:
+            pass
+        try:
+            ctx = self.state.get("vision_context_needs")
+            if isinstance(ctx, dict):
+                out.update({k: v for k, v in ctx.items() if k not in out})
+        except Exception:
+            pass
+        return out
+
+    def execute_safe_rest_corner(self, payload: dict | None = None) -> dict:
+        try:
+            if not hasattr(self, "safe_navigation"):
+                return {"ok": False, "available": False, "reason": "safe_navigation_missing"}
+            result = self.safe_navigation.execute_rest_corner(payload or {})
+            self.state["safe_navigation"] = result
+            return result
+        except Exception as exc:
+            result = {"ok": False, "available": False, "error": str(exc)}
+            self.state["safe_navigation"] = result
+            return result
+
+    def get_safe_navigation_status(self) -> dict:
+        try:
+            if hasattr(self, "safe_navigation"):
+                return self.safe_navigation.status()
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+        return {"ok": False, "available": False, "reason": "safe_navigation_missing"}
+
+    def list_safe_places(self) -> dict:
+        try:
+            if hasattr(self, "safe_navigation"):
+                return self.safe_navigation.list_places()
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+        return {"ok": False, "available": False, "reason": "safe_navigation_missing"}
+
+    def learn_safe_place(self, payload: dict | None = None) -> dict:
+        try:
+            if hasattr(self, "safe_navigation"):
+                result = self.safe_navigation.learn_place(payload or {})
+                try:
+                    place = result.get("place") if isinstance(result, dict) else {}
+                    if isinstance(place, dict):
+                        self.observe_world_memory({
+                            "kind": "place",
+                            "name": place.get("name") or place.get("id"),
+                            "summary": place.get("summary") or "learned safe place",
+                            "confidence": place.get("safety_score", 0.6),
+                            "salience": 0.65,
+                            "tags": ["safe_place", "rest_place"],
+                            "details": place,
+                        }, source="safe_navigation")
+                except Exception:
+                    pass
+                return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "error": str(exc)}
+        return {"ok": False, "available": False, "reason": "safe_navigation_missing"}
+
+    def handle_sound_interrupt(self, payload: dict | None = None) -> dict:
+        try:
+            body = payload if isinstance(payload, dict) else {}
+            event_type = str(body.get("event_type") or body.get("reason") or "sound").strip().lower()
+            is_sound = bool(body.get("sound") or body.get("wakeword") or body.get("speech") or event_type in {"sound", "wakeword", "speech", "voice"})
+            if not is_sound:
+                return {"ok": True, "available": True, "handled": False, "reason": "not_sound_interrupt"}
+            actions = []
+            try:
+                actions.append({"type": "expression", "result": self.client.set_expression_event("sound.interrupt", {"source": event_type, "payload": body})})
+            except Exception as exc:
+                actions.append({"type": "expression", "ok": False, "error": str(exc)})
+            try:
+                actions.append({"type": "liveliness", "result": self.client.set_liveliness(True, mode="alert", amplitude_deg=6, period_ms=1800)})
+            except Exception as exc:
+                actions.append({"type": "liveliness", "ok": False, "error": str(exc)})
+            try:
+                actions.append({"type": "head", "result": self.client.move_head(90, 86)})
+            except Exception as exc:
+                actions.append({"type": "head", "ok": False, "error": str(exc)})
+            try:
+                actions.append({"type": "camera_target", "result": self.client._post("camera", "/tracking/select", {"label": "person", "strategy": "center"}, timeout_s=1.0)})
+            except Exception as exc:
+                actions.append({"type": "camera_target", "ok": False, "error": str(exc)})
+            try:
+                self.observe_world_memory({
+                    "kind": "episode",
+                    "name": "sound_interrupt",
+                    "summary": "Sound interrupted resting or idle behavior; robot woke and looked for the source.",
+                    "confidence": 0.7,
+                    "salience": 0.7,
+                    "tags": ["sound", "interrupt", "wake"],
+                    "details": body,
+                }, source="audio_interrupt")
+            except Exception:
+                pass
+            result = {"ok": True, "available": True, "handled": True, "timestamp": time.time(), "event_type": event_type, "actions": actions}
+            self.state["sound_interrupt"] = result
+            hist = list(self.state.get("sound_interrupt_history") or [])
+            hist.append({"timestamp": result["timestamp"], "event_type": event_type, "handled": True})
+            self.state["sound_interrupt_history"] = hist[-20:]
+            return result
+        except Exception as exc:
+            return {"ok": False, "available": False, "handled": False, "error": str(exc)}
+
+    def get_sound_interrupt_snapshot(self) -> dict:
+        data = self.state.get("sound_interrupt") if isinstance(self.state.get("sound_interrupt"), dict) else {}
+        if not data:
+            data = {"ok": True, "available": False, "reason": "never_interrupted"}
+        out = dict(data)
+        out["history"] = list(self.state.get("sound_interrupt_history") or [])[-10:]
+        return out
 
     def _run_companion_rituals(self, now: float) -> None:
         if self._speech_busy:
@@ -627,6 +1409,11 @@ class AutonomyBrain(
 
     def _forward_visual_events_to_agent(self) -> None:
         """Forward key autonomy/vision signals to Agent Core event endpoint."""
+        interval = float(self._vision_cfg.get("forward_interval_s", 8.0) or 8.0)
+        now = time.time()
+        if now - float(self.state.get("last_agent_vision_forward_poll", 0.0) or 0.0) < max(1.0, interval):
+            return
+        self.state["last_agent_vision_forward_poll"] = now
         if not hasattr(self.client, "emit_agent_event"):
             return
         try:
@@ -1153,13 +1940,20 @@ class AutonomyBrain(
         try:
             if not self.agent.speech_arbiter._speak_fn:
                 self.agent.speech_arbiter.set_speak_fn(
-                    lambda text, tone=None, language=None: self.client.speak_preferred(
-                        text, tone=tone, language=language or lang,
+                    lambda text, tone=None, language=None, trace_id=None: self.client.speak_preferred(
+                        text,
+                        tone=tone,
+                        language=language or lang,
+                        trace_id=trace_id,
                     )
                 )
             enriched_text = self._enrich_user_text_with_companion_context(text=text, speaker=speaker)
             agent_result = self.agent.step(
-                enriched_text, language=lang, speaker=speaker, native_tools=True,
+                enriched_text,
+                language=lang,
+                speaker=speaker,
+                native_tools=True,
+                trace_id=request_id,
             )
             if agent_result and agent_result.get("text"):
                 if not self._is_active_request(request_id):
@@ -1169,7 +1963,12 @@ class AutonomyBrain(
                 self._remember_person_chat(speaker, agent_result["text"], role="assistant")
                 if not agent_result.get("speech_handled"):
                     tone = self._tone_profile(self.state.get("last_emotion") or self.mood.get_dominant_emotion())
-                    self.agent.speech_arbiter.enqueue_final(agent_result["text"], language=lang, tone=tone)
+                    self.agent.speech_arbiter.enqueue_final(
+                        agent_result["text"],
+                        language=lang,
+                        tone=tone,
+                        trace_id=request_id,
+                    )
                 return True
         except Exception as exc:
             logger.warning("Agent Core step failed, falling back to direct LLM: %s", exc)
@@ -1483,3 +2282,106 @@ class AutonomyBrain(
             if not self._run_scene("wake_entry", context={"hour": hour}):
                 self._speak_with_mood("Günaydın.", emotion="joy")
             self.client.set_speech_tracking(True)
+
+
+# BEGIN BATCH04 PI HARDWARE OWNER TOPO PATCH
+
+def _batch04_model_asset_status(self):
+    try:
+        from modules.common.model_asset_truth import collect_asset_truth
+        return collect_asset_truth(Path.cwd())
+    except Exception as exc:
+        return {"ok": False, "available": False, "error": str(exc)}
+
+def _batch04_pi_runtime_status(self):
+    try:
+        from modules.autonomy.services.pi_hardware_runtime import PiHardwareRuntime
+        cfg = self.config.get("pi_hardware_runtime", {}) if isinstance(self.config.get("pi_hardware_runtime", {}), dict) else {}
+        return PiHardwareRuntime(cfg, client=self.client).status()
+    except Exception as exc:
+        return {"ok": False, "available": False, "error": str(exc)}
+
+def _batch04_topomap_executor(self):
+    from modules.autonomy.services.topomap_motion_executor import TopomapMotionExecutor
+    cfg = self.config.get("topomap_motion", {}) if isinstance(self.config.get("topomap_motion", {}), dict) else {}
+    cur = getattr(self, "_batch04_topomap_motion", None)
+    if cur is None:
+        cur = TopomapMotionExecutor(cfg, client=self.client); setattr(self, "_batch04_topomap_motion", cur)
+    return cur
+
+def _batch04_navigation_topomap(self):
+    try: return _batch04_topomap_executor(self).list_map()
+    except Exception as exc: return {"ok": False, "available": False, "error": str(exc)}
+
+def _batch04_navigation_learn_place(self, payload=None):
+    try:
+        result = _batch04_topomap_executor(self).learn_place(payload or {})
+        try:
+            place = result.get("place") if isinstance(result, dict) else {}
+            if isinstance(place, dict) and hasattr(self, "observe_world_memory"):
+                self.observe_world_memory({"kind": "place", "name": place.get("name") or place.get("id"), "summary": place.get("summary") or "learned navigation place", "confidence": place.get("safety_score", 0.6), "salience": 0.7, "tags": ["place", "topomap", str(place.get("kind") or "place")], "details": place}, source="topomap_motion")
+        except Exception: pass
+        return result
+    except Exception as exc: return {"ok": False, "available": False, "error": str(exc)}
+
+def _batch04_navigation_goal(self, payload=None):
+    try:
+        result = _batch04_topomap_executor(self).execute_goal(payload or {}); self.state["topomap_motion"] = result; return result
+    except Exception as exc:
+        result = {"ok": False, "available": False, "error": str(exc)}; self.state["topomap_motion"] = result; return result
+
+def _batch04_owner_learning(self):
+    from modules.autonomy.services.owner_person_learning import OwnerPersonLearning
+    cfg = self.config.get("owner_learning", {}) if isinstance(self.config.get("owner_learning", {}), dict) else {}
+    cur = getattr(self, "_batch04_owner_learning", None)
+    if cur is None:
+        cur = OwnerPersonLearning(cfg, client=self.client, memory=getattr(self, "world_memory", None)); setattr(self, "_batch04_owner_learning", cur)
+    return cur
+
+def _batch04_owner_status(self):
+    try: return _batch04_owner_learning(self).status()
+    except Exception as exc: return {"ok": False, "available": False, "error": str(exc)}
+
+def _batch04_owner_learn(self, payload=None):
+    try: return _batch04_owner_learning(self).learn(payload or {})
+    except Exception as exc: return {"ok": False, "available": False, "error": str(exc)}
+
+def _batch04_owner_identify(self, payload=None):
+    try:
+        result = _batch04_owner_learning(self).identify(payload or {}); self.state["owner_identification"] = result; return result
+    except Exception as exc:
+        result = {"ok": False, "available": False, "error": str(exc)}; self.state["owner_identification"] = result; return result
+
+def _batch04_companion_e2e_scenario(self, payload=None):
+    body = payload if isinstance(payload, dict) else {}; actions = []
+    try: needs = self.tick_living_needs() if hasattr(self, "tick_living_needs") else {}
+    except Exception as exc: needs = {"ok": False, "error": str(exc)}
+    try: owner = _batch04_owner_identify(self, {})
+    except Exception as exc: owner = {"ok": False, "error": str(exc)}
+    try: tracks = self.client._get("camera", "/tracking/tracks", timeout_s=0.8)
+    except Exception as exc: tracks = {"ok": False, "error": str(exc)}
+    no_person = True
+    if isinstance(tracks, dict):
+        items = tracks.get("tracks") if isinstance(tracks.get("tracks"), list) else []
+        no_person = not any(str(t.get("label") or "").lower() == "person" for t in items if isinstance(t, dict))
+    if bool(body.get("force_rest")) or no_person:
+        try: actions.append({"type": "rest_corner", "result": self.execute_safe_rest_corner({"reason": "e2e_no_person", "allow_base_motion": bool(body.get("allow_base_motion", False))})})
+        except Exception as exc: actions.append({"type": "rest_corner", "ok": False, "error": str(exc)})
+    if bool(body.get("sound_interrupt")):
+        try: actions.append({"type": "sound_interrupt", "result": self.handle_sound_interrupt({"event_type": "sound", "source": "e2e"})})
+        except Exception as exc: actions.append({"type": "sound_interrupt", "ok": False, "error": str(exc)})
+    try: memory = self.get_world_memory_context(str(body.get("query") or "owner safe place current room"), limit=5) if hasattr(self, "get_world_memory_context") else {}
+    except Exception as exc: memory = {"ok": False, "error": str(exc)}
+    result = {"ok": True, "available": True, "mode": body.get("mode") or "safe", "needs": needs, "owner": owner, "tracks": tracks, "no_person": no_person, "actions": actions, "memory_context": memory}
+    self.state["companion_e2e_scenario"] = result; return result
+
+AutonomyBrain.get_model_asset_status = _batch04_model_asset_status
+AutonomyBrain.get_pi_runtime_status = _batch04_pi_runtime_status
+AutonomyBrain.get_navigation_topomap = _batch04_navigation_topomap
+AutonomyBrain.learn_navigation_topomap_place = _batch04_navigation_learn_place
+AutonomyBrain.execute_navigation_goal = _batch04_navigation_goal
+AutonomyBrain.get_owner_learning_status = _batch04_owner_status
+AutonomyBrain.learn_owner_person = _batch04_owner_learn
+AutonomyBrain.identify_owner_person = _batch04_owner_identify
+AutonomyBrain.run_companion_e2e_scenario = _batch04_companion_e2e_scenario
+# END BATCH04 PI HARDWARE OWNER TOPO PATCH

--- a/modules/autonomy/services/brain_parts/responses.py
+++ b/modules/autonomy/services/brain_parts/responses.py
@@ -1,5 +1,8 @@
 """LLM çıktı etiketlerini fiziksel aksiyonlara çeviren mixin."""
 from __future__ import annotations
+AUTONOMY_LLM_TAG_COMPATIBILITY_CONTRACT = True
+AUTONOMY_LLM_TAG_COMPATIBILITY_ROLE = "legacy_inline_llm_tag_adapter"
+
 
 import logging
 import re
@@ -47,7 +50,7 @@ class ResponseTagMixin:
 			if action_bundle.get("commands"):
 				self._dispatch_llm_commands(action_bundle.get("commands", []))
 		elif action_bundle is None:
-			# Backward compatibility: parse inline [cmd:*] and [[type key=value]] tags.
+			# Compatibility path: parse older inline [cmd:*] and [[type key=value]] tags.
 			cleaned, legacy_commands, blocks = self._extract_legacy_tags(raw_text or cleaned)
 
 		if legacy_commands:

--- a/modules/autonomy/services/capability_executor.py
+++ b/modules/autonomy/services/capability_executor.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class CapabilityExecutor:
+    def __init__(self, client: Any, registry_path: Optional[Path] = None) -> None:
+        self.client = client
+        self.registry_path = registry_path or Path(__file__).resolve().parents[3] / "config" / "robot_capability_registry.json"
+        self.registry = self._load_registry()
+        self._last_result: Dict[str, Any] = {"ok": True, "reason": "never_executed"}
+
+    def _load_registry(self) -> Dict[str, Any]:
+        data = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or not isinstance(data.get("capabilities"), dict):
+            raise ValueError("robot capability registry is invalid")
+        return data
+
+    def status(self) -> Dict[str, Any]:
+        capabilities = self.registry.get("capabilities", {})
+        return {
+            "ok": True,
+            "registry_path": str(self.registry_path),
+            "capability_count": len(capabilities),
+            "capabilities": sorted(capabilities),
+            "last_result": dict(self._last_result),
+        }
+
+    def execute(self, name: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        started = time.monotonic()
+        params = params if isinstance(params, dict) else {}
+        capability = self.registry.get("capabilities", {}).get(name)
+        if not isinstance(capability, dict):
+            return self._remember(name, False, "capability_not_found", started)
+        if not bool(capability.get("enabled", True)):
+            return self._remember(name, False, "capability_disabled", started)
+        risk = str(capability.get("risk") or "none").lower()
+        blocked = {str(x).lower() for x in self.registry.get("policy", {}).get("blocked_risks", ["critical"])}
+        if risk in blocked:
+            return self._remember(name, False, f"risk_blocked:{risk}", started)
+
+        handler = str(capability.get("handler") or "").strip()
+        try:
+            response = self._dispatch(handler, params, capability)
+            ok = response is not None and not (isinstance(response, dict) and response.get("ok") is False)
+            result = self._remember(name, ok, "executed" if ok else "handler_failed", started)
+            result["handler"] = handler
+            result["response"] = response
+            return result
+        except Exception as exc:
+            result = self._remember(name, False, "handler_exception", started)
+            result["handler"] = handler
+            result["error"] = str(exc)
+            return result
+
+    def _dispatch(self, handler: str, params: Dict[str, Any], capability: Dict[str, Any]) -> Any:
+        if handler == "expression_event":
+            event = str(params.get("event") or params.get("type") or "needs.balance")
+            data = params.get("data") if isinstance(params.get("data"), dict) else {}
+            return self.client._post("expression", "/event", {"type": event, "data": data})
+        if handler == "animate":
+            name = str(params.get("name") or capability.get("default_name") or "idle")
+            speed = float(params.get("speed", 1.0))
+            return self.client._post("animate", "/run", params={"name": name, "speed": speed, "loop": False}, timeout_s=4.0)
+        if handler == "stop_motion":
+            animation = self.client._post("animate", "/stop", timeout_s=1.0)
+            liveliness = self.client.set_liveliness(False)
+            return {"ok": bool(animation is not None or liveliness is not None), "animation": animation, "liveliness": liveliness}
+        if handler == "vision_latest":
+            return self.client._get_vlm("/results/latest")
+        if handler == "vision_refresh":
+            reason = str(params.get("reason") or "companion_goal")
+            return self.client._post("vlm", "/context/refresh", {"reason": reason, "mode": "semantic"}, timeout_s=8.0)
+        if handler == "track_target":
+            label = str(params.get("label") or "person").strip().lower()
+            strategy = str(params.get("strategy") or "largest").strip().lower()
+            track_id = params.get("track_id")
+            selection = self.client._post(
+                "camera",
+                "/tracking/select",
+                {"label": label, "strategy": strategy, "track_id": track_id},
+                timeout_s=1.0,
+            )
+            follow = None
+            if label == "person" and bool(params.get("follow", True)):
+                person = str(params.get("person") or "").strip() or None
+                follow = self.client._post("vlm", "/follow/start", params={"person": person} if person else None, timeout_s=1.0)
+            return {"ok": selection is not None, "selection": selection, "follow": follow}
+        if handler == "rest_corner":
+            if hasattr(self.client, "execute_rest_corner"):
+                return self.client.execute_rest_corner(params)
+            return self.client._post("autonomy", "/navigation/rest-corner", json=params, timeout_s=1.5)
+        if handler == "memory_observe":
+            payload = dict(params)
+            if "kind" not in payload:
+                payload["kind"] = "episode"
+            if "name" not in payload:
+                payload["name"] = str(params.get("summary") or "companion_event")[:80]
+            if hasattr(self.client, "world_memory_observe"):
+                return self.client.world_memory_observe(payload)
+            return self.client._post("autonomy", "/memory/observe", json=payload, timeout_s=1.0)
+        if handler == "speak":
+            text = str(params.get("text") or capability.get("fallback_text") or "").strip()
+            if not text:
+                return {"ok": True, "skipped": True, "reason": "empty_text"}
+            return self.client.speak_preferred(text, tone=params.get("tone"), language=params.get("language"))
+        # BEGIN BATCH04 CAPABILITY HANDLERS
+        if handler == "navigation_goal":
+            return self.client._post("autonomy", "/navigation/goal", json=params, timeout_s=2.0)
+        if handler == "owner_learn":
+            return self.client._post("autonomy", "/owner/learn", json=params, timeout_s=1.0)
+        if handler == "owner_identify":
+            return self.client._post("autonomy", "/owner/identify", json=params, timeout_s=1.0)
+        if handler == "asset_status":
+            return self.client._get("autonomy", "/assets/status", timeout_s=1.0)
+        # END BATCH04 CAPABILITY HANDLERS
+        if handler in {"wait", "semantic_noop"}:
+            return {"ok": True, "skipped": True, "reason": handler}
+        raise ValueError(f"unknown capability handler: {handler}")
+
+    def _remember(self, name: str, ok: bool, reason: str, started: float) -> Dict[str, Any]:
+        result = {
+            "ok": bool(ok),
+            "capability": name,
+            "reason": reason,
+            "latency_ms": round((time.monotonic() - started) * 1000.0, 2),
+            "timestamp": time.time(),
+        }
+        self._last_result = dict(result)
+        return result
+
+
+__all__ = ["CapabilityExecutor"]

--- a/modules/autonomy/services/client.py
+++ b/modules/autonomy/services/client.py
@@ -331,11 +331,13 @@ class ServiceClient:
             return start_m <= now < end_m
         return now >= start_m or now < end_m
 
-    def speak(self, text, tone=None, engine=None, language=None):
-        payload = self._build_speak_payload(text, tone=tone, engine=engine, language=language)
+    def speak(self, text, tone=None, engine=None, language=None, trace_id=None):
+        payload = self._build_speak_payload(
+            text, tone=tone, engine=engine, language=language, trace_id=trace_id,
+        )
         return self._post("speak", "/say", payload)
 
-    def _build_speak_payload(self, text, tone=None, engine=None, language=None):
+    def _build_speak_payload(self, text, tone=None, engine=None, language=None, trace_id=None):
         text_value = str(text or "")
         if self._quiet_hours_active():
             max_chars = int(self.speech_quiet_cfg.get("max_chars", 120))
@@ -353,11 +355,15 @@ class ServiceClient:
             payload["engine"] = engine
         if language:
             payload["language"] = str(language)
+        if trace_id:
+            payload["trace_id"] = str(trace_id)
         return payload
 
-    def speak_stream(self, text, tone=None, engine=None, language=None, max_chunk_chars=None):
+    def speak_stream(self, text, tone=None, engine=None, language=None, max_chunk_chars=None, trace_id=None):
         """Chunked TTS via /speak/say_stream; blocks until the stream job finishes."""
-        payload = self._build_speak_payload(text, tone=tone, engine=engine, language=language)
+        payload = self._build_speak_payload(
+            text, tone=tone, engine=engine, language=language, trace_id=trace_id,
+        )
         if not str(payload.get("text", "")).strip():
             return {"ok": False, "error": "text is empty"}
         if max_chunk_chars is not None:
@@ -368,7 +374,7 @@ class ServiceClient:
         start_timeout = float(self.request_timeouts.get("speak_stream_start_s", 4.0))
         resp = self._post("speak", "/say_stream", payload, timeout_s=start_timeout)
         if not resp or not resp.get("ok"):
-            return self.speak(text, tone=tone, engine=engine, language=language)
+            return self.speak(text, tone=tone, engine=engine, language=language, trace_id=trace_id)
 
         job_id = str(resp.get("job_id") or "").strip()
         if not job_id:
@@ -389,10 +395,12 @@ class ServiceClient:
             time.sleep(poll_s)
         return {"ok": False, "error": "stream_timeout", "job_id": job_id}
 
-    def speak_preferred(self, text, tone=None, engine=None, language=None):
+    def speak_preferred(self, text, tone=None, engine=None, language=None, trace_id=None):
         if bool(self.speech_stream_cfg.get("use_stream_tts", False)):
-            return self.speak_stream(text, tone=tone, engine=engine, language=language)
-        return self.speak(text, tone=tone, engine=engine, language=language)
+            return self.speak_stream(
+                text, tone=tone, engine=engine, language=language, trace_id=trace_id,
+            )
+        return self.speak(text, tone=tone, engine=engine, language=language, trace_id=trace_id)
 
     def chat(self, query, apply_actions: bool | None = None, source_lang: str | None = None, response_lang: str | None = None):
         # apply_actions=None leaves the decision to the ollama service config
@@ -447,6 +455,9 @@ class ServiceClient:
         if color is not None:
             payload["color"] = color
         return self._post("interactions", "/base", payload)
+
+    def set_expression_event(self, event_type, data=None):
+        return self._post("expression", "/event", {"type": str(event_type), "data": data or {}})
 
     def set_speech_tracking(self, enabled):
         endpoint = "/track/start" if enabled else "/track/stop"
@@ -644,6 +655,18 @@ class ServiceClient:
         except Exception as e:
             logger.debug(f"Failed to queue action {action_type}: {e}")
             return None
+
+    def world_memory_context(self, query: str, limit: int = 8):
+        return self._get("autonomy", "/memory/context", params={"q": str(query or ""), "limit": int(limit or 8)}, timeout_s=1.0)
+
+    def world_memory_recall(self, query: str, limit: int = 8):
+        return self._get("autonomy", "/memory/search", params={"q": str(query or ""), "limit": int(limit or 8)}, timeout_s=1.0)
+
+    def world_memory_observe(self, payload: dict | None = None):
+        return self._post("autonomy", "/memory/observe", json=payload or {}, timeout_s=1.0)
+
+    def execute_rest_corner(self, payload: dict | None = None):
+        return self._post("autonomy", "/navigation/rest-corner", json=payload or {}, timeout_s=1.5)
 
     def emit_agent_event(self, event_type: str, payload: dict | None = None):
         if payload is None:

--- a/modules/autonomy/services/companion_auto_execute_gate.py
+++ b/modules/autonomy/services/companion_auto_execute_gate.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional, Tuple
+
+
+class CompanionAutoExecuteGate:
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "require_auto_execute_flag": True,
+        "min_interval_s": 8.0,
+        "allowed_risks": ["none", "low", "medium", "semantic"],
+        "blocked_components": [],
+        "allowed_priorities": ["low", "normal", "critical"],
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        self.cfg = dict(self.DEFAULTS)
+        if isinstance(cfg, dict):
+            self.cfg.update(cfg)
+        self._last_decision: Dict[str, Any] = {"ok": True, "available": False, "should_execute": False, "reason": "never_checked"}
+        self._last_plan_id = ""
+        self._last_execute_ts = 0.0
+
+    def status(self) -> Dict[str, Any]:
+        return {"ok": True, **self.cfg, "last_decision": dict(self._last_decision)}
+
+    def decide(self, goal_plan: Optional[Dict[str, Any]], *, force: bool = False, now: Optional[float] = None, **_: Any) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        plan = goal_plan if isinstance(goal_plan, dict) else {}
+        base = {
+            "ok": True,
+            "available": bool(plan),
+            "should_execute": False,
+            "executed": False,
+            "force": bool(force),
+            "timestamp": ts,
+            "plan_id": str(plan.get("plan_id") or ""),
+            "behavior": str(plan.get("behavior") or ""),
+            "priority": str(plan.get("priority") or "low"),
+        }
+        if not plan:
+            return self._remember(base, "goal_plan_missing")
+        if not bool(self.cfg.get("enabled", True)):
+            return self._remember(base, "auto_execute_disabled")
+        if not bool(plan.get("safe_to_execute", True)):
+            return self._remember(base, "goal_marked_unsafe")
+        if bool(self.cfg.get("require_auto_execute_flag", True)) and not bool(plan.get("auto_execute", False)) and not force:
+            return self._remember(base, "auto_execute_false")
+        if str(plan.get("priority") or "low").lower() not in {str(x).lower() for x in self.cfg.get("allowed_priorities", [])}:
+            return self._remember(base, "priority_not_allowed")
+        allowed, reason = self._actions_allowed(plan)
+        if not allowed:
+            return self._remember(base, reason)
+        plan_id = str(plan.get("plan_id") or "")
+        interval = max(0.0, float(self.cfg.get("min_interval_s", 8.0)))
+        if not force and plan_id == self._last_plan_id and ts - self._last_execute_ts < interval:
+            base["cooldown_remaining_s"] = round(interval - (ts - self._last_execute_ts), 2)
+            return self._remember(base, "cooldown")
+        base["should_execute"] = True
+        base["reason"] = "execute"
+        self._last_plan_id = plan_id
+        self._last_execute_ts = ts
+        self._last_decision = dict(base)
+        return dict(base)
+
+    def mark_execution(self, decision: Dict[str, Any], execution: Dict[str, Any]) -> Dict[str, Any]:
+        out = dict(decision)
+        out["execution"] = execution
+        out["executed"] = bool(decision.get("should_execute") and execution.get("applied"))
+        out["applied"] = bool(execution.get("applied"))
+        out["execution_reason"] = execution.get("reason")
+        self._last_decision = dict(out)
+        return out
+
+    def _actions_allowed(self, plan: Dict[str, Any]) -> Tuple[bool, str]:
+        allowed_risks = {str(x).lower() for x in self.cfg.get("allowed_risks", [])}
+        blocked = {str(x).lower() for x in self.cfg.get("blocked_components", [])}
+        actions = plan.get("actions") or []
+        if not isinstance(actions, list):
+            return False, "actions_invalid"
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            component = str(action.get("component") or action.get("type") or "").lower()
+            risk = str(action.get("risk") or "none").lower()
+            if component in blocked:
+                return False, f"component_blocked:{component}"
+            if risk not in allowed_risks:
+                return False, f"risk_blocked:{risk}"
+        return True, "allowed"
+
+    def _remember(self, base: Dict[str, Any], reason: str) -> Dict[str, Any]:
+        out = dict(base)
+        out["reason"] = reason
+        self._last_decision = out
+        return out

--- a/modules/autonomy/services/companion_behavior_loop.py
+++ b/modules/autonomy/services/companion_behavior_loop.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+from modules.autonomy.services.pet_output_planner import build_pet_output_plan
+
+
+class CompanionBehaviorLoop:
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "interval_s": 10.0,
+        "min_idle_s": 5.0,
+        "skip_when_sleeping": False,
+        "skip_when_speech_busy": True,
+        "history_limit": 20,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        self.cfg = dict(self.DEFAULTS)
+        if isinstance(cfg, dict):
+            self.cfg.update(cfg)
+        self._last_tick_ts = 0.0
+        self._last_decision: Dict[str, Any] = {"ok": True, "available": False, "should_tick": False, "reason": "never_checked"}
+
+    def status(self) -> Dict[str, Any]:
+        return {"ok": True, **self.cfg, "last_decision": dict(self._last_decision)}
+
+    def decide(
+        self,
+        *,
+        needs: Optional[Dict[str, Any]] = None,
+        goal: Optional[Dict[str, Any]] = None,
+        now: Optional[float] = None,
+        sleeping: bool = False,
+        speech_busy: bool = False,
+        force: bool = False,
+        **_: Any,
+    ) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        needs_map = needs if isinstance(needs, dict) else {}
+        goal_map = goal if isinstance(goal, dict) else {}
+        idle_s = float(needs_map.get("idle_s") or 0.0)
+        pet = goal_map.get("pet_companion") if isinstance(goal_map.get("pet_companion"), dict) else {}
+        output_plan = build_pet_output_plan(pet)
+        base = {
+            "ok": True,
+            "available": bool(goal_map),
+            "should_tick": False,
+            "executed": False,
+            "timestamp": ts,
+            "idle_s": round(idle_s, 2),
+            "plan_id": str(goal_map.get("plan_id") or ""),
+            "dominant_need": str(goal_map.get("dominant_need") or ""),
+            "behavior": str(goal_map.get("behavior") or ""),
+            "priority": str(goal_map.get("priority") or "low"),
+            "pet_output_plan": output_plan,
+        }
+        if not bool(self.cfg.get("enabled", True)):
+            return self._remember(base, "behavior_loop_disabled")
+        if not goal_map:
+            return self._remember(base, "goal_missing")
+        if bool(self.cfg.get("skip_when_sleeping", False)) and sleeping:
+            return self._remember(base, "sleeping")
+        if bool(self.cfg.get("skip_when_speech_busy", True)) and speech_busy:
+            return self._remember(base, "speech_busy")
+        if not force and idle_s < float(self.cfg.get("min_idle_s", 5.0)):
+            return self._remember(base, "idle_too_fresh")
+        interval = max(1.0, float(self.cfg.get("interval_s", 10.0)))
+        if not force and ts - self._last_tick_ts < interval:
+            base["cooldown_remaining_s"] = round(interval - (ts - self._last_tick_ts), 2)
+            return self._remember(base, "cooldown")
+        base["should_tick"] = True
+        base["reason"] = "scheduled"
+        self._last_tick_ts = ts
+        self._last_decision = dict(base)
+        return dict(base)
+
+    def mark_execution(self, decision: Dict[str, Any], execution: Dict[str, Any]) -> Dict[str, Any]:
+        out = dict(decision)
+        out["execution"] = execution
+        out["executed"] = bool(execution.get("applied"))
+        out["applied"] = bool(execution.get("applied"))
+        out["execution_reason"] = execution.get("reason")
+        self._last_decision = dict(out)
+        return out
+
+    def _remember(self, base: Dict[str, Any], reason: str) -> Dict[str, Any]:
+        out = dict(base)
+        out["reason"] = reason
+        self._last_decision = out
+        return out

--- a/modules/autonomy/services/companion_goal_executor.py
+++ b/modules/autonomy/services/companion_goal_executor.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+from .capability_executor import CapabilityExecutor
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+class CompanionGoalExecutor:
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None, client: Any = None) -> None:
+        self.cfg = cfg if isinstance(cfg, dict) else {}
+        self.enabled = bool(self.cfg.get("enabled", True))
+        self.stop_on_failure = bool(self.cfg.get("stop_on_failure", True))
+        self.capabilities = CapabilityExecutor(client) if client is not None else None
+        self._last_execution: Dict[str, Any] = {"ok": True, "available": False, "applied": False, "reason": "never_executed"}
+
+    def status(self) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "enabled": self.enabled,
+            "stop_on_failure": self.stop_on_failure,
+            "capability_executor": self.capabilities.status() if self.capabilities is not None else {"ok": False, "reason": "client_missing"},
+            "last_execution": dict(self._last_execution),
+        }
+
+    def execute(self, goal_plan: Optional[Dict[str, Any]], **_: Any) -> Dict[str, Any]:
+        started = time.monotonic()
+        plan = _as_dict(goal_plan)
+        if not self.enabled:
+            return self._remember(False, False, "executor_disabled", plan, [], started)
+        if not plan:
+            return self._remember(False, False, "goal_plan_missing", plan, [], started)
+        if not bool(plan.get("safe_to_execute", True)):
+            return self._remember(True, False, "goal_marked_unsafe", plan, [], started)
+        if self.capabilities is None:
+            return self._remember(True, False, "capability_executor_unavailable", plan, [], started)
+
+        steps = self._steps_for(plan)
+        results: List[Dict[str, Any]] = []
+        for step in steps:
+            result = self.capabilities.execute(step["capability"], step.get("params"))
+            result["index"] = step["index"]
+            results.append(result)
+            if self.stop_on_failure and not result.get("ok"):
+                break
+
+        applied = bool(steps) and len(results) == len(steps) and all(bool(item.get("ok")) for item in results)
+        reason = "executed" if applied else "execution_failed"
+        return self._remember(True, applied, reason, plan, results, started)
+
+    def _remember(
+        self,
+        available: bool,
+        applied: bool,
+        reason: str,
+        plan: Dict[str, Any],
+        results: List[Dict[str, Any]],
+        started: float,
+    ) -> Dict[str, Any]:
+        out = {
+            "ok": bool(applied or not available),
+            "available": bool(available),
+            "applied": bool(applied),
+            "reason": reason,
+            "plan_id": str(plan.get("plan_id") or ""),
+            "behavior": str(plan.get("behavior") or ""),
+            "dominant_need": str(plan.get("dominant_need") or ""),
+            "recommended_goal": str(plan.get("recommended_goal") or ""),
+            "priority": str(plan.get("priority") or "low"),
+            "result_count": len(results),
+            "results": results,
+            "latency_ms": round((time.monotonic() - started) * 1000.0, 2),
+            "timestamp": time.time(),
+        }
+        self._last_execution = dict(out)
+        return out
+
+    def _steps_for(self, plan: Dict[str, Any]) -> List[Dict[str, Any]]:
+        steps: List[Dict[str, Any]] = []
+        for index, action in enumerate(plan.get("actions") or [], start=1):
+            if not isinstance(action, dict):
+                continue
+            capability, params = self._translate(action)
+            steps.append({"index": index, "capability": capability, "params": params})
+        return steps
+
+    @staticmethod
+    def _translate(action: Dict[str, Any]) -> tuple[str, Dict[str, Any]]:
+        action_type = str(action.get("type") or "").strip().lower()
+        if action_type == "expression":
+            return "expression.event", {"event": action.get("event"), "data": action.get("data") or {}}
+        if action_type == "motion":
+            name = str(action.get("name") or "idle")
+            if name == "freeze":
+                return "motion.freeze", dict(action)
+            return f"motion.{name}", dict(action)
+        if action_type == "pose":
+            return f"pose.{str(action.get('name') or 'idle')}", dict(action)
+        if action_type == "vision":
+            mode = str(action.get("mode") or "cheap")
+            return ("vision.semantic" if mode == "semantic" else "vision.cheap"), dict(action)
+        if action_type == "perception":
+            name = str(action.get('name') or 'owner_scan')
+            if name in {"track_person", "track_object"}:
+                return "perception.track_object", dict(action)
+            return f"perception.{name}", dict(action)
+        if action_type == "navigation":
+            return f"navigation.{str(action.get('name') or 'rest_corner')}", dict(action)
+        if action_type == "memory":
+            return f"memory.{str(action.get('name') or 'observe')}", dict(action)
+        if action_type == "speech":
+            mode = str(action.get("mode") or "silent")
+            return ("speech.silent" if mode == "silent" else "speech.short_prompt"), dict(action)
+        if action_type == "wait":
+            return "scheduler.wait", dict(action)
+        if action_type == "pet_intent":
+            return "semantic.pet_intent", dict(action)
+        return "semantic.unknown", dict(action)
+
+
+__all__ = ["CompanionGoalExecutor"]

--- a/modules/autonomy/services/companion_goal_selector.py
+++ b/modules/autonomy/services/companion_goal_selector.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+from modules.autonomy.services.pet_companion_core import PetCompanionCore
+
+PET_COMPANION_GOAL_SELECTOR_INTEGRATION_CONTRACT = True
+PET_COMPANION_GOAL_SELECTOR_INTEGRATION_ROLE = "pet_core_side_channel_for_goal_selector"
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+class CompanionGoalSelector:
+    """Turn companion needs into a semantic goal plan.
+
+    This class does not drive hardware. It produces a safe, inspectable plan
+    that can later be executed by capability/safety layers. This keeps the
+    companion behavior semantic: needs -> goal -> expression/capability plan.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "event_cooldown_s": 12.0,
+        "auto_execute": True,
+        "pet_companion_enabled": True,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg: Dict[str, Any] = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self.enabled = bool(self.cfg.get("enabled", True))
+        self._last_event_ts: float = 0.0
+        self._last_plan_key: str = ""
+
+    def select(
+        self,
+        needs_snapshot: Optional[Dict[str, Any]],
+        *,
+        owner_present: bool = False,
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        snap = _as_dict(needs_snapshot)
+        dominant = str(snap.get("dominant_need") or "balance").strip().lower()
+        recommended = str(snap.get("recommended_goal") or "calm_idle").strip().lower()
+        confidence = max(0.0, min(1.0, _as_float(snap.get("confidence"), 0.55)))
+        scores = _as_dict(snap.get("scores"))
+
+        plan = self._plan_for(dominant, recommended, scores=scores, owner_present=owner_present)
+        pet_companion = self._pet_companion_decision(
+            snap,
+            dominant=dominant,
+            recommended=recommended,
+            scores=scores,
+            owner_present=owner_present,
+        )
+        plan = self._merge_pet_companion_plan(plan, pet_companion)
+        plan_key = f"{dominant}:{recommended}:{plan.get('behavior')}"
+        event = self._event_for(plan_key, dominant, ts)
+
+        auto_execute = bool(self.cfg.get("auto_execute", True))
+
+        out: Dict[str, Any] = {
+            "ok": True,
+            "available": bool(self.enabled),
+            "timestamp": ts,
+            "plan_id": plan_key,
+            "dominant_need": dominant,
+            "recommended_goal": recommended,
+            "behavior": plan.get("behavior", "calm_idle"),
+            "pet_companion": pet_companion,
+            "pet_intent": str(pet_companion.get("intent") or ""),
+            "pet_expression_hint": str(pet_companion.get("expression_hint") or ""),
+            "pet_motion_hint": str(pet_companion.get("motion_hint") or ""),
+            "pet_speech_hint": str(pet_companion.get("speech_hint") or ""),
+            "pet_goal_hints": list(pet_companion.get("goal_hints") or []),
+            "pet_needs_bias": dict(pet_companion.get("needs_bias") or {}),
+            "pet_memory_tags": list(pet_companion.get("memory_tags") or []),
+            "priority": plan.get("priority", "low"),
+            "confidence": round(confidence, 2),
+            "reason": f"needs.{dominant}",
+            "event": event,
+            "expression_event": plan.get("expression_event", f"needs.{dominant}"),
+            "expression_data": {
+                "recommended_goal": recommended,
+                "confidence": round(confidence, 2),
+                "dominant_need": dominant,
+            },
+            "actions": plan.get("actions", []),
+            "safe_to_execute": bool(plan.get("safe_to_execute", True)),
+            "auto_execute": auto_execute,
+            "owner_present": bool(owner_present),
+            "scores": {k: round(_as_float(v), 1) for k, v in scores.items()},
+        }
+        return out
+
+
+    def _pet_companion_decision(
+        self,
+        snap: Dict[str, Any],
+        *,
+        dominant: str,
+        recommended: str,
+        scores: Dict[str, Any],
+        owner_present: bool,
+    ) -> Dict[str, Any]:
+        if not bool(self.cfg.get("pet_companion_enabled", True)):
+            return {}
+        score_map = _as_dict(scores)
+        pet_needs = {
+            "safety": _as_float(score_map.get("safety"), 0.0),
+            "social": _as_float(score_map.get("social"), 0.0),
+            "curiosity": _as_float(score_map.get("curiosity"), 0.0),
+            "boredom": _as_float(score_map.get("boredom"), 0.0),
+            "energy": _as_float(score_map.get("energy"), _as_float(snap.get("energy"), 0.7)),
+            "dominant_need": dominant,
+            "recommended_goal": recommended,
+        }
+        if dominant == "exploration":
+            pet_needs["curiosity"] = max(pet_needs["curiosity"], 0.65)
+        elif dominant == "rest":
+            pet_needs["energy"] = min(pet_needs["energy"], 0.2)
+        elif dominant == "social":
+            pet_needs["social"] = max(pet_needs["social"], 0.65)
+        elif dominant == "safety":
+            pet_needs["safety"] = max(pet_needs["safety"], 0.75)
+        elif dominant == "boredom":
+            pet_needs["boredom"] = max(pet_needs["boredom"], 0.7)
+        elif dominant == "curiosity":
+            pet_needs["curiosity"] = max(pet_needs["curiosity"], 0.7)
+
+        context = {
+            "needs": pet_needs,
+            "bond": _as_dict(snap.get("bond")),
+            "routine": _as_dict(snap.get("routine")),
+            "perception": {
+                **_as_dict(snap.get("perception")),
+                "owner_present": bool(owner_present),
+            },
+        }
+        return PetCompanionCore().decide(context).as_dict()
+
+    def _merge_pet_companion_plan(self, plan: Dict[str, Any], pet_companion: Dict[str, Any]) -> Dict[str, Any]:
+        if not pet_companion:
+            return plan
+        out = dict(plan)
+        actions = list(out.get("actions") or [])
+        actions.append(
+            {
+                "type": "pet_intent",
+                "name": str(pet_companion.get("intent") or ""),
+                "expression_hint": str(pet_companion.get("expression_hint") or ""),
+                "motion_hint": str(pet_companion.get("motion_hint") or ""),
+                "speech_hint": str(pet_companion.get("speech_hint") or ""),
+                "goal_hints": list(pet_companion.get("goal_hints") or []),
+                "risk": "semantic",
+            }
+        )
+        out["actions"] = actions
+        out["pet_companion"] = pet_companion
+        return out
+
+    def _plan_for(self, dominant: str, recommended: str, *, scores: Dict[str, Any], owner_present: bool) -> Dict[str, Any]:
+        if dominant == "safety":
+            return {
+                "behavior": "pause_and_observe",
+                "priority": "critical",
+                "expression_event": "needs.safety",
+                "safe_to_execute": True,
+                "actions": [
+                    {"type": "expression", "event": "needs.safety"},
+                    {"type": "motion", "name": "freeze", "risk": "low"},
+                    {"type": "vision", "mode": "cheap", "reason": "safety"},
+                ],
+            }
+        if recommended == "rest_in_safe_place" or dominant == "rest":
+            return {
+                "behavior": "rest_in_safe_place",
+                "priority": "low",
+                "expression_event": "needs.rest",
+                "safe_to_execute": True,
+                "actions": [
+                    {"type": "expression", "event": "needs.rest"},
+                    {"type": "navigation", "name": "rest_corner", "risk": "low"},
+                    {"type": "pose", "name": "sleepy_idle", "risk": "low"},
+                    {"type": "speech", "mode": "silent"},
+                ],
+            }
+        if dominant == "social":
+            return {
+                "behavior": "seek_owner_or_invite_interaction" if not owner_present else "engage_owner",
+                "priority": "normal",
+                "expression_event": "needs.social",
+                "safe_to_execute": True,
+                "actions": [
+                    {"type": "expression", "event": "needs.social"},
+                    {"type": "perception", "name": "owner_scan", "risk": "low"},
+                    {"type": "speech", "mode": "short_prompt", "template": "social_invite"},
+                ],
+            }
+        if dominant == "exploration":
+            return {
+                "behavior": "look_around_and_learn",
+                "priority": "normal",
+                "expression_event": "needs.exploration",
+                "safe_to_execute": True,
+                "actions": [
+                    {"type": "expression", "event": "needs.exploration"},
+                    {"type": "vision", "mode": "cheap", "reason": "exploration"},
+                    {"type": "motion", "name": "look_around", "risk": "low"},
+                ],
+            }
+        if recommended == "look_for_company_or_rest" or dominant == "boredom":
+            return {
+                "behavior": "scan_for_company_then_rest",
+                "priority": "normal",
+                "expression_event": "needs.boredom",
+                "safe_to_execute": True,
+                "actions": [
+                    {"type": "expression", "event": "needs.boredom"},
+                    {"type": "motion", "name": "stretch_or_scan", "risk": "low"},
+                    {"type": "vision", "mode": "cheap", "reason": "boredom"},
+                    {"type": "perception", "name": "track_person", "label": "person", "strategy": "center", "risk": "low"},
+                    {"type": "memory", "name": "observe", "kind": "episode", "summary": "Robot was bored and scanned for company.", "risk": "none"},
+                ],
+            }
+        if recommended == "inspect_sound_source":
+            return {
+                "behavior": "inspect_sound_source",
+                "priority": "high",
+                "expression_event": "needs.sound_attention",
+                "safe_to_execute": True,
+                "actions": [
+                    {"type": "expression", "event": "needs.sound_attention"},
+                    {"type": "motion", "name": "attend", "risk": "low"},
+                    {"type": "perception", "name": "track_person", "label": "person", "strategy": "center", "risk": "low"},
+                    {"type": "vision", "mode": "cheap", "reason": "sound_interrupt"},
+                ],
+            }
+        if dominant == "curiosity":
+            return {
+                "behavior": "inspect_environment_and_learn",
+                "priority": "normal",
+                "expression_event": "needs.curiosity",
+                "safe_to_execute": True,
+                "actions": [
+                    {"type": "expression", "event": "needs.curiosity"},
+                    {"type": "vision", "mode": "cheap", "reason": "curiosity"},
+                    {"type": "vision", "mode": "semantic", "reason": "curiosity_unknown"},
+                    {"type": "motion", "name": "attend", "risk": "low"},
+                ],
+            }
+        return {
+            "behavior": "calm_idle",
+            "priority": "low",
+            "expression_event": "needs.balance",
+            "safe_to_execute": True,
+            "actions": [
+                {"type": "expression", "event": "needs.balance"},
+                {"type": "wait", "label": "calm_idle", "risk": "none"},
+            ],
+        }
+
+    def _event_for(self, plan_key: str, dominant: str, now_ts: float) -> str:
+        if not self.enabled:
+            return ""
+        cooldown = max(1.0, _as_float(self.cfg.get("event_cooldown_s"), 12.0))
+        if plan_key == self._last_plan_key and (now_ts - self._last_event_ts) < cooldown:
+            return ""
+        self._last_plan_key = plan_key
+        self._last_event_ts = now_ts
+        return f"goal.{dominant}"

--- a/modules/autonomy/services/companion_lines.py
+++ b/modules/autonomy/services/companion_lines.py
@@ -39,6 +39,13 @@ class CompanionLineGenerator:
         lang = str(ctx.get("language") or self.default_language)
         try:
             resp = self.client.chat(prompt, response_lang=lang)
+            if isinstance(resp, dict) and resp.get("ok") is False:
+                self._last_llm_ts = time.time()
+                logger.info(
+                    "companion LLM unavailable; using template fallback: %s",
+                    resp.get("error") or resp.get("reason") or "unavailable",
+                )
+                return None
             text = ""
             if isinstance(resp, dict):
                 text = str(resp.get("answer") or resp.get("text") or "").strip()
@@ -50,6 +57,7 @@ class CompanionLineGenerator:
             self._last_llm_ts = time.time()
             return text
         except Exception as exc:
+            self._last_llm_ts = time.time()
             logger.debug("companion LLM line failed: %s", exc)
             return None
 

--- a/modules/autonomy/services/expression_director.py
+++ b/modules/autonomy/services/expression_director.py
@@ -1,14 +1,3 @@
-"""Multi-modal expression director.
-
-Fires a single, coherent emotional expression across every output modality at
-once — eyes (OLED), LEDs (NeoPixel), ears (PiServo, via interaction event),
-optional head pose and optional speech with a matching TTS tone.
-
-All modalities are resolved from the shared canonical emotion vocabulary so they
-stay in sync. Every call is best-effort: a failing modality never blocks the
-others, keeping the robot alive even if one subsystem is down.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -16,36 +5,12 @@ from typing import Any, Optional, Tuple
 
 logger = logging.getLogger("autonomy.expression")
 
-try:
-    from modules.common.emotion_vocab import emotion_render as _emotion_render
-except Exception:  # pragma: no cover - optional dependency
-    _emotion_render = None
-
-
-def _safe(label: str, fn) -> bool:
-    try:
-        fn()
-        return True
-    except Exception:
-        logger.debug("expression modality failed: %s", label, exc_info=True)
-        return False
-
 
 class ExpressionDirector:
-    """Coordinates eyes + LEDs + ears + head + voice for one emotion."""
+    """Publishes semantic expression intent to the single expression owner."""
 
     def __init__(self, client: Any) -> None:
         self.client = client
-
-    def _render_leds(self, canon: str, effect: str, color: list[int]) -> bool:
-        """Prefer palette emote; fall back to effect+RGB animate."""
-        if hasattr(self.client, "emote_neopixel"):
-            if _safe("emote", lambda: self.client.emote_neopixel([canon], duration=0.25)):
-                return True
-        return _safe(
-            "leds",
-            lambda: self.client.set_neopixel(effect, emotions=[canon], color=color),
-        )
 
     def express(
         self,
@@ -55,36 +20,24 @@ class ExpressionDirector:
         language: Optional[str] = None,
         move_head: Optional[Tuple[int, int]] = None,
     ) -> str:
-        """Render ``emotion`` across all modalities; returns the canonical label."""
-        if _emotion_render is not None:
-            render = _emotion_render(emotion)
-            canon = render.canonical
-            effect = render.effect
-            oled = render.oled
-            color = list(render.rgb)
-            tone = render.tone
-        else:  # minimal fallback when shared vocab is unavailable
-            canon = str(emotion or "neutral").strip().lower()
-            effect, oled, color, tone = "BREATHE", "normal", [120, 120, 140], "neutral"
-
-        modalities = []
-        if self._render_leds(canon, effect, color):
-            modalities.append("leds")
-        if _safe("eyes", lambda: self.client.oled_show(oled)):
-            modalities.append("eyes")
-        # interaction event drives ears (piservo bridge); LEDs handled above
-        if _safe("ears", lambda: self.client.push_interaction_event(f"emotion:{canon}")):
-            modalities.append("ears")
+        canonical = str(emotion or "neutral").strip().lower()
+        data = {
+            "emotion": canonical,
+            "attention": "user" if say else "internal",
+            "speaking": bool(say),
+        }
         if move_head is not None:
-            pan, tilt = move_head
-            if _safe("head", lambda: self.client.move_head(int(pan), int(tilt))):
-                modalities.append("head")
+            data["head_hint"] = {"pan": int(move_head[0]), "tilt": int(move_head[1])}
+        try:
+            self.client.set_expression_event(f"emotion:{canonical}", data)
+        except Exception:
+            logger.debug("semantic expression publish failed", exc_info=True)
         if say:
-            if _safe("voice", lambda: self.client.speak(say, tone=tone, language=language)):
-                modalities.append("voice")
-
-        logger.debug("expressed %s via %s", canon, modalities)
-        return canon
+            try:
+                self.client.speak_preferred(say, tone=canonical, language=language)
+            except Exception:
+                logger.debug("expression speech failed", exc_info=True)
+        return canonical
 
 
 __all__ = ["ExpressionDirector"]

--- a/modules/autonomy/services/living_needs.py
+++ b/modules/autonomy/services/living_needs.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp01(value: Any, default: float = 0.0) -> float:
+    return max(0.0, min(1.0, _as_float(value, default)))
+
+
+class LivingNeedsEngine:
+    """Utility-style pet needs model.
+
+    Values are normalized 0..1 and intentionally semantic. Low-level servo,
+    motor and LED details stay inside deterministic capability/safety layers.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "idle_boredom_s": 90.0,
+        "alone_social_s": 180.0,
+        "curiosity_decay_s": 150.0,
+        "rest_energy_threshold": 0.28,
+        "sound_attention_hold_s": 18.0,
+        "person_attention_hold_s": 45.0,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self._last: Dict[str, Any] = {"ok": True, "available": False, "reason": "never_ticked"}
+
+    def tick(
+        self,
+        *,
+        now: Optional[float] = None,
+        state: Optional[Dict[str, Any]] = None,
+        mood: Any = None,
+        vision: Optional[Dict[str, Any]] = None,
+        audio: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        st = state if isinstance(state, dict) else {}
+        vision_map = vision if isinstance(vision, dict) else {}
+        audio_map = audio if isinstance(audio, dict) else {}
+
+        last_interaction = _as_float(st.get("last_interaction"), ts)
+        idle_s = max(0.0, ts - last_interaction)
+        owner_last_seen = _as_float(st.get("owner_last_seen"), 0.0)
+        owner_absent_s = max(0.0, ts - owner_last_seen) if owner_last_seen > 0 else idle_s
+        owner_present = bool(owner_last_seen > 0 and owner_absent_s <= float(self.cfg.get("person_attention_hold_s", 45.0)))
+
+        energy_raw = 100.0
+        try:
+            if hasattr(mood, "get"):
+                energy_raw = _as_float(mood.get("energy", 100.0), 100.0)
+            elif isinstance(mood, dict):
+                energy_raw = _as_float(mood.get("energy"), 100.0)
+        except Exception:
+            energy_raw = 100.0
+        energy = max(0.0, min(1.0, energy_raw / 100.0 if energy_raw > 1.0 else energy_raw))
+
+        people_count = self._count_people(vision_map)
+        objects_count = self._count_objects(vision_map)
+        hazards_count = self._count_hazards(vision_map)
+        last_sound_ts = _as_float(audio_map.get("timestamp") or audio_map.get("last_sound_ts"), 0.0)
+        sound_recent = last_sound_ts > 0 and (ts - last_sound_ts) <= float(self.cfg.get("sound_attention_hold_s", 18.0))
+        speech_busy = bool(st.get("speech_busy") or audio_map.get("speech_busy"))
+
+        boredom = _clamp01(idle_s / max(1.0, float(self.cfg.get("idle_boredom_s", 90.0))))
+        social = _clamp01(owner_absent_s / max(1.0, float(self.cfg.get("alone_social_s", 180.0))))
+        if owner_present or people_count > 0:
+            social *= 0.25
+            boredom *= 0.55
+        curiosity = 0.25 + min(0.55, objects_count * 0.09)
+        if sound_recent:
+            curiosity = max(curiosity, 0.72)
+        if people_count == 0 and idle_s > 30:
+            curiosity = max(curiosity, min(0.85, idle_s / max(1.0, float(self.cfg.get("curiosity_decay_s", 150.0)))))
+        rest = _clamp01((float(self.cfg.get("rest_energy_threshold", 0.28)) - energy) / 0.28)
+        safety = _clamp01(hazards_count / 2.0)
+        attachment = 1.0 - min(1.0, owner_absent_s / 900.0) if owner_last_seen > 0 else 0.35
+
+        scores = {
+            "social": round(social, 3),
+            "curiosity": round(_clamp01(curiosity), 3),
+            "boredom": round(boredom, 3),
+            "rest": round(rest, 3),
+            "safety": round(safety, 3),
+            "attachment": round(_clamp01(attachment), 3),
+            "energy": round(energy, 3),
+        }
+        dominant = max((k for k in scores if k != "energy"), key=lambda key: scores[key])
+        recommended = self._goal_for(dominant, people_count=people_count, sound_recent=sound_recent)
+        out = {
+            "ok": True,
+            "available": bool(self.cfg.get("enabled", True)),
+            "timestamp": ts,
+            "idle_s": round(idle_s, 2),
+            "owner_absent_s": round(owner_absent_s, 2),
+            "owner_present": bool(owner_present),
+            "people_count": int(people_count),
+            "objects_count": int(objects_count),
+            "hazards_count": int(hazards_count),
+            "sound_recent": bool(sound_recent),
+            "speech_busy": bool(speech_busy),
+            "scores": scores,
+            "dominant_need": dominant,
+            "recommended_goal": recommended,
+            "confidence": round(max(v for k, v in scores.items() if k != "energy"), 3),
+            "semantic_state": {
+                "emotion": self._emotion_for(dominant),
+                "attention": "sound" if sound_recent else ("person" if people_count else "environment"),
+                "energy": scores["energy"],
+                "arousal": max(scores["curiosity"], scores["safety"], 0.2),
+            },
+        }
+        self._last = dict(out)
+        return out
+
+    def status(self) -> Dict[str, Any]:
+        return {"ok": True, "enabled": bool(self.cfg.get("enabled", True)), "config": dict(self.cfg), "last": dict(self._last)}
+
+    @staticmethod
+    def _count_people(vision: Dict[str, Any]) -> int:
+        tracks = vision.get("tracks") if isinstance(vision.get("tracks"), list) else []
+        people = [x for x in tracks if isinstance(x, dict) and str(x.get("label") or "").lower() == "person"]
+        if people:
+            return len(people)
+        people_ctx = vision.get("people") if isinstance(vision.get("people"), list) else []
+        return len(people_ctx)
+
+    @staticmethod
+    def _count_objects(vision: Dict[str, Any]) -> int:
+        tracks = vision.get("tracks") if isinstance(vision.get("tracks"), list) else []
+        if tracks:
+            return len([x for x in tracks if isinstance(x, dict) and str(x.get("label") or "").lower() != "person"])
+        objects = vision.get("objects") if isinstance(vision.get("objects"), list) else []
+        return len(objects)
+
+    @staticmethod
+    def _count_hazards(vision: Dict[str, Any]) -> int:
+        hazards = vision.get("hazards") if isinstance(vision.get("hazards"), list) else []
+        return len(hazards)
+
+    @staticmethod
+    def _goal_for(dominant: str, *, people_count: int, sound_recent: bool) -> str:
+        if dominant == "safety":
+            return "pause_and_observe"
+        if dominant == "rest":
+            return "rest_in_safe_place"
+        if sound_recent:
+            return "inspect_sound_source"
+        if dominant == "boredom" and people_count == 0:
+            return "look_for_company_or_rest"
+        if dominant == "curiosity":
+            return "inspect_environment"
+        if dominant == "social":
+            return "seek_owner_or_person"
+        return "calm_idle"
+
+    @staticmethod
+    def _emotion_for(dominant: str) -> str:
+        return {
+            "safety": "worried",
+            "rest": "tired",
+            "boredom": "bored",
+            "curiosity": "curiosity",
+            "social": "curiosity",
+            "attachment": "calm",
+        }.get(str(dominant), "neutral")
+
+
+__all__ = ["LivingNeedsEngine"]

--- a/modules/autonomy/services/memory_decision_shadow.py
+++ b/modules/autonomy/services/memory_decision_shadow.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _clean(value: Any, default: str = "") -> str:
+    text = str(value if value is not None else default).strip()
+    return " ".join(text.split())
+
+
+def _lower_tokens(*values: Any) -> str:
+    parts: List[str] = []
+    for value in values:
+        if isinstance(value, (list, tuple, set)):
+            parts.extend(str(x) for x in value)
+        elif isinstance(value, dict):
+            parts.extend(str(k) for k in value.keys())
+            parts.extend(str(v) for v in value.values())
+        elif value is not None:
+            parts.append(str(value))
+    return " ".join(parts).lower()
+
+
+def _num(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class MemoryDecisionShadow:
+    """Read-only memory influence evaluator.
+
+    Recency guard is intentionally here, before needs bias. A remembered hazard,
+    object, or sound can suggest behavior only while it is fresh enough. This
+    prevents persistent world_memory.json entries from locking the robot into a
+    stale safety/exploration state after restarts.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "mode": "shadow",
+        "max_items": 25,
+        "fresh_window_s": 180.0,
+        "max_age_s": 240.0,
+        "safety_max_age_s": 45.0,
+        "social_max_age_s": 180.0,
+        "exploration_max_age_s": 240.0,
+        "curiosity_max_age_s": 180.0,
+        "balance_max_age_s": 600.0,
+        "unknown_age_score": 0.35,
+        "apply_to_needs": False,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg: Dict[str, Any] = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+
+    def enabled(self) -> bool:
+        return bool(self.cfg.get("enabled", True))
+
+    def evaluate(self, memory_snapshot: Optional[Dict[str, Any]] = None, recent: Optional[List[Dict[str, Any]]] = None, now: Optional[float] = None) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        if not self.enabled():
+            return {"ok": True, "enabled": False, "mode": "shadow", "available": False, "reason": "disabled", "apply_to_needs": False, "timestamp": ts, "influences": [], "stale_count": 0}
+        snapshot = _as_dict(memory_snapshot)
+        if recent is None:
+            recent = _as_list(snapshot.get("recent"))
+        items = [x for x in recent if isinstance(x, dict)]
+        max_items = int(_num(self.cfg.get("max_items"), 25))
+        if max_items > 0:
+            items = items[:max_items]
+        influences: List[Dict[str, Any]] = []
+        stale: List[Dict[str, Any]] = []
+        for item in items:
+            influence, stale_marker = self._influence_or_stale_for_item(item, ts)
+            if influence:
+                influences.append(influence)
+            elif stale_marker:
+                stale.append(stale_marker)
+        influences.sort(key=lambda x: (_num(x.get("score")), _num(x.get("confidence"))), reverse=True)
+        top = influences[0] if influences else {}
+        return {
+            "ok": True,
+            "enabled": True,
+            "mode": str(self.cfg.get("mode") or "shadow"),
+            "apply_to_needs": bool(self.cfg.get("apply_to_needs", False)),
+            "available": bool(influences),
+            "reason": "memory_shadow_hint" if influences else ("memory_hints_stale" if stale else "no_memory_hint"),
+            "timestamp": ts,
+            "total_memory": int(_num(snapshot.get("total"), len(items))),
+            "considered": len(items),
+            "stale_count": len(stale),
+            "stale": stale[:10],
+            "influences": influences[:10],
+            "recommended_need": top.get("need", ""),
+            "recommended_goal": top.get("goal", ""),
+            "behavior": top.get("behavior", ""),
+            "priority": top.get("priority", ""),
+            "confidence": top.get("confidence", 0.0),
+            "top_source": top.get("source", ""),
+            "top_item": top.get("item", {}),
+        }
+
+    def _item_age(self, item: Dict[str, Any], now: float) -> float:
+        last_seen = _num(item.get("last_seen_ts"), 0.0)
+        if last_seen <= 0.0:
+            return -1.0
+        return max(0.0, now - last_seen)
+
+    def _age_score(self, item: Dict[str, Any], now: float) -> float:
+        last_seen = _num(item.get("last_seen_ts"), 0.0)
+        if last_seen <= 0.0:
+            return max(0.0, min(1.0, _num(self.cfg.get("unknown_age_score"), 0.35)))
+        age = max(0.0, now - last_seen)
+        window = max(1.0, _num(self.cfg.get("fresh_window_s"), 180.0))
+        return max(0.0, 1.0 - min(age / window, 1.0))
+
+    def _age_limit_for_need(self, need: str) -> float:
+        if need == "safety":
+            return max(1.0, _num(self.cfg.get("safety_max_age_s"), 45.0))
+        if need == "social":
+            return max(1.0, _num(self.cfg.get("social_max_age_s"), 180.0))
+        if need == "exploration":
+            return max(1.0, _num(self.cfg.get("exploration_max_age_s"), 240.0))
+        if need == "curiosity":
+            return max(1.0, _num(self.cfg.get("curiosity_max_age_s"), 180.0))
+        if need == "balance":
+            return max(1.0, _num(self.cfg.get("balance_max_age_s"), 600.0))
+        return max(1.0, _num(self.cfg.get("max_age_s"), 240.0))
+
+    def _stale_marker(self, item: Dict[str, Any], need: str, age_s: float, limit_s: float, reason: str) -> Dict[str, Any]:
+        return {
+            "need": need,
+            "reason": reason,
+            "age_s": round(age_s, 1),
+            "max_age_s": round(limit_s, 1),
+            "source": _clean(item.get("source"), "memory"),
+            "item": {"id": item.get("id"), "kind": item.get("kind"), "name": item.get("name"), "summary": item.get("summary")},
+        }
+
+    def _mk(self, item: Dict[str, Any], need: str, goal: str, behavior: str, priority: str, base: float, reason: str, now: float) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        age_s = self._item_age(item, now)
+        limit_s = self._age_limit_for_need(need)
+        if age_s >= 0.0 and age_s > limit_s:
+            return {}, self._stale_marker(item, need, age_s, limit_s, f"{reason}.stale")
+        conf = max(0.0, min(1.0, _num(item.get("confidence"), 0.6)))
+        salience = max(0.0, min(1.0, _num(item.get("salience"), conf)))
+        age_score = self._age_score(item, now)
+        score = max(0.0, min(1.0, base * 0.45 + conf * 0.25 + salience * 0.20 + age_score * 0.10))
+        return {
+            "need": need,
+            "goal": goal,
+            "behavior": behavior,
+            "priority": priority,
+            "score": round(score, 4),
+            "confidence": round(max(conf, score), 4),
+            "reason": reason,
+            "age_s": round(age_s, 1) if age_s >= 0.0 else None,
+            "max_age_s": round(limit_s, 1),
+            "source": _clean(item.get("source"), "memory"),
+            "item": {"id": item.get("id"), "kind": item.get("kind"), "name": item.get("name"), "summary": item.get("summary")},
+        }, {}
+
+    def _influence_or_stale_for_item(self, item: Dict[str, Any], now: float) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        kind = _clean(item.get("kind")).lower()
+        name = _clean(item.get("name"))
+        summary = _clean(item.get("summary"))
+        tokens = _lower_tokens(kind, name, summary, item.get("tags"), item.get("properties"), item.get("source"))
+        if any(t in tokens for t in ["hazard", "loud", "obstacle", "safety", "danger"]):
+            return self._mk(item, "safety", "pause_and_observe", "pause_and_observe", "critical", 0.96, "memory.safety", now)
+        if any(t in tokens for t in ["wakeword", "speech", "owner", "person", "heard", "seen"]):
+            return self._mk(item, "social", "seek_owner_or_invite_interaction", "engage_owner", "normal", 0.82, "memory.social", now)
+        if kind == "objects" or any(t in tokens for t in ["novel", "unknown object", "new object"]):
+            return self._mk(item, "exploration", "look_around_and_learn", "look_around_and_learn", "normal", 0.78, "memory.exploration", now)
+        if any(t in tokens for t in ["sound", "noise", "curiosity"]):
+            return self._mk(item, "curiosity", "inspect_environment", "inspect_environment", "normal", 0.74, "memory.curiosity", now)
+        if any(t in tokens for t in ["quiet", "stable", "silence", "calm"]):
+            return self._mk(item, "balance", "calm_idle", "calm_idle", "low", 0.58, "memory.balance", now)
+        return {}, {}
+
+    # Compatibility for tests/tools that used the old private helper name.
+    def _influence_for_item(self, item: Dict[str, Any], now: float) -> Dict[str, Any]:
+        influence, _stale = self._influence_or_stale_for_item(item, now)
+        return influence

--- a/modules/autonomy/services/memory_needs_bias.py
+++ b/modules/autonomy/services/memory_needs_bias.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional, Tuple
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _num(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clean(value: Any, default: str = "") -> str:
+    text = str(value if value is not None else default).strip()
+    return " ".join(text.split())
+
+
+def _clamp(value: Any, lo: float = 0.0, hi: float = 100.0) -> float:
+    return max(lo, min(hi, _num(value, lo)))
+
+
+GOAL_BY_NEED: Dict[str, Tuple[str, str, str]] = {
+    "social": ("seek_owner_or_invite_interaction", "engage_owner", "normal"),
+    "exploration": ("look_around_and_learn", "look_around_and_learn", "normal"),
+    "curiosity": ("inspect_environment", "inspect_environment", "normal"),
+    "boredom": ("choose_idle_activity", "choose_idle_activity", "normal"),
+    "rest": ("rest_quietly", "rest_quietly", "low"),
+    "safety": ("pause_and_observe", "pause_and_observe", "critical"),
+    "balance": ("calm_idle", "calm_idle", "low"),
+}
+
+
+class MemoryNeedsBias:
+    """Applies memory hints to needs snapshots in a guarded way.
+
+    This is not an executor. It only annotates and gently adjusts semantic need
+    scores. Hardware execution remains behind the existing goal/auto/behavior
+    gates and PC dry-run profile.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "mode": "bias",
+        "apply_to_needs": True,
+        "min_confidence": 0.58,
+        "max_boost": 18.0,
+        "safety_override": True,
+        "safety_score_cap": 45.0,
+        "allow_critical": True,
+        "annotate_only_for_balance": True,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg: Dict[str, Any] = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self._last: Dict[str, Any] = {
+            "ok": True,
+            "enabled": bool(self.cfg.get("enabled", True)),
+            "mode": str(self.cfg.get("mode") or "bias"),
+            "available": False,
+            "applied": False,
+            "reason": "never_evaluated",
+            "timestamp": 0.0,
+        }
+
+    def snapshot(self) -> Dict[str, Any]:
+        out = dict(self._last)
+        out["enabled"] = bool(self.cfg.get("enabled", True))
+        out["apply_to_needs"] = bool(self.cfg.get("apply_to_needs", True))
+        out["min_confidence"] = float(self.cfg.get("min_confidence", 0.58) or 0.58)
+        out["max_boost"] = float(self.cfg.get("max_boost", 18.0) or 18.0)
+        return out
+
+    def apply(self, needs_snapshot: Optional[Dict[str, Any]], memory_shadow: Optional[Dict[str, Any]], now: Optional[float] = None) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        needs = dict(_as_dict(needs_snapshot))
+        shadow = _as_dict(memory_shadow)
+        base_reason = {
+            "ok": True,
+            "enabled": bool(self.cfg.get("enabled", True)),
+            "mode": str(self.cfg.get("mode") or "bias"),
+            "apply_to_needs": bool(self.cfg.get("apply_to_needs", True)),
+            "timestamp": ts,
+            "available": False,
+            "applied": False,
+        }
+        if not needs:
+            self._last = dict(base_reason, reason="missing_needs")
+            return {"ok": False, "available": False, "reason": "missing_needs"}
+        if not bool(self.cfg.get("enabled", True)):
+            marker = dict(base_reason, reason="disabled")
+            self._attach(needs, marker)
+            self._last = marker
+            return needs
+        if not bool(self.cfg.get("apply_to_needs", True)):
+            marker = dict(base_reason, reason="apply_disabled")
+            self._attach(needs, marker)
+            self._last = marker
+            return needs
+        if not shadow or not shadow.get("available"):
+            marker = dict(base_reason, reason="no_memory_hint")
+            self._attach(needs, marker)
+            self._last = marker
+            return needs
+        rec_need = _clean(shadow.get("recommended_need")).lower()
+        rec_goal = _clean(shadow.get("recommended_goal"))
+        rec_priority = _clean(shadow.get("priority"), "normal").lower()
+        confidence = max(0.0, min(1.0, _num(shadow.get("confidence"), 0.0)))
+        min_conf = float(self.cfg.get("min_confidence", 0.58) or 0.58)
+        if rec_need not in GOAL_BY_NEED:
+            marker = dict(base_reason, reason="unsupported_memory_need", available=True, memory_need=rec_need, confidence=confidence)
+            self._attach(needs, marker)
+            self._last = marker
+            return needs
+        if confidence < min_conf:
+            marker = dict(base_reason, reason="memory_confidence_low", available=True, memory_need=rec_need, confidence=round(confidence, 4))
+            self._attach(needs, marker)
+            self._last = marker
+            return needs
+        if rec_priority == "critical" and not bool(self.cfg.get("allow_critical", True)):
+            marker = dict(base_reason, reason="critical_bias_disabled", available=True, memory_need=rec_need, confidence=round(confidence, 4))
+            self._attach(needs, marker)
+            self._last = marker
+            return needs
+
+        previous_need = _clean(needs.get("dominant_need"))
+        previous_goal = _clean(needs.get("recommended_goal"))
+        scores = dict(_as_dict(needs.get("scores")))
+        before_scores = {k: _num(v) for k, v in scores.items()}
+        max_boost = max(0.0, float(self.cfg.get("max_boost", 18.0) or 18.0))
+        boost = round(max_boost * confidence, 2)
+        applied = False
+        reason = "memory_bias_applied"
+
+        if rec_need == "safety":
+            if bool(self.cfg.get("safety_override", True)):
+                cap = max(5.0, min(100.0, float(self.cfg.get("safety_score_cap", 45.0) or 45.0)))
+                scores["safety"] = round(min(_num(scores.get("safety"), 100.0), cap), 1)
+                applied = True
+            else:
+                reason = "safety_override_disabled"
+        elif rec_need == "balance" and bool(self.cfg.get("annotate_only_for_balance", True)):
+            applied = False
+            reason = "balance_annotate_only"
+        else:
+            current = _num(scores.get(rec_need), 0.0)
+            scores[rec_need] = round(min(100.0, current + boost), 1)
+            applied = True
+
+        need, goal, priority = self._choose_goal(scores, rec_need, rec_goal)
+        needs["scores"] = {k: round(_num(v), 1) for k, v in scores.items()}
+        if applied:
+            needs["dominant_need"] = need
+            needs["recommended_goal"] = goal
+            needs["confidence"] = max(_num(needs.get("confidence"), 0.55), round(confidence, 2))
+        reasons = dict(_as_dict(needs.get("reasons")))
+        marker = {
+            **base_reason,
+            "available": True,
+            "applied": bool(applied),
+            "reason": reason,
+            "memory_need": rec_need,
+            "memory_goal": rec_goal or GOAL_BY_NEED[rec_need][0],
+            "memory_priority": rec_priority or priority,
+            "confidence": round(confidence, 4),
+            "boost": boost,
+            "previous_need": previous_need,
+            "previous_goal": previous_goal,
+            "result_need": needs.get("dominant_need"),
+            "result_goal": needs.get("recommended_goal"),
+            "top_item": shadow.get("top_item", {}),
+            "score_before": round(before_scores.get(rec_need if rec_need != "safety" else "safety", 0.0), 1),
+            "score_after": round(_num(scores.get(rec_need if rec_need != "safety" else "safety"), 0.0), 1),
+        }
+        reasons["memory_bias"] = marker
+        needs["reasons"] = reasons
+        needs["memory_bias"] = marker
+        self._last = marker
+        return needs
+
+    def _choose_goal(self, scores: Dict[str, Any], memory_need: str, memory_goal: str) -> Tuple[str, str, str]:
+        safety = _num(scores.get("safety"), 100.0)
+        if safety < 55.0:
+            return "safety", "pause_and_observe", "critical"
+        if _num(scores.get("rest"), 0.0) >= 72.0:
+            return "rest", "rest_quietly", "low"
+        if _num(scores.get("social"), 0.0) >= 70.0:
+            return "social", "seek_owner_or_invite_interaction", "normal"
+        if _num(scores.get("exploration"), 0.0) >= 68.0:
+            return "exploration", "look_around_and_learn", "normal"
+        if _num(scores.get("boredom"), 0.0) >= 60.0:
+            return "boredom", "choose_idle_activity", "normal"
+        if _num(scores.get("curiosity"), 0.0) >= 65.0:
+            return "curiosity", "inspect_environment", "normal"
+        if memory_need == "balance":
+            return "balance", "calm_idle", "low"
+        return "balance", "calm_idle", "low"
+
+    @staticmethod
+    def _attach(needs: Dict[str, Any], marker: Dict[str, Any]) -> None:
+        reasons = dict(_as_dict(needs.get("reasons")))
+        reasons["memory_bias"] = marker
+        needs["reasons"] = reasons
+        needs["memory_bias"] = marker

--- a/modules/autonomy/services/needs_engine.py
+++ b/modules/autonomy/services/needs_engine.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, Optional
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 100.0) -> float:
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        v = 0.0
+    return max(lo, min(hi, v))
+
+
+@dataclass
+class NeedsSnapshot:
+    ok: bool
+    timestamp: float
+    idle_s: float
+    owner_present: bool
+    dominant_need: str
+    recommended_goal: str
+    event: str
+    confidence: float
+    scores: Dict[str, float]
+    reasons: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["scores"] = {k: round(float(v), 1) for k, v in self.scores.items()}
+        data["confidence"] = round(float(self.confidence), 2)
+        data["idle_s"] = round(float(self.idle_s), 1)
+        return data
+
+
+class CompanionNeedsEngine:
+    """Centralized companion needs model.
+
+    This is intentionally semantic, not hardware-specific. It converts runtime
+    context into need intensities and a recommended high-level goal. Hardware
+    output is handled later by the expression/output bridge.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "boredom_threshold_s": 35.0,
+        "alone_threshold_s": 120.0,
+        "low_energy_threshold": 25.0,
+        "event_cooldown_s": 18.0,
+        "owner_recent_timeout_s": 35.0,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg: Dict[str, Any] = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self.enabled = bool(self.cfg.get("enabled", True))
+        self._last_snapshot: Optional[NeedsSnapshot] = None
+        self._last_event_ts: float = 0.0
+        self._last_event_name: str = ""
+        self._last_interaction_source: str = ""
+
+    def observe_interaction(self, source: str = "") -> None:
+        self._last_interaction_source = str(source or "interaction").strip().lower()
+
+    def tick(
+        self,
+        *,
+        now: Optional[float] = None,
+        last_interaction_ts: Optional[float] = None,
+        mood_state: Optional[Dict[str, Any]] = None,
+        needs_state: Optional[Dict[str, Any]] = None,
+        owner_present: bool = False,
+        owner_last_seen_ts: Optional[float] = None,
+        is_sleeping: bool = False,
+        speech_busy: bool = False,
+        scene: Optional[Dict[str, Any]] = None,
+        pc_test: bool = False,
+    ) -> Dict[str, Any]:
+        now_ts = float(now if now is not None else time.time())
+        last_ts = float(last_interaction_ts or now_ts)
+        idle_s = max(0.0, now_ts - last_ts)
+        mood = mood_state if isinstance(mood_state, dict) else {}
+        needs = needs_state if isinstance(needs_state, dict) else {}
+        scene_map = scene if isinstance(scene, dict) else {}
+        audio_map = scene_map.get("audio_context") if isinstance(scene_map.get("audio_context"), dict) else {}
+        audio_wakeword = bool(audio_map.get("wakeword"))
+        audio_speech = bool(audio_map.get("speech"))
+        audio_sound = bool(audio_map.get("sound"))
+        audio_silence = bool(audio_map.get("silence"))
+        audio_loud = bool(audio_map.get("loud"))
+        scene_novelty = bool(scene_map.get("new_object") or scene_map.get("novelty") or scene_map.get("unknown_object"))
+        scene_no_person = bool(scene_map.get("no_person"))
+        scene_stable = bool(scene_map.get("scene_stable") or scene_map.get("stable"))
+        scene_person_seen = bool(scene_map.get("person_seen") or scene_map.get("owner_present"))
+
+        boredom_threshold = max(5.0, float(self.cfg.get("boredom_threshold_s", 35.0) or 35.0))
+        alone_threshold = max(boredom_threshold, float(self.cfg.get("alone_threshold_s", 120.0) or 120.0))
+        low_energy = max(1.0, float(self.cfg.get("low_energy_threshold", 25.0) or 25.0))
+
+        energy = _clamp(mood.get("energy", 100.0))
+        mood_curiosity = _clamp(mood.get("curiosity", 50.0))
+        mood_fear = _clamp(mood.get("fear", 0.0))
+        existing_social = _clamp(needs.get("social", 50.0))
+        existing_stimulation = _clamp(needs.get("stimulation", 40.0))
+        existing_rest = _clamp(needs.get("rest", 80.0))
+
+        boredom = _clamp((idle_s / boredom_threshold) * 100.0)
+        social_need = _clamp((idle_s / alone_threshold) * 100.0)
+        if owner_present:
+            social_need = max(0.0, social_need - 45.0)
+        social_need = _clamp((social_need * 0.65) + (existing_social * 0.35))
+
+        curiosity = _clamp((mood_curiosity * 0.45) + (existing_stimulation * 0.35) + (boredom * 0.20))
+        rest_need = _clamp((100.0 - energy) * 0.75 + max(0.0, 55.0 - existing_rest) * 0.25)
+        safety = _clamp(100.0 - mood_fear)
+        if scene_map.get("hazards"):
+            safety = min(safety, 35.0)
+        if pc_test:
+            safety = max(safety, 85.0)
+
+        if scene_person_seen:
+            owner_present = True
+        if audio_wakeword or audio_speech:
+            owner_present = True
+        owner_proximity = 100.0 if owner_present else 0.0
+        if not owner_present and owner_last_seen_ts:
+            timeout = max(1.0, float(self.cfg.get("owner_recent_timeout_s", 35.0) or 35.0))
+            owner_proximity = _clamp(100.0 - ((now_ts - float(owner_last_seen_ts)) / timeout) * 100.0)
+
+        if audio_wakeword or audio_speech:
+            social_need = max(social_need, 82.0)
+            curiosity = max(curiosity, 62.0)
+        if audio_sound:
+            curiosity = max(curiosity, 72.0)
+        if audio_silence:
+            boredom = max(boredom, min(68.0, boredom + 12.0))
+        if audio_loud:
+            safety = min(safety, 45.0)
+            curiosity = max(curiosity, 68.0)
+
+        exploration = _clamp((curiosity * 0.55) + (boredom * 0.30) + (energy * 0.15))
+        if energy < low_energy:
+            exploration *= 0.45
+        if safety < 50.0:
+            exploration *= 0.35
+        if audio_sound and safety >= 50.0:
+            exploration = max(exploration, 66.0)
+        if scene_novelty:
+            curiosity = max(curiosity, 82.0)
+            exploration = max(exploration, 72.0)
+        if scene_no_person and idle_s >= (boredom_threshold * 0.45):
+            exploration = max(exploration, 64.0)
+            boredom = max(boredom, min(70.0, boredom + 8.0))
+        if scene_stable and not scene_novelty and not scene_map.get("hazards") and idle_s < boredom_threshold:
+            curiosity = min(curiosity, 52.0)
+            exploration = min(exploration, 48.0)
+
+        scores = {
+            "social": social_need,
+            "curiosity": curiosity,
+            "boredom": boredom,
+            "energy": energy,
+            "rest": rest_need,
+            "safety": safety,
+            "owner_proximity": owner_proximity,
+            "exploration": exploration,
+        }
+        dominant, goal = self._choose_goal(scores, is_sleeping=is_sleeping, speech_busy=speech_busy)
+        event = self._maybe_event(dominant, now_ts)
+        confidence = self._confidence(scores, dominant)
+
+        snap = NeedsSnapshot(
+            ok=True,
+            timestamp=now_ts,
+            idle_s=idle_s,
+            owner_present=bool(owner_present),
+            dominant_need=dominant,
+            recommended_goal=goal,
+            event=event,
+            confidence=confidence,
+            scores=scores,
+            reasons={
+                "pc_test": bool(pc_test),
+                "sleeping": bool(is_sleeping),
+                "speech_busy": bool(speech_busy),
+                "last_interaction_source": self._last_interaction_source,
+                "scene_hazards": bool(scene_map.get("hazards")),
+                "audio_context": {"wakeword": audio_wakeword, "speech": audio_speech, "sound": audio_sound, "silence": audio_silence, "loud": audio_loud},
+                "vision_context": {"new_object": scene_novelty, "no_person": scene_no_person, "scene_stable": scene_stable, "person_seen": scene_person_seen},
+            },
+        )
+        self._last_snapshot = snap
+        return snap.to_dict()
+
+    def snapshot(self) -> Dict[str, Any]:
+        if self._last_snapshot is None:
+            return {
+                "ok": True,
+                "available": False,
+                "reason": "no_snapshot_yet",
+                "enabled": self.enabled,
+            }
+        data = self._last_snapshot.to_dict()
+        data["available"] = True
+        data["enabled"] = self.enabled
+        return data
+
+    def _choose_goal(self, scores: Dict[str, float], *, is_sleeping: bool, speech_busy: bool) -> tuple[str, str]:
+        if is_sleeping:
+            return "rest", "stay_asleep"
+        if speech_busy:
+            return "conversation", "listen_and_respond"
+        if scores.get("safety", 100.0) < 55.0:
+            return "safety", "pause_and_observe"
+        if scores.get("rest", 0.0) >= 72.0:
+            return "rest", "rest_quietly"
+        if scores.get("social", 0.0) >= 70.0:
+            return "social", "seek_owner_or_invite_interaction"
+        if scores.get("exploration", 0.0) >= 68.0:
+            return "exploration", "look_around_and_learn"
+        if scores.get("boredom", 0.0) >= 60.0:
+            return "boredom", "choose_idle_activity"
+        if scores.get("curiosity", 0.0) >= 65.0:
+            return "curiosity", "inspect_environment"
+        return "balance", "calm_idle"
+
+    def _maybe_event(self, dominant: str, now_ts: float) -> str:
+        if not self.enabled:
+            return ""
+        cooldown = max(1.0, float(self.cfg.get("event_cooldown_s", 18.0) or 18.0))
+        event = f"needs.{dominant}"
+        if event == self._last_event_name and (now_ts - self._last_event_ts) < cooldown:
+            return ""
+        if (now_ts - self._last_event_ts) < max(2.0, cooldown / 3.0):
+            return ""
+        self._last_event_name = event
+        self._last_event_ts = now_ts
+        return event
+
+    @staticmethod
+    def _confidence(scores: Dict[str, float], dominant: str) -> float:
+        if dominant in {"balance", "conversation"}:
+            return 0.55
+        val = float(scores.get(dominant, 50.0) or 50.0)
+        if dominant == "safety":
+            val = 100.0 - val
+        return _clamp(0.35 + (val / 100.0) * 0.55, 0.35, 0.95)

--- a/modules/autonomy/services/owner_person_learning.py
+++ b/modules/autonomy/services/owner_person_learning.py
@@ -1,0 +1,75 @@
+
+from __future__ import annotations
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+class OwnerPersonLearning:
+    DEFAULTS = {"enabled": True, "profile_path": "data/owner_profile.json", "min_confidence": 0.55}
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None, client: Any = None, memory: Any = None) -> None:
+        self.cfg = dict(self.DEFAULTS)
+        if isinstance(cfg, dict):
+            self.cfg.update(cfg)
+        self.client = client; self.memory = memory
+        self.path = Path(str(self.cfg.get("profile_path") or self.DEFAULTS["profile_path"]))
+        if not self.path.is_absolute():
+            self.path = Path.cwd() / self.path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self.path.write_text(json.dumps({"owners": [], "updated_ts": time.time()}, ensure_ascii=False, indent=2), encoding="utf-8")
+        self._last: Dict[str, Any] = {"ok": True, "reason": "never_identified"}
+    def _load(self) -> Dict[str, Any]:
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {"owners": []}
+        except Exception:
+            return {"owners": []}
+    def _save(self, data: Dict[str, Any]) -> None:
+        data["updated_ts"] = time.time(); self.path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    def status(self) -> Dict[str, Any]:
+        data = self._load(); return {"ok": True, "available": True, "profile_path": str(self.path), "owners": data.get("owners", []), "last": dict(self._last)}
+    def learn(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        body = payload if isinstance(payload, dict) else {}
+        name = str(body.get("name") or body.get("person") or body.get("owner_name") or "owner").strip()
+        owner_id = str(body.get("id") or body.get("owner_id") or name.lower().replace(" ", "_")).strip()
+        record = {"id": owner_id, "name": name, "aliases": [str(a) for a in body.get("aliases", [])] if isinstance(body.get("aliases"), list) else [], "confidence": max(0.0, min(1.0, float(body.get("confidence", 0.75)))), "learned_ts": time.time(), "last_seen": time.time(), "track_hint": body.get("track") if isinstance(body.get("track"), dict) else self._current_target(), "details": body.get("details") if isinstance(body.get("details"), dict) else {}}
+        data = self._load(); owners = [x for x in data.get("owners", []) if isinstance(x, dict) and x.get("id") != owner_id]; owners.append(record); data["owners"] = owners; self._save(data); self._remember_world(record)
+        return {"ok": True, "available": True, "owner": record}
+    def identify(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        body = payload if isinstance(payload, dict) else {}; target = body.get("target") if isinstance(body.get("target"), dict) else self._current_target()
+        owners = [x for x in self._load().get("owners", []) if isinstance(x, dict)]
+        if not owners:
+            self._last = {"ok": True, "available": True, "identified": False, "reason": "no_owner_learned", "target": target}; return dict(self._last)
+        label = str((target or {}).get("label") or (target or {}).get("name") or (target or {}).get("person") or "").lower()
+        best = None; score = 0.0
+        for owner in owners:
+            names = [str(owner.get("name") or "").lower(), str(owner.get("id") or "").lower()] + [str(a).lower() for a in owner.get("aliases", [])]
+            local = float(owner.get("confidence", 0.0))
+            if label and any(n and n in label for n in names):
+                local = max(local, 0.85)
+            if local > score:
+                score = local; best = owner
+        identified = bool(best and score >= float(self.cfg.get("min_confidence", 0.55)))
+        self._last = {"ok": True, "available": True, "identified": identified, "owner": best if identified else None, "score": round(score, 3), "target": target}
+        return dict(self._last)
+    def _current_target(self) -> Dict[str, Any]:
+        if self.client is None:
+            return {}
+        try:
+            data = self.client._get("camera", "/tracking/target", timeout_s=0.6)
+            if isinstance(data, dict):
+                target = data.get("target") if isinstance(data.get("target"), dict) else data
+                return target if isinstance(target, dict) else {}
+        except Exception:
+            pass
+        return {}
+    def _remember_world(self, owner: Dict[str, Any]) -> None:
+        if self.memory is None:
+            return
+        try:
+            self.memory.observe({"kind": "person", "name": owner.get("name") or owner.get("id"), "summary": "Known owner/person: " + str(owner.get("name") or owner.get("id")), "confidence": owner.get("confidence", 0.75), "salience": 0.9, "tags": ["person", "owner"], "details": owner}, source="owner_learning")
+        except Exception:
+            pass
+
+__all__ = ["OwnerPersonLearning"]

--- a/modules/autonomy/services/pet_companion_core.py
+++ b/modules/autonomy/services/pet_companion_core.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from time import time
+from typing import Any, Dict, Mapping, Optional
+
+PET_COMPANION_CORE_CONTRACT = True
+PET_COMPANION_CORE_ROLE = "personality_bond_routine_to_semantic_pet_behavior"
+PET_COMPANION_CORE_HARDWARE_SAFE = True
+
+
+DEFAULT_PROFILE = {
+    "name": "sentry",
+    "traits": {
+        "curiosity": 0.72,
+        "sociability": 0.68,
+        "calmness": 0.58,
+        "playfulness": 0.62,
+        "protectiveness": 0.70,
+        "independence": 0.45,
+    },
+    "style": {
+        "speech": "short_warm",
+        "motion": "soft_reactive",
+        "expression": "alive_subtle",
+    },
+}
+
+
+def _clamp(value: Any, default: float = 0.0) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        number = default
+    return max(0.0, min(1.0, number))
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+@dataclass(frozen=True)
+class PersonalityProfile:
+    name: str = "sentry"
+    curiosity: float = 0.72
+    sociability: float = 0.68
+    calmness: float = 0.58
+    playfulness: float = 0.62
+    protectiveness: float = 0.70
+    independence: float = 0.45
+    speech_style: str = "short_warm"
+    motion_style: str = "soft_reactive"
+    expression_style: str = "alive_subtle"
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "PersonalityProfile":
+        traits = _mapping(data.get("traits"))
+        style = _mapping(data.get("style"))
+        return cls(
+            name=str(data.get("name", "sentry")),
+            curiosity=_clamp(traits.get("curiosity", DEFAULT_PROFILE["traits"]["curiosity"])),
+            sociability=_clamp(traits.get("sociability", DEFAULT_PROFILE["traits"]["sociability"])),
+            calmness=_clamp(traits.get("calmness", DEFAULT_PROFILE["traits"]["calmness"])),
+            playfulness=_clamp(traits.get("playfulness", DEFAULT_PROFILE["traits"]["playfulness"])),
+            protectiveness=_clamp(traits.get("protectiveness", DEFAULT_PROFILE["traits"]["protectiveness"])),
+            independence=_clamp(traits.get("independence", DEFAULT_PROFILE["traits"]["independence"])),
+            speech_style=str(style.get("speech", DEFAULT_PROFILE["style"]["speech"])),
+            motion_style=str(style.get("motion", DEFAULT_PROFILE["style"]["motion"])),
+            expression_style=str(style.get("expression", DEFAULT_PROFILE["style"]["expression"])),
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "traits": {
+                "curiosity": self.curiosity,
+                "sociability": self.sociability,
+                "calmness": self.calmness,
+                "playfulness": self.playfulness,
+                "protectiveness": self.protectiveness,
+                "independence": self.independence,
+            },
+            "style": {
+                "speech": self.speech_style,
+                "motion": self.motion_style,
+                "expression": self.expression_style,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class PetCompanionDecision:
+    intent: str
+    reason: str
+    score: float
+    expression_hint: str
+    motion_hint: str
+    speech_hint: str
+    goal_hints: list[str] = field(default_factory=list)
+    needs_bias: Dict[str, float] = field(default_factory=dict)
+    memory_tags: list[str] = field(default_factory=list)
+    safety: Dict[str, bool] = field(default_factory=dict)
+    status_only: bool = True
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "intent": self.intent,
+            "reason": self.reason,
+            "score": round(float(self.score), 3),
+            "expression_hint": self.expression_hint,
+            "motion_hint": self.motion_hint,
+            "speech_hint": self.speech_hint,
+            "goal_hints": list(self.goal_hints),
+            "needs_bias": dict(self.needs_bias),
+            "memory_tags": list(self.memory_tags),
+            "safety": dict(self.safety),
+            "status_only": self.status_only,
+        }
+
+
+class PetCompanionCore:
+    """Semantic pet-like behavior selector for autonomy.
+
+    This is real autonomy logic, not a hardware adapter. It turns needs,
+    relationship/bond state, routine energy, and perception hints into a
+    pet-like semantic intent. Hardware execution remains behind existing
+    autonomy goal/capability/safety gates.
+    """
+
+    def __init__(self, profile: Optional[PersonalityProfile] = None) -> None:
+        self.profile = profile or PersonalityProfile.from_mapping(DEFAULT_PROFILE)
+
+    def decide(self, context: Optional[Mapping[str, Any]] = None) -> PetCompanionDecision:
+        data = _mapping(context)
+        needs = _mapping(data.get("needs"))
+        bond = _mapping(data.get("bond"))
+        routine = _mapping(data.get("routine"))
+        perception = _mapping(data.get("perception"))
+
+        safety_need = _clamp(needs.get("safety", 0.0))
+        energy = _clamp(routine.get("energy", needs.get("energy", 0.7)), default=0.7)
+        boredom = _clamp(needs.get("boredom", 0.0))
+        curiosity = _clamp(needs.get("curiosity", 0.0))
+        social = _clamp(needs.get("social", 0.0))
+        owner_present = bool(perception.get("owner_present", perception.get("person_present", False)))
+        owner_speaking = bool(perception.get("owner_speaking", False))
+        trust = _clamp(bond.get("trust", 0.35), default=0.35)
+        affection = _clamp(bond.get("affection", 0.35), default=0.35)
+
+        candidates = {
+            "safe_observe": safety_need * (0.8 + self.profile.protectiveness * 0.5),
+            "rest_nearby": (1.0 - energy) * (0.7 + self.profile.calmness * 0.4),
+            "attend_owner": (social + affection * 0.5 + trust * 0.3 + (0.35 if owner_present else 0.0)) * self.profile.sociability,
+            "listen_owner": (0.6 if owner_speaking else 0.0) + social * 0.4,
+            "curious_inspect": (curiosity * 0.7 + boredom * 0.35) * self.profile.curiosity,
+            "playful_ping": (boredom * 0.65 + energy * 0.25) * self.profile.playfulness,
+            "calm_idle": self.profile.calmness * 0.35 + self.profile.independence * 0.25,
+        }
+
+        if safety_need >= 0.55:
+            intent = "safe_observe"
+        elif energy <= 0.25:
+            intent = "rest_nearby"
+        else:
+            intent = max(candidates, key=candidates.get)
+
+        return self._decision_for(intent, candidates[intent], owner_present=owner_present, owner_speaking=owner_speaking)
+
+    def _decision_for(self, intent: str, score: float, *, owner_present: bool, owner_speaking: bool) -> PetCompanionDecision:
+        safety = {
+            "hardware_enabled": False,
+            "motion_started": False,
+            "audio_started": False,
+            "camera_started": False,
+            "vlm_started": False,
+            "semantic_only": True,
+        }
+
+        if intent == "safe_observe":
+            return PetCompanionDecision(
+                intent=intent,
+                reason="safety_need_dominant",
+                score=score,
+                expression_hint="alert_soft",
+                motion_hint="freeze_or_slow_scan",
+                speech_hint="silent_or_short_check",
+                goal_hints=["prefer_safe_observation", "avoid_motion_until_clear"],
+                needs_bias={"safety": 0.7},
+                memory_tags=["safety_context"],
+                safety=safety,
+            )
+
+        if intent == "rest_nearby":
+            return PetCompanionDecision(
+                intent=intent,
+                reason="low_energy_or_rest_routine",
+                score=score,
+                expression_hint="sleepy_calm",
+                motion_hint="settle_near_owner",
+                speech_hint="minimal",
+                goal_hints=["rest", "stay_available"],
+                needs_bias={"energy_recovery": 0.5},
+                memory_tags=["routine_rest"],
+                safety=safety,
+            )
+
+        if intent == "attend_owner":
+            return PetCompanionDecision(
+                intent=intent,
+                reason="bond_social_owner_presence",
+                score=score,
+                expression_hint="happy_attentive" if owner_present else "searching_soft",
+                motion_hint="orient_to_owner",
+                speech_hint=self.profile.speech_style,
+                goal_hints=["orient_to_owner", "offer_presence", "update_bond_memory"],
+                needs_bias={"social": 0.35, "bond": 0.25},
+                memory_tags=["owner_interaction"],
+                safety=safety,
+            )
+
+        if intent == "listen_owner":
+            return PetCompanionDecision(
+                intent=intent,
+                reason="owner_speaking_or_audio_attention",
+                score=score,
+                expression_hint="listening",
+                motion_hint="hold_still_attention",
+                speech_hint="do_not_interrupt",
+                goal_hints=["listen", "avoid_talking_over_owner"],
+                needs_bias={"attention": 0.4},
+                memory_tags=["audio_attention"],
+                safety=safety,
+            )
+
+        if intent == "curious_inspect":
+            return PetCompanionDecision(
+                intent=intent,
+                reason="curiosity_or_boredom",
+                score=score,
+                expression_hint="curious",
+                motion_hint="small_head_tilt_or_scan",
+                speech_hint="curious_short",
+                goal_hints=["inspect_interesting_context", "ask_short_question_if_allowed"],
+                needs_bias={"curiosity": 0.4},
+                memory_tags=["curiosity_context"],
+                safety=safety,
+            )
+
+        if intent == "playful_ping":
+            return PetCompanionDecision(
+                intent=intent,
+                reason="boredom_with_enough_energy",
+                score=score,
+                expression_hint="playful",
+                motion_hint="small_bouncy_idle",
+                speech_hint="playful_short",
+                goal_hints=["invite_interaction", "small_idle_animation"],
+                needs_bias={"play": 0.35, "social": 0.15},
+                memory_tags=["play_context"],
+                safety=safety,
+            )
+
+        return PetCompanionDecision(
+            intent="calm_idle",
+            reason="stable_low_pressure_state",
+            score=score,
+            expression_hint="calm_alive",
+            motion_hint="breathing_idle",
+            speech_hint="silent",
+            goal_hints=["ambient_presence"],
+            needs_bias={"calm": 0.2},
+            memory_tags=["ambient_state"],
+            safety=safety,
+        )
+
+
+def load_personality_profile(path: str | Path = "config/autonomy/pet_companion_profile.json") -> PersonalityProfile:
+    cfg_path = Path(path)
+    if not cfg_path.exists():
+        return PersonalityProfile.from_mapping(DEFAULT_PROFILE)
+    try:
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except Exception:
+        data = DEFAULT_PROFILE
+    return PersonalityProfile.from_mapping(_mapping(data))
+
+
+def decide_pet_companion_behavior(context: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+    profile = load_personality_profile()
+    return PetCompanionCore(profile).decide(context).as_dict()

--- a/modules/autonomy/services/pet_output_planner.py
+++ b/modules/autonomy/services/pet_output_planner.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional
+
+PET_OUTPUT_PLANNER_CONTRACT = True
+PET_OUTPUT_PLANNER_ROLE = "pet_intent_to_expression_motion_speech_semantic_plan"
+PET_OUTPUT_PLANNER_HARDWARE_SAFE = True
+
+
+def _text(value: Any, default: str = "") -> str:
+    text = str(value if value is not None else default).strip()
+    return text or default
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+@dataclass(frozen=True)
+class PetOutputPlan:
+    intent: str
+    expression: Dict[str, Any] = field(default_factory=dict)
+    motion: Dict[str, Any] = field(default_factory=dict)
+    speech: Dict[str, Any] = field(default_factory=dict)
+    led: Dict[str, Any] = field(default_factory=dict)
+    safety: Dict[str, bool] = field(default_factory=dict)
+    semantic_only: bool = True
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "intent": self.intent,
+            "expression": dict(self.expression),
+            "motion": dict(self.motion),
+            "speech": dict(self.speech),
+            "led": dict(self.led),
+            "safety": dict(self.safety),
+            "semantic_only": self.semantic_only,
+        }
+
+
+class PetOutputPlanner:
+    """Translate pet companion hints into semantic expression/motion/speech plan.
+
+    This module does not execute OLED, servo, LED, TTS, audio, camera, or VLM.
+    It only produces safe semantic commands that later execution layers can
+    route through capability and hardware gates.
+    """
+
+    def plan(self, pet_companion: Optional[Mapping[str, Any]] = None) -> PetOutputPlan:
+        data = _mapping(pet_companion)
+        intent = _text(data.get("intent"), "calm_idle")
+        expression_hint = _text(data.get("expression_hint"), self._default_expression(intent))
+        motion_hint = _text(data.get("motion_hint"), self._default_motion(intent))
+        speech_hint = _text(data.get("speech_hint"), self._default_speech(intent))
+
+        intensity = self._intensity_for(intent)
+        expression = {
+            "type": "expression",
+            "name": expression_hint,
+            "intent": intent,
+            "intensity": intensity,
+            "duration_s": 2.0,
+            "semantic_only": True,
+            "hardware_started": False,
+        }
+        motion = {
+            "type": "motion",
+            "name": motion_hint,
+            "intent": intent,
+            "amplitude": self._motion_amplitude(intent),
+            "duration_s": 1.5,
+            "semantic_only": True,
+            "hardware_started": False,
+            "requires_arm_gate": True,
+        }
+        speech = {
+            "type": "speech",
+            "style": speech_hint,
+            "intent": intent,
+            "utterance": self._utterance_for(intent, speech_hint),
+            "semantic_only": True,
+            "tts_started": False,
+        }
+        led = {
+            "type": "led",
+            "pattern": self._led_pattern(intent),
+            "intent": intent,
+            "semantic_only": True,
+            "hardware_started": False,
+        }
+        safety = {
+            "camera_started": False,
+            "frame_captured": False,
+            "vlm_started": False,
+            "tts_started": False,
+            "audio_started": False,
+            "motion_started": False,
+            "led_started": False,
+            "hardware_enabled": False,
+            "semantic_only": True,
+        }
+        return PetOutputPlan(
+            intent=intent,
+            expression=expression,
+            motion=motion,
+            speech=speech,
+            led=led,
+            safety=safety,
+            semantic_only=True,
+        )
+
+    def _default_expression(self, intent: str) -> str:
+        return {
+            "safe_observe": "alert_soft",
+            "rest_nearby": "sleepy_calm",
+            "attend_owner": "happy_attentive",
+            "listen_owner": "listening",
+            "curious_inspect": "curious",
+            "playful_ping": "playful",
+            "calm_idle": "calm_alive",
+        }.get(intent, "calm_alive")
+
+    def _default_motion(self, intent: str) -> str:
+        return {
+            "safe_observe": "freeze_or_slow_scan",
+            "rest_nearby": "settle_near_owner",
+            "attend_owner": "orient_to_owner",
+            "listen_owner": "hold_still_attention",
+            "curious_inspect": "small_head_tilt_or_scan",
+            "playful_ping": "small_bouncy_idle",
+            "calm_idle": "breathing_idle",
+        }.get(intent, "breathing_idle")
+
+    def _default_speech(self, intent: str) -> str:
+        return {
+            "safe_observe": "silent_or_short_check",
+            "rest_nearby": "minimal",
+            "attend_owner": "short_warm",
+            "listen_owner": "do_not_interrupt",
+            "curious_inspect": "curious_short",
+            "playful_ping": "playful_short",
+            "calm_idle": "silent",
+        }.get(intent, "silent")
+
+    def _intensity_for(self, intent: str) -> float:
+        return {
+            "safe_observe": 0.25,
+            "rest_nearby": 0.18,
+            "attend_owner": 0.55,
+            "listen_owner": 0.35,
+            "curious_inspect": 0.50,
+            "playful_ping": 0.62,
+            "calm_idle": 0.25,
+        }.get(intent, 0.25)
+
+    def _motion_amplitude(self, intent: str) -> float:
+        return {
+            "safe_observe": 0.05,
+            "rest_nearby": 0.08,
+            "attend_owner": 0.25,
+            "listen_owner": 0.03,
+            "curious_inspect": 0.22,
+            "playful_ping": 0.32,
+            "calm_idle": 0.10,
+        }.get(intent, 0.10)
+
+    def _led_pattern(self, intent: str) -> str:
+        return {
+            "safe_observe": "soft_alert",
+            "rest_nearby": "dim_breath",
+            "attend_owner": "warm_pulse",
+            "listen_owner": "focus_dot",
+            "curious_inspect": "curious_spark",
+            "playful_ping": "playful_blink",
+            "calm_idle": "slow_breath",
+        }.get(intent, "slow_breath")
+
+    def _utterance_for(self, intent: str, speech_hint: str) -> str:
+        if speech_hint in {"silent", "minimal", "do_not_interrupt"}:
+            return ""
+        return {
+            "attend_owner": "BuradayÄ±m.",
+            "curious_inspect": "Bunu merak ettim.",
+            "playful_ping": "Bir ÅŸey yapalÄ±m mÄ±?",
+            "safe_observe": "Dikkat ediyorum.",
+        }.get(intent, "")
+
+
+def build_pet_output_plan(pet_companion: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+    return PetOutputPlanner().plan(pet_companion).as_dict()

--- a/modules/autonomy/services/pi_hardware_runtime.py
+++ b/modules/autonomy/services/pi_hardware_runtime.py
@@ -1,0 +1,63 @@
+
+from __future__ import annotations
+import glob
+import importlib.util
+import os
+import platform
+import socket
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+from modules.common.model_asset_truth import collect_asset_truth
+
+def _read(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="ignore").strip()
+    except Exception:
+        return ""
+
+def is_raspberry_pi() -> bool:
+    model = _read("/proc/device-tree/model") or _read("/sys/firmware/devicetree/base/model")
+    return "raspberry pi" in model.lower()
+
+class PiHardwareRuntime:
+    DEFAULTS = {"require_pi": True, "require_camera": True, "require_esp": False, "camera_device_glob": "/dev/video*"}
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None, client: Any = None) -> None:
+        self.cfg = dict(self.DEFAULTS)
+        if isinstance(cfg, dict):
+            self.cfg.update(cfg)
+        self.client = client
+        self._last: Dict[str, Any] = {"ok": False, "reason": "never_checked"}
+    def status(self) -> Dict[str, Any]:
+        model = _read("/proc/device-tree/model") or _read("/sys/firmware/devicetree/base/model")
+        pi = is_raspberry_pi()
+        video_devices = sorted(glob.glob(str(self.cfg.get("camera_device_glob") or "/dev/video*")))
+        picamera2 = importlib.util.find_spec("picamera2") is not None
+        libcamera = bool(Path("/usr/bin/libcamera-hello").exists()) or bool(os.environ.get("LIBCAMERA_LOG_LEVEL"))
+        assets = collect_asset_truth(Path.cwd())
+        esp = self._esp_status()
+        ok = True
+        reasons = []
+        if self.cfg.get("require_pi", True) and not pi:
+            ok = False; reasons.append("not_raspberry_pi")
+        if self.cfg.get("require_camera", True) and not (picamera2 and (video_devices or pi)):
+            ok = False; reasons.append("camera_stack_missing")
+        if self.cfg.get("require_esp", False) and not esp.get("ok"):
+            ok = False; reasons.append("esp_unreachable")
+        if assets.get("required_missing"):
+            ok = False; reasons.append("required_assets_missing")
+        out = {"ok": ok, "available": True, "timestamp": time.time(), "hostname": socket.gethostname(), "machine": platform.machine(), "platform": platform.platform(), "model": model, "is_raspberry_pi": pi, "picamera2_available": picamera2, "libcamera_present": libcamera, "video_devices": video_devices, "esp": esp, "assets": assets, "reason": "ok" if ok else ",".join(reasons)}
+        self._last = out
+        return out
+    def _esp_status(self) -> Dict[str, Any]:
+        if self.client is None:
+            return {"ok": False, "reason": "client_missing"}
+        try:
+            resp = self.client.robot_command("hello")
+            return {"ok": bool(isinstance(resp, dict) and resp.get("ok")), "response": resp}
+        except Exception as exc:
+            return {"ok": False, "reason": str(exc)}
+    def last(self) -> Dict[str, Any]:
+        return dict(self._last)
+
+__all__ = ["PiHardwareRuntime", "is_raspberry_pi"]

--- a/modules/autonomy/services/robot_capability_map.py
+++ b/modules/autonomy/services/robot_capability_map.py
@@ -1,0 +1,132 @@
+# Read-only robot capability source-of-truth adapter.
+#
+# This module intentionally does not enable hardware and does not execute actions.
+# It exposes the configured capability registry to runtime/autonomy code so tools
+# and runtime can share one canonical capability source.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+ROBOT_CAPABILITY_SOURCE_OF_TRUTH = True
+ROBOT_CAPABILITY_BOUNDARY_ROLE = "autonomy_read_only_capability_registry_adapter"
+ROBOT_CAPABILITY_CONFIG_PATH = "config/robot_capability_registry.json"
+ROBOT_CAPABILITY_RUNTIME_OWNER = "modules.autonomy reads capability registry; hard safety/arm gates remain in tools/ci and execution gates"
+ROBOT_CAPABILITY_BOUNDARY_REASON = (
+    "Capability registry lives in config/robot_capability_registry.json. "
+    "This adapter makes that registry available to autonomy without enabling real hardware."
+)
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def registry_path(root: Optional[Path] = None) -> Path:
+    base = Path(root) if root is not None else _project_root()
+    return base / ROBOT_CAPABILITY_CONFIG_PATH
+
+
+def load_registry(root: Optional[Path] = None) -> Dict[str, Any]:
+    path = registry_path(root)
+    if not path.exists():
+        return {
+            "ok": False,
+            "available": False,
+            "reason": "robot_capability_registry_missing",
+            "path": str(path),
+            "capabilities": {},
+        }
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {
+            "ok": False,
+            "available": False,
+            "reason": "robot_capability_registry_invalid_json",
+            "path": str(path),
+            "error": str(exc),
+            "capabilities": {},
+        }
+
+    if not isinstance(data, dict):
+        return {
+            "ok": False,
+            "available": False,
+            "reason": "robot_capability_registry_not_object",
+            "path": str(path),
+            "capabilities": {},
+        }
+
+    data = dict(data)
+    data.setdefault("ok", True)
+    data.setdefault("available", True)
+    data.setdefault("path", str(path))
+    data.setdefault("source", ROBOT_CAPABILITY_CONFIG_PATH)
+    return data
+
+
+def _capability_items(registry: Dict[str, Any]) -> Dict[str, Any]:
+    for key in ("capabilities", "registry", "items", "actions"):
+        value = registry.get(key)
+        if isinstance(value, dict):
+            return value
+    metadata = {
+        "ok", "available", "path", "source", "version", "updated_at",
+        "profiles", "defaults", "metadata", "schema", "reason", "error",
+    }
+    candidates = {k: v for k, v in registry.items() if k not in metadata}
+    return candidates if candidates else {}
+
+
+def list_capabilities(root: Optional[Path] = None) -> List[str]:
+    registry = load_registry(root)
+    return sorted(str(k) for k in _capability_items(registry).keys())
+
+
+def get_capability(name: str, root: Optional[Path] = None) -> Dict[str, Any]:
+    key = str(name or "").strip()
+    registry = load_registry(root)
+    items = _capability_items(registry)
+    value = items.get(key)
+    if isinstance(value, dict):
+        out = dict(value)
+        out.setdefault("name", key)
+        out.setdefault("available", True)
+        return out
+    if value is not None:
+        return {"name": key, "available": True, "value": value}
+    return {"name": key, "available": False, "reason": "capability_not_found"}
+
+
+def status(root: Optional[Path] = None) -> Dict[str, Any]:
+    registry = load_registry(root)
+    names = list_capabilities(root)
+    return {
+        "ok": bool(registry.get("ok", False)),
+        "available": bool(registry.get("available", False)),
+        "source": registry.get("source", ROBOT_CAPABILITY_CONFIG_PATH),
+        "path": registry.get("path"),
+        "capability_count": len(names),
+        "capabilities": names,
+        "read_only": True,
+        "hardware_enabled": False,
+        "armed": False,
+    }
+
+
+__all__ = [
+    "ROBOT_CAPABILITY_SOURCE_OF_TRUTH",
+    "ROBOT_CAPABILITY_BOUNDARY_ROLE",
+    "ROBOT_CAPABILITY_CONFIG_PATH",
+    "ROBOT_CAPABILITY_RUNTIME_OWNER",
+    "ROBOT_CAPABILITY_BOUNDARY_REASON",
+    "registry_path",
+    "load_registry",
+    "list_capabilities",
+    "get_capability",
+    "status",
+]

--- a/modules/autonomy/services/robot_runtime_profile.py
+++ b/modules/autonomy/services/robot_runtime_profile.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from modules.common.runtime_target import detect_runtime_target
+
+
+PROFILE_PATH = "config/robot_execution_profiles.json"
+PROFILE_NAME = "raspberry_pi"
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def profile_config_path(root: Optional[Path] = None) -> Path:
+    return (Path(root) if root is not None else _project_root()) / PROFILE_PATH
+
+
+def load_profile_config(root: Optional[Path] = None) -> Dict[str, Any]:
+    path = profile_config_path(root)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"ok": False, "reason": "profile_missing", "path": str(path), "profiles": {}}
+    except Exception as exc:
+        return {"ok": False, "reason": "profile_invalid", "path": str(path), "error": str(exc), "profiles": {}}
+    if not isinstance(data, dict):
+        return {"ok": False, "reason": "profile_not_object", "path": str(path), "profiles": {}}
+    data = dict(data)
+    data["ok"] = True
+    data["path"] = str(path)
+    return data
+
+
+def resolve_runtime_profile(root: Optional[Path] = None) -> Dict[str, Any]:
+    target = detect_runtime_target()
+    cfg = load_profile_config(root)
+    profiles = cfg.get("profiles") if isinstance(cfg.get("profiles"), dict) else {}
+    profile = profiles.get(PROFILE_NAME) if isinstance(profiles.get(PROFILE_NAME), dict) else {}
+    return {
+        "ok": bool(target.is_raspberry_pi and cfg.get("ok") and profile),
+        "target": target.to_dict(),
+        "profile_name": PROFILE_NAME,
+        "profile": dict(profile),
+        "config_path": cfg.get("path"),
+        "reason": "ready" if target.is_raspberry_pi else target.reason,
+    }
+
+
+def status(root: Optional[Path] = None) -> Dict[str, Any]:
+    resolved = resolve_runtime_profile(root)
+    profile = resolved.get("profile") if isinstance(resolved.get("profile"), dict) else {}
+    return {
+        "ok": bool(resolved.get("ok")),
+        "target": resolved.get("target", {}),
+        "profile_name": PROFILE_NAME,
+        "allow_real_hardware": bool(profile.get("allow_real_hardware", True)),
+        "allowed_risks": list(profile.get("allowed_risks") or ["none", "low", "medium"]),
+        "reason": resolved.get("reason"),
+    }
+
+
+__all__ = ["PROFILE_PATH", "PROFILE_NAME", "profile_config_path", "load_profile_config", "resolve_runtime_profile", "status"]

--- a/modules/autonomy/services/safe_navigation.py
+++ b/modules/autonomy/services/safe_navigation.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class SafeNavigationMemory:
+    """Safe-place selector and pose-only rest executor.
+
+    Base movement is disabled by default. A learned map can enable base motion
+    explicitly; otherwise the robot chooses a rest place semantically and applies
+    the safe rest pose, dim expression and lights-off state.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "places_path": "data/safe_places.json",
+        "allow_base_motion": False,
+        "default_rest_place": "quiet_corner",
+        "rest_pose": {"pan": 90, "tilt": 125},
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None, client: Any = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self.client = client
+        self.path = Path(str(self.cfg.get("places_path") or self.DEFAULTS["places_path"]))
+        if not self.path.is_absolute():
+            self.path = Path.cwd() / self.path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._last: Dict[str, Any] = {"ok": True, "available": False, "reason": "never_executed"}
+        self._ensure_defaults()
+
+    def _ensure_defaults(self) -> None:
+        if self.path.exists():
+            return
+        data = {
+            "places": [
+                {
+                    "id": "quiet_corner",
+                    "kind": "rest_place",
+                    "name": "quiet_corner",
+                    "summary": "Default quiet rest place. Base motion stays disabled until a real map confirms it.",
+                    "safety_score": 0.55,
+                    "learned": False,
+                    "pose_only": True,
+                    "created_ts": time.time(),
+                }
+            ]
+        }
+        self.path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def _load(self) -> Dict[str, Any]:
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {"places": []}
+        except Exception:
+            return {"places": []}
+
+    def _save(self, data: Dict[str, Any]) -> None:
+        self.path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def list_places(self) -> Dict[str, Any]:
+        data = self._load()
+        places = data.get("places") if isinstance(data.get("places"), list) else []
+        return {"ok": True, "available": True, "places": places, "count": len(places), "path": str(self.path)}
+
+    def learn_place(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        body = payload if isinstance(payload, dict) else {}
+        place_id = str(body.get("id") or body.get("name") or f"place_{int(time.time())}").strip()
+        place = {
+            "id": place_id,
+            "kind": str(body.get("kind") or "rest_place"),
+            "name": str(body.get("name") or place_id),
+            "summary": str(body.get("summary") or "learned safe place"),
+            "safety_score": max(0.0, min(1.0, _safe_float(body.get("safety_score"), 0.6))),
+            "learned": True,
+            "pose_only": bool(body.get("pose_only", not bool(self.cfg.get("allow_base_motion", False)))),
+            "created_ts": float(body.get("created_ts") or time.time()),
+            "last_seen": float(body.get("last_seen") or time.time()),
+            "details": body.get("details") if isinstance(body.get("details"), dict) else {},
+        }
+        data = self._load()
+        places = [p for p in data.get("places", []) if isinstance(p, dict) and p.get("id") != place_id]
+        places.append(place)
+        data["places"] = places
+        self._save(data)
+        return {"ok": True, "available": True, "place": place}
+
+    def select_rest_place(self) -> Dict[str, Any]:
+        places = [p for p in self._load().get("places", []) if isinstance(p, dict)]
+        candidates = [p for p in places if str(p.get("kind") or "") in {"rest_place", "safe_place", "corner"}]
+        if not candidates:
+            self._ensure_defaults()
+            candidates = [p for p in self._load().get("places", []) if isinstance(p, dict)]
+        candidates.sort(key=lambda p: (_safe_float(p.get("safety_score"), 0.0), _safe_float(p.get("last_seen") or p.get("created_ts"), 0.0)), reverse=True)
+        place = candidates[0] if candidates else {}
+        return {"ok": bool(place), "available": bool(place), "place": place, "allow_base_motion": bool(self.cfg.get("allow_base_motion", False))}
+
+    def execute_rest_corner(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        body = payload if isinstance(payload, dict) else {}
+        selected = self.select_rest_place()
+        place = selected.get("place") if isinstance(selected.get("place"), dict) else {}
+        allow_motion = bool(body.get("allow_base_motion", self.cfg.get("allow_base_motion", False)))
+        actions: List[Dict[str, Any]] = []
+        nav_result = None
+        if allow_motion and self.client is not None and not bool(place.get("pose_only", False)):
+            try:
+                nav_result = self.client.queue_action("navigation.goal", priority=60, ttl_ms=20000, payload={"place": place})
+                actions.append({"type": "navigation.goal", "result": nav_result})
+            except Exception as exc:
+                actions.append({"type": "navigation.goal", "ok": False, "error": str(exc)})
+        else:
+            actions.append({"type": "navigation.skipped", "reason": "base_motion_disabled_or_pose_only"})
+        if self.client is not None:
+            pose = self.cfg.get("rest_pose") if isinstance(self.cfg.get("rest_pose"), dict) else {}
+            pan = int(pose.get("pan", 90))
+            tilt = int(pose.get("tilt", 125))
+            try:
+                actions.append({"type": "expression", "result": self.client.set_expression_event("navigation.resting", {"place": place})})
+            except Exception as exc:
+                actions.append({"type": "expression", "ok": False, "error": str(exc)})
+            try:
+                actions.append({"type": "head", "result": self.client.move_head(pan, tilt)})
+            except Exception as exc:
+                actions.append({"type": "head", "ok": False, "error": str(exc)})
+            try:
+                actions.append({"type": "liveliness", "result": self.client.set_liveliness(False)})
+            except Exception as exc:
+                actions.append({"type": "liveliness", "ok": False, "error": str(exc)})
+            try:
+                actions.append({"type": "lights", "result": self.client.set_neopixel("SOLID", color=[0, 0, 0], duration=2.0)})
+            except Exception as exc:
+                actions.append({"type": "lights", "ok": False, "error": str(exc)})
+        out = {
+            "ok": True,
+            "available": True,
+            "timestamp": time.time(),
+            "place": place,
+            "base_motion_requested": bool(nav_result),
+            "pose_only": not bool(nav_result),
+            "actions": actions,
+            "reason": "rest_corner_pose_applied" if not nav_result else "rest_corner_navigation_requested",
+        }
+        self._last = dict(out)
+        return out
+
+    def status(self) -> Dict[str, Any]:
+        return {"ok": True, "enabled": bool(self.cfg.get("enabled", True)), "config": dict(self.cfg), "last": dict(self._last), "places": self.list_places()}
+
+
+__all__ = ["SafeNavigationMemory"]

--- a/modules/autonomy/services/topomap_motion_executor.py
+++ b/modules/autonomy/services/topomap_motion_executor.py
@@ -1,0 +1,117 @@
+
+from __future__ import annotations
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+def _float(v: Any, default: float = 0.0) -> float:
+    try:
+        return float(v)
+    except Exception:
+        return default
+
+class TopomapMotionExecutor:
+    DEFAULTS = {"enabled": True, "map_path": "data/topomap_places.json", "allow_base_motion": False, "require_ultrasonic_clearance": True, "min_clearance_cm": 28.0, "max_steps": 8, "max_step_duration_s": 2.0, "max_drive_value": 120}
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None, client: Any = None) -> None:
+        self.cfg = dict(self.DEFAULTS)
+        if isinstance(cfg, dict):
+            self.cfg.update(cfg)
+        self.client = client
+        self.map_path = Path(str(self.cfg.get("map_path") or self.DEFAULTS["map_path"]))
+        if not self.map_path.is_absolute():
+            self.map_path = Path.cwd() / self.map_path
+        self.map_path.parent.mkdir(parents=True, exist_ok=True)
+        self._last: Dict[str, Any] = {"ok": True, "reason": "never_executed"}
+        self._ensure_map()
+    def _ensure_map(self) -> None:
+        if not self.map_path.exists():
+            self.map_path.write_text(json.dumps({"places": [], "edges": [], "updated_ts": time.time()}, ensure_ascii=False, indent=2), encoding="utf-8")
+    def _load(self) -> Dict[str, Any]:
+        self._ensure_map()
+        try:
+            data = json.loads(self.map_path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {"places": [], "edges": []}
+        except Exception:
+            return {"places": [], "edges": []}
+    def _save(self, data: Dict[str, Any]) -> None:
+        data["updated_ts"] = time.time()
+        self.map_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    def status(self) -> Dict[str, Any]:
+        data = self._load()
+        places = data.get("places") if isinstance(data.get("places"), list) else []
+        edges = data.get("edges") if isinstance(data.get("edges"), list) else []
+        return {"ok": True, "available": True, "config": dict(self.cfg), "map_path": str(self.map_path), "place_count": len(places), "edge_count": len(edges), "last": dict(self._last)}
+    def list_map(self) -> Dict[str, Any]:
+        return {"ok": True, "available": True, "map": self._load(), "status": self.status()}
+    def learn_place(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        body = payload if isinstance(payload, dict) else {}
+        place_id = str(body.get("id") or body.get("name") or f"place_{int(time.time())}").strip()
+        place = {"id": place_id, "name": str(body.get("name") or place_id), "kind": str(body.get("kind") or "place"), "summary": str(body.get("summary") or "learned topomap place"), "safety_score": max(0.0, min(1.0, _float(body.get("safety_score"), 0.6))), "motion_plan": body.get("motion_plan") if isinstance(body.get("motion_plan"), list) else [], "created_ts": time.time(), "last_seen": time.time(), "details": body.get("details") if isinstance(body.get("details"), dict) else {}}
+        data = self._load()
+        places = [p for p in data.get("places", []) if isinstance(p, dict) and p.get("id") != place_id]
+        places.append(place); data["places"] = places; self._save(data)
+        return {"ok": True, "available": True, "place": place}
+    def _find(self, place_id: str) -> Dict[str, Any]:
+        for p in self._load().get("places", []):
+            if isinstance(p, dict) and str(p.get("id") or p.get("name")) == str(place_id):
+                return p
+        return {}
+    def execute_goal(self, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        body = payload if isinstance(payload, dict) else {}
+        place_id = str(body.get("place_id") or body.get("id") or body.get("name") or "").strip()
+        place = self._find(place_id) if place_id else {}
+        if not place:
+            self._last = {"ok": False, "available": True, "reason": "place_not_found", "place_id": place_id}; return dict(self._last)
+        allow = bool(body.get("allow_base_motion", self.cfg.get("allow_base_motion", False)))
+        if not allow:
+            self._last = {"ok": True, "available": True, "moved": False, "pose_only": True, "reason": "base_motion_disabled", "place": place}; return dict(self._last)
+        clearance = self._clearance_ok()
+        if not clearance.get("ok"):
+            self._last = {"ok": False, "available": True, "moved": False, "reason": "clearance_blocked", "clearance": clearance, "place": place}; return dict(self._last)
+        plan = place.get("motion_plan") if isinstance(place.get("motion_plan"), list) else []
+        if not plan:
+            self._last = {"ok": False, "available": True, "moved": False, "reason": "motion_plan_missing", "place": place}; return dict(self._last)
+        actions = [self._execute_step(s) for s in plan[: int(self.cfg.get("max_steps", 8))] if isinstance(s, dict)]
+        moved = bool(actions and all(a.get("ok") is not False for a in actions))
+        self._last = {"ok": moved, "available": True, "moved": moved, "reason": "executed" if moved else "step_failed", "place": place, "actions": actions}
+        return dict(self._last)
+    def _clearance_ok(self) -> Dict[str, Any]:
+        if not self.cfg.get("require_ultrasonic_clearance", True):
+            return {"ok": True, "reason": "not_required"}
+        if self.client is None:
+            return {"ok": False, "reason": "client_missing"}
+        try:
+            resp = self.client.read_sensor("ultra_read")
+            dist = None
+            if isinstance(resp, dict):
+                for k in ("cm", "distance_cm", "distance", "value"):
+                    if k in resp:
+                        dist = _float(resp.get(k), -1.0); break
+            if dist is None or dist < 0:
+                return {"ok": False, "reason": "ultrasonic_unavailable", "response": resp}
+            return {"ok": dist >= _float(self.cfg.get("min_clearance_cm"), 28.0), "distance_cm": dist, "min_clearance_cm": _float(self.cfg.get("min_clearance_cm"), 28.0)}
+        except Exception as exc:
+            return {"ok": False, "reason": str(exc)}
+    def _execute_step(self, step: Dict[str, Any]) -> Dict[str, Any]:
+        if self.client is None:
+            return {"ok": False, "reason": "client_missing", "step": step}
+        kind = str(step.get("type") or step.get("cmd") or "").strip().lower()
+        try:
+            if kind in {"drive", "move"}:
+                maxv = int(self.cfg.get("max_drive_value", 120)); value = max(-maxv, min(maxv, int(_float(step.get("value"), 0))))
+                resp = self.client._arduino_request({"cmd": "drive", "value": value}, timeout=min(_float(step.get("duration_s"), 0.2), _float(self.cfg.get("max_step_duration_s"), 2.0)) + 0.5)
+                return {"ok": bool(isinstance(resp, dict) and resp.get("ok")), "type": kind, "value": value, "response": resp}
+            if kind in {"stepper", "turn"}:
+                resp = self.client.set_stepper(int(step.get("id", 0)), str(step.get("mode") or "rel"), int(_float(step.get("value"), 0)), drive=int(step.get("drive", 160)))
+                return {"ok": bool(isinstance(resp, dict) and resp.get("ok")), "type": kind, "response": resp}
+            if kind in {"wait", "pause"}:
+                time.sleep(max(0.0, min(_float(step.get("duration_s"), 0.2), _float(self.cfg.get("max_step_duration_s"), 2.0))))
+                return {"ok": True, "type": kind}
+            if kind == "home":
+                resp = self.client.robot_command("home"); return {"ok": bool(isinstance(resp, dict) and resp.get("ok")), "type": kind, "response": resp}
+            return {"ok": False, "reason": "unknown_step", "step": step}
+        except Exception as exc:
+            return {"ok": False, "reason": str(exc), "step": step}
+
+__all__ = ["TopomapMotionExecutor"]

--- a/modules/autonomy/services/vision_context_bridge.py
+++ b/modules/autonomy/services/vision_context_bridge.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from time import time
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+VISION_CONTEXT_BRIDGE_CONTRACT = True
+VISION_CONTEXT_BRIDGE_ROLE = "camera_vlm_to_autonomy_semantic_context_adapter"
+VISION_CONTEXT_BRIDGE_STATUS_ONLY = True
+
+
+def _now() -> float:
+    return float(time())
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _compact_text(value: Any, limit: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) > limit:
+        return text[: limit - 1].rstrip() + "..."
+    return text
+
+
+def _compact_list(value: Any, limit: int = 8) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes)):
+        return [_compact_text(value)]
+    if isinstance(value, Sequence):
+        return list(value[:limit])
+    return [value]
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "running", "ready", "ok"}
+    return bool(value)
+
+
+@dataclass
+class VisionContextBridge:
+    """Status-only bridge from camera/VLM facts into autonomy semantic context.
+
+    This class never opens a camera, never captures a frame, never calls a VLM,
+    and never calls Ollama. It only normalizes already-produced status/result
+    dictionaries so autonomy can consume them safely.
+    """
+
+    config: Optional[Mapping[str, Any]] = None
+    history_limit: int = 20
+    _history: List[Dict[str, Any]] = field(default_factory=list)
+
+    def ingest_camera_status(
+        self,
+        status: Optional[Mapping[str, Any]],
+        *,
+        source: str = "camera",
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        data = _as_mapping(status)
+        context = {
+            "kind": "camera_status",
+            "source": source,
+            "timestamp": float(_now() if now is None else now),
+            "enabled": _truthy(data.get("enabled", data.get("camera_enabled", False))),
+            "running": _truthy(data.get("running", data.get("active", False))),
+            "has_frame": _truthy(data.get("has_frame", data.get("frame_available", False))),
+            "degraded": _truthy(data.get("degraded", data.get("gave_up", False))),
+            "reason": _compact_text(data.get("reason", data.get("status", "")), limit=160),
+        }
+        return self._remember(context)
+
+    def ingest_vlm_result(
+        self,
+        result: Optional[Mapping[str, Any]],
+        *,
+        source: str = "vlm",
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        data = _as_mapping(result)
+        context = {
+            "kind": "vlm_semantic_context",
+            "source": source,
+            "timestamp": float(_now() if now is None else now),
+            "caption": _compact_text(data.get("caption", data.get("description", ""))),
+            "objects": _compact_list(data.get("objects", data.get("labels", []))),
+            "people": _compact_list(data.get("people", data.get("persons", []))),
+            "scene": _compact_text(data.get("scene", data.get("place", "")), limit=120),
+            "risk": _compact_text(data.get("risk", data.get("safety", "")), limit=80),
+            "confidence": data.get("confidence"),
+        }
+        return self._remember(context)
+
+    def build_context(
+        self,
+        *,
+        camera_status: Optional[Mapping[str, Any]] = None,
+        vlm_result: Optional[Mapping[str, Any]] = None,
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        entries: List[Dict[str, Any]] = []
+        if camera_status is not None:
+            entries.append(self.ingest_camera_status(camera_status, now=now))
+        if vlm_result is not None:
+            entries.append(self.ingest_vlm_result(vlm_result, now=now))
+        return {
+            "kind": "vision_context_bundle",
+            "timestamp": float(_now() if now is None else now),
+            "entries": entries,
+            "latest": self.latest(),
+            "status_only": True,
+            "activation_started": False,
+        }
+
+    def latest(self) -> Optional[Dict[str, Any]]:
+        return dict(self._history[-1]) if self._history else None
+
+    def history(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        if limit is None:
+            return [dict(item) for item in self._history]
+        return [dict(item) for item in self._history[-int(limit):]]
+
+    def clear(self) -> None:
+        self._history.clear()
+
+    def _remember(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        self._history.append(dict(context))
+        if len(self._history) > self.history_limit:
+            self._history = self._history[-self.history_limit :]
+        return dict(context)
+
+
+def build_vision_context(
+    *,
+    camera_status: Optional[Mapping[str, Any]] = None,
+    vlm_result: Optional[Mapping[str, Any]] = None,
+    now: Optional[float] = None,
+) -> Dict[str, Any]:
+    return VisionContextBridge().build_context(
+        camera_status=camera_status,
+        vlm_result=vlm_result,
+        now=now,
+    )

--- a/modules/autonomy/services/vision_context_needs_bridge.py
+++ b/modules/autonomy/services/vision_context_needs_bridge.py
@@ -1,0 +1,170 @@
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "enabled", "seen", "present"}
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    if value in (None, ""):
+        return []
+    return [value]
+
+
+class VisionContextNeedsBridge:
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "ttl_s": 45.0,
+        "owner_seen_timeout_s": 60.0,
+        "history_limit": 20,
+        "novelty_curiosity": 92.0,
+        "no_person_stimulation": 62.0,
+        "stable_curiosity": 35.0,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg: Dict[str, Any] = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self._latest: Dict[str, Any] = {
+            "ok": True,
+            "available": False,
+            "reason": "no_vision_context_yet",
+            "timestamp": 0.0,
+        }
+        self._owner_last_seen_ts: float = 0.0
+        self._history: List[Dict[str, Any]] = []
+
+    def observe(self, payload: Optional[Dict[str, Any]], *, source: str = "manual", now: Optional[float] = None) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        data = _as_dict(payload)
+        summary = str(data.get("summary") or data.get("caption") or data.get("scene") or "").strip()
+        objects = _as_list(data.get("objects") or data.get("detected_objects"))
+        hazards = _as_list(data.get("hazards") or data.get("hazard"))
+        person_seen = _as_bool(data.get("person_seen"), False) or _as_bool(data.get("person_present"), False) or _as_bool(data.get("owner_present"), False)
+        owner_present = _as_bool(data.get("owner_present"), person_seen)
+        no_person = _as_bool(data.get("no_person"), False) or ("person_seen" in data and not _as_bool(data.get("person_seen"), False))
+        new_object = _as_bool(data.get("new_object"), False) or _as_bool(data.get("novelty"), False) or _as_bool(data.get("unknown_object"), False)
+        scene_stable = _as_bool(data.get("scene_stable"), False) or _as_bool(data.get("stable"), False)
+        confidence = max(0.0, min(1.0, _as_float(data.get("confidence"), 0.65)))
+        if person_seen or owner_present:
+            self._owner_last_seen_ts = ts
+        context = {
+            "ok": True,
+            "available": True,
+            "timestamp": ts,
+            "source": str(source or data.get("source") or "manual"),
+            "summary": summary,
+            "objects": objects,
+            "hazards": hazards,
+            "person_seen": bool(person_seen),
+            "owner_present": bool(owner_present),
+            "no_person": bool(no_person and not person_seen and not owner_present),
+            "new_object": bool(new_object),
+            "scene_stable": bool(scene_stable),
+            "confidence": round(confidence, 2),
+            "reason": self._reason_for(person_seen=person_seen, owner_present=owner_present, no_person=no_person, new_object=new_object, scene_stable=scene_stable, hazards=hazards),
+        }
+        self._latest = context
+        self._push_history(context)
+        return self.status(now=ts)
+
+    def status(self, *, now: Optional[float] = None) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        latest = dict(self._latest)
+        age = max(0.0, ts - _as_float(latest.get("timestamp"), 0.0)) if latest.get("available") else 0.0
+        ttl = max(1.0, _as_float(self.cfg.get("ttl_s"), 45.0))
+        latest["enabled"] = _as_bool(self.cfg.get("enabled"), True)
+        latest["age_s"] = round(age, 1)
+        latest["fresh"] = bool(latest.get("available") and age <= ttl)
+        latest["owner_last_seen_ts"] = self._owner_last_seen_ts
+        latest["history"] = list(self._history[-10:])
+        return latest
+
+    def context(self, *, now: Optional[float] = None) -> Dict[str, Any]:
+        ts = float(now if now is not None else time.time())
+        if not _as_bool(self.cfg.get("enabled"), True):
+            return {"available": False, "reason": "vision_context_bridge_disabled"}
+        st = self.status(now=ts)
+        if not st.get("available") or not st.get("fresh"):
+            return {"available": False, "reason": st.get("reason") or "vision_context_stale", "status": st}
+        scene: Dict[str, Any] = {
+            "summary": st.get("summary", ""),
+            "objects": list(st.get("objects") or []),
+            "hazards": list(st.get("hazards") or []),
+            "person_seen": bool(st.get("person_seen")),
+            "owner_present": bool(st.get("owner_present")),
+            "no_person": bool(st.get("no_person")),
+            "new_object": bool(st.get("new_object")),
+            "novelty": bool(st.get("new_object")),
+            "scene_stable": bool(st.get("scene_stable")),
+            "vision_confidence": st.get("confidence", 0.0),
+        }
+        mood_overrides: Dict[str, Any] = {}
+        needs_overrides: Dict[str, Any] = {}
+        if scene.get("new_object"):
+            mood_overrides["curiosity"] = max(_as_float(mood_overrides.get("curiosity"), 0.0), _as_float(self.cfg.get("novelty_curiosity"), 92.0))
+            needs_overrides["stimulation"] = max(_as_float(needs_overrides.get("stimulation"), 0.0), 85.0)
+        if scene.get("no_person"):
+            needs_overrides["stimulation"] = max(_as_float(needs_overrides.get("stimulation"), 0.0), _as_float(self.cfg.get("no_person_stimulation"), 62.0))
+        if scene.get("scene_stable") and not scene.get("new_object") and not scene.get("hazards"):
+            mood_overrides["curiosity"] = min(_as_float(self.cfg.get("stable_curiosity"), 35.0), _as_float(self.cfg.get("stable_curiosity"), 35.0))
+        owner_timeout = max(1.0, _as_float(self.cfg.get("owner_seen_timeout_s"), 60.0))
+        owner_recent = self._owner_last_seen_ts > 0.0 and (ts - self._owner_last_seen_ts) <= owner_timeout
+        return {
+            "available": True,
+            "status": st,
+            "scene": scene,
+            "mood_overrides": mood_overrides,
+            "needs_overrides": needs_overrides,
+            "owner_present": bool(scene.get("owner_present") or owner_recent),
+            "owner_last_seen_ts": self._owner_last_seen_ts or None,
+        }
+
+    def _push_history(self, item: Dict[str, Any]) -> None:
+        compact = {
+            "timestamp": item.get("timestamp"),
+            "reason": item.get("reason"),
+            "summary": item.get("summary", ""),
+            "owner_present": item.get("owner_present", False),
+            "no_person": item.get("no_person", False),
+            "new_object": item.get("new_object", False),
+            "hazards": item.get("hazards", []),
+        }
+        self._history.append(compact)
+        limit = int(_as_float(self.cfg.get("history_limit"), 20))
+        self._history = self._history[-max(1, limit):]
+
+    def _reason_for(self, *, person_seen: bool, owner_present: bool, no_person: bool, new_object: bool, scene_stable: bool, hazards: List[Any]) -> str:
+        if hazards:
+            return "vision.hazard"
+        if owner_present or person_seen:
+            return "vision.person_seen"
+        if new_object:
+            return "vision.new_object"
+        if no_person:
+            return "vision.no_person"
+        if scene_stable:
+            return "vision.scene_stable"
+        return "vision.context"

--- a/modules/autonomy/services/vision_context_to_autonomy.py
+++ b/modules/autonomy/services/vision_context_to_autonomy.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from time import time
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+VISION_CONTEXT_TO_AUTONOMY_CONTRACT = True
+VISION_CONTEXT_TO_AUTONOMY_ROLE = "status_only_vision_semantics_to_autonomy_signal_adapter"
+VISION_CONTEXT_TO_AUTONOMY_STATUS_ONLY_SAFE = True
+
+
+def _now() -> float:
+    return float(time())
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_list(value: Any, limit: int = 12) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes)):
+        return [str(value)]
+    if isinstance(value, Sequence):
+        return list(value[:limit])
+    return [value]
+
+
+def _compact_text(value: Any, limit: int = 180) -> str:
+    text = str(value or "").strip()
+    if len(text) > limit:
+        return text[: limit - 3].rstrip() + "..."
+    return text
+
+
+def _merge_bias(target: Dict[str, float], key: str, value: float) -> None:
+    target[key] = round(max(float(target.get(key, 0.0)), float(value)), 3)
+
+
+def _is_risky(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return False
+    return text not in {"none", "no", "false", "safe", "low", "normal", "ok"}
+
+
+@dataclass(frozen=True)
+class AutonomyVisionSignal:
+    kind: str = "vision_context_to_autonomy_signal"
+    timestamp: float = 0.0
+    observations: List[str] = field(default_factory=list)
+    needs_bias: Dict[str, float] = field(default_factory=dict)
+    goal_hints: List[str] = field(default_factory=list)
+    safety_flags: List[str] = field(default_factory=list)
+    confidence: Optional[float] = None
+    status_only: bool = True
+    activation_started: bool = False
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "timestamp": self.timestamp,
+            "observations": list(self.observations),
+            "needs_bias": dict(self.needs_bias),
+            "goal_hints": list(self.goal_hints),
+            "safety_flags": list(self.safety_flags),
+            "confidence": self.confidence,
+            "status_only": self.status_only,
+            "activation_started": self.activation_started,
+        }
+
+
+@dataclass
+class VisionContextToAutonomyAdapter:
+    """Pure semantic adapter from vision context into autonomy signals.
+
+    The adapter consumes already-produced camera/VLM context dictionaries. It
+    never opens a camera, captures a frame, runs a model, makes network calls,
+    or mutates robot state. The output is a semantic proposal for autonomy.
+    """
+
+    now_fn: Any = _now
+
+    def translate(self, context: Optional[Mapping[str, Any]], *, now: Optional[float] = None) -> AutonomyVisionSignal:
+        data = _as_mapping(context)
+        entries = self._entries(data)
+        timestamp = float(self.now_fn() if now is None else now)
+
+        observations: List[str] = []
+        needs_bias: Dict[str, float] = {}
+        goal_hints: List[str] = []
+        safety_flags: List[str] = []
+        confidences: List[float] = []
+
+        for entry in entries:
+            item = _as_mapping(entry)
+            kind = str(item.get("kind", "")).strip()
+
+            if kind == "camera_status":
+                self._apply_camera_status(item, observations, needs_bias, goal_hints)
+            elif kind == "vlm_semantic_context":
+                self._apply_vlm_semantics(item, observations, needs_bias, goal_hints, safety_flags, confidences)
+            else:
+                if item:
+                    observations.append("vision_context:unknown_entry")
+
+        confidence = round(sum(confidences) / len(confidences), 3) if confidences else None
+        return AutonomyVisionSignal(
+            timestamp=timestamp,
+            observations=observations,
+            needs_bias=needs_bias,
+            goal_hints=goal_hints,
+            safety_flags=safety_flags,
+            confidence=confidence,
+            status_only=True,
+            activation_started=False,
+        )
+
+    def _entries(self, data: Mapping[str, Any]) -> List[Mapping[str, Any]]:
+        entries = data.get("entries")
+        if isinstance(entries, Sequence) and not isinstance(entries, (str, bytes)):
+            return [_as_mapping(item) for item in entries]
+        if data:
+            return [data]
+        return []
+
+    def _apply_camera_status(
+        self,
+        item: Mapping[str, Any],
+        observations: List[str],
+        needs_bias: Dict[str, float],
+        goal_hints: List[str],
+    ) -> None:
+        enabled = bool(item.get("enabled", False))
+        running = bool(item.get("running", False))
+        has_frame = bool(item.get("has_frame", False))
+
+        observations.append(f"camera_status:enabled={enabled},running={running},has_frame={has_frame}")
+
+        if enabled and running and has_frame:
+            goal_hints.append("use_visual_context_when_needed")
+            _merge_bias(needs_bias, "curiosity", 0.05)
+        else:
+            goal_hints.append("vision_unavailable_keep_audio_memory_behaviour")
+            _merge_bias(needs_bias, "visual_confidence", 0.0)
+
+    def _apply_vlm_semantics(
+        self,
+        item: Mapping[str, Any],
+        observations: List[str],
+        needs_bias: Dict[str, float],
+        goal_hints: List[str],
+        safety_flags: List[str],
+        confidences: List[float],
+    ) -> None:
+        caption = _compact_text(item.get("caption", ""))
+        objects = [str(obj) for obj in _as_list(item.get("objects", []))]
+        people = [str(person) for person in _as_list(item.get("people", []))]
+        scene = _compact_text(item.get("scene", ""))
+        risk = _compact_text(item.get("risk", ""))
+
+        if caption:
+            observations.append(f"caption:{caption}")
+        if objects:
+            observations.append("objects:" + ",".join(objects[:8]))
+            goal_hints.append("inspect_interesting_object")
+            _merge_bias(needs_bias, "curiosity", 0.12)
+        if people:
+            observations.append("people:" + ",".join(people[:8]))
+            goal_hints.append("attend_to_known_person")
+            _merge_bias(needs_bias, "social", 0.2)
+            _merge_bias(needs_bias, "attention", 0.12)
+        if scene:
+            observations.append(f"scene:{scene}")
+
+        if _is_risky(risk):
+            safety_flags.append(f"vision_risk:{risk}")
+            goal_hints.append("prefer_safe_observation")
+            _merge_bias(needs_bias, "safety", 0.6)
+
+        try:
+            confidence = float(item.get("confidence"))
+        except (TypeError, ValueError):
+            confidence = None
+        if confidence is not None:
+            confidences.append(max(0.0, min(1.0, confidence)))
+
+
+def build_autonomy_vision_signal(
+    context: Optional[Mapping[str, Any]],
+    *,
+    now: Optional[float] = None,
+) -> Dict[str, Any]:
+    return VisionContextToAutonomyAdapter().translate(context, now=now).as_dict()

--- a/modules/autonomy/services/world_memory.py
+++ b/modules/autonomy/services/world_memory.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+KIND_ALIASES: Dict[str, str] = {
+    "person": "people",
+    "people": "people",
+    "owner": "people",
+    "user": "people",
+    "place": "places",
+    "location": "places",
+    "room": "places",
+    "places": "places",
+    "object": "objects",
+    "objects": "objects",
+    "thing": "objects",
+    "item": "objects",
+    "event": "events",
+    "events": "events",
+    "observation": "observations",
+    "observations": "observations",
+    "note": "observations",
+    "habit": "habits",
+    "habits": "habits",
+    "routine": "habits",
+}
+
+
+WORLD_MEMORY_PERSISTENCE_TRUTH_CONTRACT = True
+WORLD_MEMORY_PERSISTENCE_ROLE = "local_json_semantic_memory_store"
+SCHEMA: Dict[str, Dict[str, Any]] = {
+    "people": {"description": "known or recently observed people", "merge_by": "name"},
+    "places": {"description": "rooms, locations and stable zones", "merge_by": "name"},
+    "objects": {"description": "known or recently observed objects", "merge_by": "name"},
+    "events": {"description": "time-based semantic events", "merge_by": "name+source"},
+    "observations": {"description": "raw semantic observations", "merge_by": "summary+source"},
+    "habits": {"description": "learned or declared repeated patterns", "merge_by": "name"},
+}
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clean_text(value: Any, default: str = "") -> str:
+    text = str(value if value is not None else default).strip()
+    return " ".join(text.split())
+
+
+def _normalize_kind(kind: Any) -> str:
+    key = _clean_text(kind or "observation").lower().replace("-", "_")
+    return KIND_ALIASES.get(key, KIND_ALIASES.get(key.rstrip("s"), "observations"))
+
+
+def _slug(text: str) -> str:
+    cleaned = []
+    for ch in text.lower():
+        if ch.isalnum():
+            cleaned.append(ch)
+        elif cleaned and cleaned[-1] != "_":
+            cleaned.append("_")
+    value = "".join(cleaned).strip("_")
+    return value or "unnamed"
+
+
+class WorldMemory:
+    """Small semantic world-memory store for companion behavior.
+
+    This is intentionally local and deterministic. It is not vector/RAG yet. The
+    goal is to establish a stable schema that later vision, audio, dialog and RAG
+    layers can write into while reporting local persistence status explicitly.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "max_entries_per_kind": 200,
+        "recent_limit": 20,
+        "decay_half_life_s": 86400.0,
+        "persistence_enabled": True,
+        "storage_path": ".sentrybot_state/world_memory.json",
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg: Dict[str, Any] = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self._store: Dict[str, Dict[str, Dict[str, Any]]] = {kind: {} for kind in SCHEMA}
+        self._history: List[Dict[str, Any]] = []
+        self._last_persist_error = ""
+        self._loaded_from_disk = False
+        self._load()
+
+    def schema(self) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "enabled": bool(self.cfg.get("enabled", True)),
+            "kinds": list(SCHEMA.keys()),
+            "schema": SCHEMA,
+            "fields": [
+                "id", "kind", "name", "summary", "properties", "source",
+                "confidence", "salience", "count", "first_seen_ts", "last_seen_ts", "tags",
+            ],
+            "persistence": self._persistence_status(),
+        }
+
+    def status(self, *, limit: Optional[int] = None) -> Dict[str, Any]:
+        counts = {kind: len(bucket) for kind, bucket in self._store.items()}
+        recent_limit = _as_int(limit, _as_int(self.cfg.get("recent_limit"), 20))
+        return {
+            "ok": True,
+            "enabled": bool(self.cfg.get("enabled", True)),
+            "total": sum(counts.values()),
+            "counts": counts,
+            "kinds": list(SCHEMA.keys()),
+            "recent": self.recent(limit=recent_limit).get("items", []),
+            "persistence": self._persistence_status(),
+        }
+
+    def observe(self, payload: Optional[Dict[str, Any]], *, source: str = "api", now: Optional[float] = None) -> Dict[str, Any]:
+        if not bool(self.cfg.get("enabled", True)):
+            return {"ok": False, "available": False, "reason": "world_memory_disabled"}
+        data = _as_dict(payload)
+        ts = float(now if now is not None else time.time())
+        kind = _normalize_kind(data.get("kind") or data.get("type") or data.get("category"))
+        name = _clean_text(data.get("name") or data.get("label") or data.get("title") or data.get("summary") or kind)
+        summary = _clean_text(data.get("summary") or data.get("description") or name)
+        src = _clean_text(data.get("source") or source or "api")
+        confidence = max(0.0, min(1.0, _as_float(data.get("confidence"), 0.6)))
+        salience = max(0.0, min(1.0, _as_float(data.get("salience"), confidence)))
+        properties = dict(_as_dict(data.get("properties")))
+        for key in ("location", "transcript", "reason", "emotion", "object", "person"):
+            if key in data and key not in properties:
+                properties[key] = data.get(key)
+        tags_raw = data.get("tags")
+        if isinstance(tags_raw, list):
+            tags = [_clean_text(x).lower() for x in tags_raw if _clean_text(x)]
+        elif tags_raw:
+            tags = [_clean_text(tags_raw).lower()]
+        else:
+            tags = []
+        key = self._key_for(kind, name, summary, src)
+        bucket = self._store.setdefault(kind, {})
+        created = key not in bucket
+        if created:
+            item = {
+                "id": f"{kind}:{key}",
+                "kind": kind,
+                "name": name,
+                "summary": summary,
+                "properties": properties,
+                "source": src,
+                "confidence": round(confidence, 3),
+                "salience": round(salience, 3),
+                "count": 1,
+                "first_seen_ts": ts,
+                "last_seen_ts": ts,
+                "tags": sorted(set(tags)),
+            }
+        else:
+            item = dict(bucket[key])
+            merged_props = dict(_as_dict(item.get("properties")))
+            merged_props.update(properties)
+            item["properties"] = merged_props
+            item["summary"] = summary or item.get("summary", "")
+            item["confidence"] = round(max(_as_float(item.get("confidence"), 0.0), confidence), 3)
+            item["salience"] = round(max(_as_float(item.get("salience"), 0.0), salience), 3)
+            item["count"] = _as_int(item.get("count"), 1) + 1
+            item["last_seen_ts"] = ts
+            item["tags"] = sorted(set(list(item.get("tags") or []) + tags))
+        bucket[key] = item
+        self._trim_kind(kind)
+        history_item = {
+            "timestamp": ts,
+            "id": item.get("id"),
+            "kind": kind,
+            "name": name,
+            "source": src,
+            "created": created,
+            "summary": summary,
+        }
+        self._history.append(history_item)
+        self._history = self._history[-100:]
+        self._save()
+        return {"ok": True, "available": True, "created": created, "item": dict(item), "timestamp": ts}
+
+    def recent(self, *, kind: Optional[str] = None, limit: int = 10) -> Dict[str, Any]:
+        limit = max(1, min(100, _as_int(limit, 10)))
+        kinds = [_normalize_kind(kind)] if kind else list(SCHEMA.keys())
+        items: List[Dict[str, Any]] = []
+        for k in kinds:
+            bucket = self._store.get(k, {})
+            items.extend(dict(x) for x in bucket.values())
+        items.sort(key=lambda x: _as_float(x.get("last_seen_ts"), 0.0), reverse=True)
+        return {"ok": True, "kind": _normalize_kind(kind) if kind else "all", "limit": limit, "items": items[:limit], "count": len(items[:limit])}
+
+    def get(self, item_id: str) -> Dict[str, Any]:
+        item_id = _clean_text(item_id)
+        if ":" in item_id:
+            kind, key = item_id.split(":", 1)
+            kind = _normalize_kind(kind)
+            item = self._store.get(kind, {}).get(key)
+            if item:
+                return {"ok": True, "available": True, "item": dict(item)}
+        for bucket in self._store.values():
+            for item in bucket.values():
+                if item.get("id") == item_id:
+                    return {"ok": True, "available": True, "item": dict(item)}
+        return {"ok": True, "available": False, "reason": "not_found", "id": item_id}
+
+    def clear(self, *, kind: Optional[str] = None) -> Dict[str, Any]:
+        if kind:
+            normalized = _normalize_kind(kind)
+            removed = len(self._store.get(normalized, {}))
+            self._store[normalized] = {}
+            self._history.append({"timestamp": time.time(), "kind": normalized, "event": "clear", "removed": removed})
+            self._save()
+            return {"ok": True, "kind": normalized, "removed": removed}
+        removed = sum(len(bucket) for bucket in self._store.values())
+        self._store = {k: {} for k in SCHEMA}
+        self._history.append({"timestamp": time.time(), "kind": "all", "event": "clear", "removed": removed})
+        self._save()
+        return {"ok": True, "kind": "all", "removed": removed}
+
+    def history(self, *, limit: int = 20) -> Dict[str, Any]:
+        limit = max(1, min(100, _as_int(limit, 20)))
+        return {"ok": True, "items": list(self._history[-limit:]), "count": min(limit, len(self._history))}
+
+    def _key_for(self, kind: str, name: str, summary: str, source: str) -> str:
+        if kind in {"events"}:
+            return _slug(f"{name}_{source}")
+        if kind in {"observations"}:
+            return _slug(f"{summary}_{source}")
+        return _slug(name)
+
+    def _trim_kind(self, kind: str) -> None:
+        max_entries = max(10, _as_int(self.cfg.get("max_entries_per_kind"), 200))
+        bucket = self._store.get(kind, {})
+        if len(bucket) <= max_entries:
+            return
+        ordered = sorted(bucket.items(), key=lambda kv: (_as_float(kv[1].get("salience"), 0.0), _as_float(kv[1].get("last_seen_ts"), 0.0)))
+        for key, _ in ordered[: max(0, len(bucket) - max_entries)]:
+            bucket.pop(key, None)
+
+    def _storage_file(self) -> Path:
+        raw = _clean_text(self.cfg.get("storage_path"), ".sentrybot_state/world_memory.json")
+        return Path(raw).expanduser()
+
+    def _persistence_enabled(self) -> bool:
+        return bool(self.cfg.get("persistence_enabled", True))
+
+    def _persistence_status(self) -> Dict[str, Any]:
+        path = self._storage_file()
+        return {
+            "enabled": self._persistence_enabled(),
+            "path": str(path),
+            "exists": path.exists(),
+            "loaded": self._loaded_from_disk,
+            "error": self._last_persist_error,
+        }
+
+    def _load(self) -> None:
+        if not self._persistence_enabled():
+            return
+        path = self._storage_file()
+        try:
+            if not path.exists():
+                return
+            data = json.loads(path.read_text(encoding="utf-8"))
+            raw_store = data.get("store") if isinstance(data, dict) else None
+            if isinstance(raw_store, dict):
+                loaded: Dict[str, Dict[str, Dict[str, Any]]] = {kind: {} for kind in SCHEMA}
+                for kind in SCHEMA:
+                    bucket = raw_store.get(kind)
+                    if isinstance(bucket, dict):
+                        loaded[kind] = {str(key): dict(value) for key, value in bucket.items() if isinstance(value, dict)}
+                self._store = loaded
+            raw_history = data.get("history") if isinstance(data, dict) else None
+            if isinstance(raw_history, list):
+                self._history = [dict(x) for x in raw_history[-100:] if isinstance(x, dict)]
+            self._loaded_from_disk = True
+            self._last_persist_error = ""
+        except Exception as exc:
+            self._last_persist_error = str(exc)
+
+    def _save(self) -> None:
+        if not self._persistence_enabled():
+            return
+        path = self._storage_file()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            data = {
+                "version": 1,
+                "saved_at": time.time(),
+                "store": self._store,
+                "history": self._history[-100:],
+            }
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+            tmp.replace(path)
+            self._last_persist_error = ""
+        except Exception as exc:
+            self._last_persist_error = str(exc)

--- a/modules/autonomy/services/world_memory_autowriter.py
+++ b/modules/autonomy/services/world_memory_autowriter.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    if value in (None, ""):
+        return []
+    return [value]
+
+
+def _clean(value: Any, default: str = "") -> str:
+    text = str(value if value is not None else default).strip()
+    return " ".join(text.split())
+
+
+def _confidence(value: Any, default: float = 0.6) -> float:
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        out = default
+    return max(0.0, min(1.0, out))
+
+
+class WorldMemoryAutoWriter:
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "write_people": True,
+        "write_objects": True,
+        "write_events": True,
+        "write_observations": True,
+        "write_low_salience_silence": True,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg: Dict[str, Any] = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+
+    def enabled(self) -> bool:
+        return bool(self.cfg.get("enabled", True))
+
+    def from_vision(self, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if not self.enabled():
+            return []
+        ctx = _as_dict(context)
+        out: List[Dict[str, Any]] = []
+        conf = _confidence(ctx.get("confidence"), 0.7)
+        summary = _clean(ctx.get("summary") or ctx.get("reason") or "vision observation", "vision observation")
+        reason = _clean(ctx.get("reason"), "vision.context")
+        if bool(ctx.get("person_seen") or ctx.get("owner_present")) and self.cfg.get("write_people", True):
+            name = _clean(ctx.get("person") or ctx.get("person_name") or "owner")
+            out.append({"kind": "people", "name": name, "summary": "owner seen nearby" if name == "owner" else f"{name} seen nearby", "source": "vision", "confidence": conf, "salience": max(0.75, conf), "tags": ["owner"] if name == "owner" else ["person"], "properties": {"reason": reason, "owner_present": bool(ctx.get("owner_present", True))}})
+        if bool(ctx.get("new_object")) and self.cfg.get("write_objects", True):
+            objects = [_clean(x) for x in _as_list(ctx.get("objects")) if _clean(x)] or ["unknown object"]
+            for obj in objects[:5]:
+                out.append({"kind": "objects", "name": obj, "summary": summary or f"new object observed: {obj}", "source": "vision", "confidence": conf, "salience": max(0.80, conf), "tags": ["novel"], "properties": {"reason": reason, "new_object": True}})
+        hazards = [_clean(x) for x in _as_list(ctx.get("hazards")) if _clean(x)]
+        if hazards and self.cfg.get("write_events", True):
+            out.append({"kind": "events", "name": "hazard", "summary": summary or ", ".join(hazards), "source": "vision", "confidence": conf, "salience": 0.95, "tags": ["safety", "hazard"], "properties": {"reason": reason, "hazards": hazards}})
+        if self.cfg.get("write_observations", True):
+            if bool(ctx.get("no_person")):
+                out.append({"kind": "observations", "name": "no person visible", "summary": summary or "no person visible", "source": "vision", "confidence": conf, "salience": 0.45, "tags": ["no_person"], "properties": {"reason": reason}})
+            elif bool(ctx.get("scene_stable")):
+                out.append({"kind": "observations", "name": "stable quiet room", "summary": summary or "stable quiet room", "source": "vision", "confidence": conf, "salience": 0.35, "tags": ["stable"], "properties": {"reason": reason}})
+        return out
+
+    def from_audio(self, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if not self.enabled():
+            return []
+        ctx = _as_dict(context)
+        out: List[Dict[str, Any]] = []
+        conf = _confidence(ctx.get("confidence"), 0.7)
+        event_type = _clean(ctx.get("event_type"), "audio")
+        transcript = _clean(ctx.get("transcript"), "")
+        reason = _clean(ctx.get("reason"), f"audio.{event_type}")
+        if bool(ctx.get("wakeword") or ctx.get("speech") or ctx.get("owner_present")) and self.cfg.get("write_people", True):
+            out.append({"kind": "people", "name": "owner", "summary": "owner heard nearby", "source": "audio", "confidence": conf, "salience": max(0.78, conf), "tags": ["owner", "heard"], "properties": {"reason": reason, "wakeword": bool(ctx.get("wakeword")), "speech": bool(ctx.get("speech"))}})
+        if bool(ctx.get("wakeword")) and self.cfg.get("write_events", True):
+            out.append({"kind": "events", "name": "wakeword", "summary": "wakeword detected", "source": "audio", "confidence": conf, "salience": 0.86, "tags": ["wakeword", "owner_attention"], "properties": {"reason": reason}})
+        if bool(ctx.get("speech")) and self.cfg.get("write_events", True):
+            out.append({"kind": "events", "name": "speech", "summary": transcript or "speech detected", "source": "audio", "confidence": conf, "salience": 0.82, "tags": ["speech"], "properties": {"reason": reason, "transcript": transcript}})
+        if bool(ctx.get("sound")) and self.cfg.get("write_events", True):
+            out.append({"kind": "events", "name": "sound", "summary": "small sound detected", "source": "audio", "confidence": conf, "salience": 0.65, "tags": ["sound", "curiosity"], "properties": {"reason": reason}})
+        if bool(ctx.get("loud")) and self.cfg.get("write_events", True):
+            out.append({"kind": "events", "name": "loud noise", "summary": "loud noise detected", "source": "audio", "confidence": conf, "salience": 0.94, "tags": ["safety", "loud"], "properties": {"reason": reason}})
+        if bool(ctx.get("silence")) and self.cfg.get("write_low_salience_silence", True):
+            out.append({"kind": "observations", "name": "long quiet period", "summary": "long quiet period", "source": "audio", "confidence": conf, "salience": 0.30, "tags": ["silence"], "properties": {"reason": reason}})
+        return out
+
+    def build(self, source_type: str, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+        st = _clean(source_type).lower().replace("-", "_")
+        if st in {"vision", "vision_context", "camera"}:
+            return self.from_vision(context)
+        if st in {"audio", "audio_context", "sound"}:
+            return self.from_audio(context)
+        return []

--- a/modules/autonomy/services/world_memory_rag.py
+++ b/modules/autonomy/services/world_memory_rag.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+import sqlite3
+import time
+from contextlib import closing
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+_TOKEN_RE = re.compile(r"[\wçğıöşüÇĞİÖŞÜ]+", re.UNICODE)
+
+
+def _tokens(text: str) -> List[str]:
+    return [t.lower() for t in _TOKEN_RE.findall(str(text or "")) if len(t) > 1]
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _json_loads(value: str, default: Any) -> Any:
+    try:
+        return json.loads(value) if value else default
+    except Exception:
+        return default
+
+
+def _clamp(value: Any, default: float, lo: float, hi: float) -> float:
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        v = default
+    return max(lo, min(hi, v))
+
+
+def _clean_id_part(value: Any, default: str = "unknown") -> str:
+    text = str(value or default).strip().lower()
+    text = text.replace(" ", "_")
+    text = re.sub(r"[^a-z0-9_\-çğıöşü]+", "_", text)
+    return text.strip("_") or default
+
+
+class WorldMemoryRAG:
+    """Local semantic world memory and RAG store.
+
+    The store is SQLite-only so it runs on Raspberry Pi without a separate vector
+    database. It uses FTS5 when available and falls back to deterministic token
+    overlap ranking when FTS5 is missing. Observations are merged by stable ids;
+    repeated sightings increase confidence and observation_count instead of
+    blindly creating duplicates.
+    """
+
+    DEFAULTS: Dict[str, Any] = {
+        "enabled": True,
+        "db_path": "data/world_memory.sqlite3",
+        "max_context_items": 8,
+        "default_confidence": 0.55,
+        "observation_ttl_s": 60 * 60 * 24 * 180,
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
+        raw = cfg if isinstance(cfg, dict) else {}
+        self.cfg = dict(self.DEFAULTS)
+        self.cfg.update(raw)
+        self.enabled = bool(self.cfg.get("enabled", True))
+        self.path = Path(str(self.cfg.get("db_path") or self.DEFAULTS["db_path"]))
+        if not self.path.is_absolute():
+            self.path = Path.cwd() / self.path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fts_available = False
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        con = sqlite3.connect(str(self.path), timeout=10.0)
+        con.row_factory = sqlite3.Row
+        return con
+
+    def _init_db(self) -> None:
+        with closing(self._connect()) as con:
+            con.execute("PRAGMA journal_mode=WAL")
+            con.execute("PRAGMA synchronous=NORMAL")
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memories (
+                    id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    details_json TEXT NOT NULL DEFAULT '{}',
+                    source TEXT NOT NULL DEFAULT 'unknown',
+                    confidence REAL NOT NULL DEFAULT 0.5,
+                    salience REAL NOT NULL DEFAULT 0.5,
+                    observation_count INTEGER NOT NULL DEFAULT 1,
+                    first_seen REAL NOT NULL,
+                    last_seen REAL NOT NULL,
+                    location TEXT NOT NULL DEFAULT '',
+                    tags_json TEXT NOT NULL DEFAULT '[]'
+                )
+                """
+            )
+            con.execute("CREATE INDEX IF NOT EXISTS idx_memories_kind ON memories(kind)")
+            con.execute("CREATE INDEX IF NOT EXISTS idx_memories_last_seen ON memories(last_seen DESC)")
+            con.execute("CREATE INDEX IF NOT EXISTS idx_memories_name ON memories(name)")
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS observations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts REAL NOT NULL,
+                    memory_id TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    text TEXT NOT NULL,
+                    details_json TEXT NOT NULL DEFAULT '{}'
+                )
+                """
+            )
+            con.execute("CREATE INDEX IF NOT EXISTS idx_observations_ts ON observations(ts DESC)")
+            try:
+                con.execute(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(id UNINDEXED, kind, name, summary, tags)"
+                )
+                self._fts_available = True
+                self._rebuild_fts(con)
+            except sqlite3.OperationalError:
+                self._fts_available = False
+
+    def _rebuild_fts(self, con: sqlite3.Connection) -> None:
+        if not self._fts_available:
+            return
+        con.execute("DELETE FROM memories_fts")
+        rows = con.execute("SELECT id, kind, name, summary, tags_json FROM memories").fetchall()
+        for row in rows:
+            tags = " ".join(str(x) for x in _json_loads(row["tags_json"], []))
+            con.execute(
+                "INSERT INTO memories_fts(id, kind, name, summary, tags) VALUES (?, ?, ?, ?, ?)",
+                (row["id"], row["kind"], row["name"], row["summary"], tags),
+            )
+
+    @staticmethod
+    def memory_id(kind: str, name: str) -> str:
+        return f"{_clean_id_part(kind, 'fact')}:{_clean_id_part(name, 'unknown')}"[:180]
+
+    def observe(self, payload: Optional[Dict[str, Any]], *, source: str = "api") -> Dict[str, Any]:
+        if not self.enabled:
+            return {"ok": False, "available": False, "reason": "world_memory_rag_disabled"}
+        body = payload if isinstance(payload, dict) else {}
+        kind = str(body.get("kind") or body.get("type") or "observation").strip().lower() or "observation"
+        name = str(body.get("name") or body.get("label") or body.get("title") or kind).strip() or kind
+        summary = str(body.get("summary") or body.get("text") or body.get("description") or name).strip()
+        location = str(body.get("location") or body.get("place") or "").strip()
+        tags = body.get("tags") if isinstance(body.get("tags"), list) else []
+        tags = [str(x).strip().lower() for x in tags if str(x).strip()]
+        confidence = _clamp(body.get("confidence"), float(self.cfg.get("default_confidence", 0.55)), 0.0, 1.0)
+        salience = _clamp(body.get("salience"), max(confidence, 0.45), 0.0, 1.0)
+        details = body.get("details") if isinstance(body.get("details"), dict) else dict(body)
+        now = time.time()
+        memory_id = str(body.get("id") or self.memory_id(kind, name))
+        with closing(self._connect()) as con:
+            old = con.execute("SELECT * FROM memories WHERE id=?", (memory_id,)).fetchone()
+            created = old is None
+            if old is None:
+                con.execute(
+                    """
+                    INSERT INTO memories(id, kind, name, summary, details_json, source, confidence, salience,
+                                         observation_count, first_seen, last_seen, location, tags_json)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+                    """,
+                    (memory_id, kind, name, summary, _json_dumps(details), source, confidence, salience, now, now, location, _json_dumps(tags)),
+                )
+            else:
+                old_count = int(old["observation_count"] or 1)
+                merged_conf = max(float(old["confidence"] or 0.0), confidence)
+                merged_salience = max(float(old["salience"] or 0.0) * 0.98, salience)
+                old_tags = set(_json_loads(old["tags_json"], []))
+                merged_tags = sorted(old_tags.union(tags))[:32]
+                previous_summary = str(old["summary"] or "")
+                final_summary = summary if len(summary) >= len(previous_summary) or confidence >= float(old["confidence"] or 0.0) else previous_summary
+                old_details = _json_loads(old["details_json"], {})
+                if isinstance(old_details, dict):
+                    merged_details = dict(old_details)
+                    merged_details.update(details)
+                else:
+                    merged_details = details
+                con.execute(
+                    """
+                    UPDATE memories
+                    SET summary=?, details_json=?, source=?, confidence=?, salience=?, observation_count=?,
+                        last_seen=?, location=CASE WHEN ? != '' THEN ? ELSE location END, tags_json=?
+                    WHERE id=?
+                    """,
+                    (
+                        final_summary,
+                        _json_dumps(merged_details),
+                        source,
+                        merged_conf,
+                        merged_salience,
+                        old_count + 1,
+                        now,
+                        location,
+                        location,
+                        _json_dumps(merged_tags),
+                        memory_id,
+                    ),
+                )
+            con.execute(
+                "INSERT INTO observations(ts, memory_id, source, text, details_json) VALUES (?, ?, ?, ?, ?)",
+                (now, memory_id, source, summary, _json_dumps(details)),
+            )
+            if self._fts_available:
+                con.execute("DELETE FROM memories_fts WHERE id=?", (memory_id,))
+                row = con.execute("SELECT id, kind, name, summary, tags_json FROM memories WHERE id=?", (memory_id,)).fetchone()
+                if row is not None:
+                    tags_text = " ".join(str(x) for x in _json_loads(row["tags_json"], []))
+                    con.execute(
+                        "INSERT INTO memories_fts(id, kind, name, summary, tags) VALUES (?, ?, ?, ?, ?)",
+                        (row["id"], row["kind"], row["name"], row["summary"], tags_text),
+                    )
+        return {"ok": True, "available": True, "created": created, "id": memory_id, "timestamp": now, "item": self.get(memory_id)}
+
+    def get(self, memory_id: str) -> Dict[str, Any]:
+        with closing(self._connect()) as con:
+            row = con.execute("SELECT * FROM memories WHERE id=?", (str(memory_id),)).fetchone()
+        return self._row_to_item(row) if row is not None else {}
+
+    def recent(self, *, kind: Optional[str] = None, limit: int = 10) -> Dict[str, Any]:
+        limit = max(1, min(100, int(limit or 10)))
+        with closing(self._connect()) as con:
+            if kind:
+                rows = con.execute("SELECT * FROM memories WHERE kind=? ORDER BY last_seen DESC LIMIT ?", (str(kind), limit)).fetchall()
+            else:
+                rows = con.execute("SELECT * FROM memories ORDER BY last_seen DESC LIMIT ?", (limit,)).fetchall()
+        return {"ok": True, "available": True, "items": [self._row_to_item(row) for row in rows]}
+
+    def recall(self, query: str, *, limit: int = 8, kinds: Optional[Sequence[str]] = None) -> Dict[str, Any]:
+        if not self.enabled:
+            return {"ok": False, "available": False, "reason": "world_memory_rag_disabled", "items": []}
+        q = str(query or "").strip()
+        limit = max(1, min(30, int(limit or self.cfg.get("max_context_items", 8))))
+        q_tokens = set(_tokens(q))
+        kind_set = {str(k).strip().lower() for k in kinds or [] if str(k).strip()}
+        rows: List[sqlite3.Row] = []
+        with closing(self._connect()) as con:
+            if q and self._fts_available and q_tokens:
+                try:
+                    fts_query = " OR ".join(sorted(q_tokens))
+                    sql = """
+                        SELECT m.* FROM memories_fts f JOIN memories m ON m.id=f.id
+                        WHERE memories_fts MATCH ?
+                        ORDER BY bm25(memories_fts), m.salience DESC, m.last_seen DESC
+                        LIMIT ?
+                    """
+                    rows = con.execute(sql, (fts_query, limit * 3)).fetchall()
+                except Exception:
+                    rows = []
+            if not rows:
+                rows = con.execute("SELECT * FROM memories ORDER BY salience DESC, last_seen DESC LIMIT ?", (limit * 8,)).fetchall()
+        ranked = []
+        now = time.time()
+        for row in rows:
+            item = self._row_to_item(row)
+            if kind_set and item.get("kind") not in kind_set:
+                continue
+            text = " ".join([str(item.get("kind", "")), str(item.get("name", "")), str(item.get("summary", "")), " ".join(item.get("tags", []))])
+            tks = set(_tokens(text))
+            overlap = len(q_tokens & tks) / max(1, len(q_tokens)) if q_tokens else 0.0
+            age_hours = max(0.0, (now - float(item.get("last_seen", now))) / 3600.0)
+            recency = 1.0 / (1.0 + math.log1p(age_hours))
+            score = 0.50 * overlap + 0.25 * float(item.get("salience", 0.0)) + 0.15 * float(item.get("confidence", 0.0)) + 0.10 * recency
+            item["rank_score"] = round(score, 4)
+            ranked.append(item)
+        ranked.sort(key=lambda item: (float(item.get("rank_score", 0.0)), float(item.get("last_seen", 0.0))), reverse=True)
+        return {"ok": True, "available": True, "query": q, "items": ranked[:limit]}
+
+    def build_context(self, query: str, *, limit: int = 8) -> Dict[str, Any]:
+        recalled = self.recall(query, limit=limit)
+        items = recalled.get("items", []) if isinstance(recalled, dict) else []
+        lines = []
+        for item in items:
+            lines.append(
+                f"- {item.get('kind')}:{item.get('name')} | {item.get('summary')} | "
+                f"confidence={item.get('confidence')} seen={item.get('observation_count')}"
+            )
+        return {"ok": True, "available": True, "query": str(query or ""), "context": "\n".join(lines), "items": items}
+
+    def forget(self, memory_id: str = "", *, kind: str = "") -> Dict[str, Any]:
+        with closing(self._connect()) as con:
+            if memory_id:
+                count = con.execute("DELETE FROM memories WHERE id=?", (memory_id,)).rowcount
+                con.execute("DELETE FROM observations WHERE memory_id=?", (memory_id,))
+                if self._fts_available:
+                    con.execute("DELETE FROM memories_fts WHERE id=?", (memory_id,))
+            elif kind:
+                ids = [row[0] for row in con.execute("SELECT id FROM memories WHERE kind=?", (kind,)).fetchall()]
+                count = len(ids)
+                con.execute("DELETE FROM memories WHERE kind=?", (kind,))
+                for mid in ids:
+                    con.execute("DELETE FROM observations WHERE memory_id=?", (mid,))
+                    if self._fts_available:
+                        con.execute("DELETE FROM memories_fts WHERE id=?", (mid,))
+            else:
+                count = con.execute("DELETE FROM memories").rowcount
+                con.execute("DELETE FROM observations")
+                if self._fts_available:
+                    con.execute("DELETE FROM memories_fts")
+        return {"ok": True, "available": True, "deleted": int(count or 0)}
+
+    def status(self) -> Dict[str, Any]:
+        with closing(self._connect()) as con:
+            total = int(con.execute("SELECT COUNT(*) FROM memories").fetchone()[0])
+            by_kind = {str(row[0]): int(row[1]) for row in con.execute("SELECT kind, COUNT(*) FROM memories GROUP BY kind").fetchall()}
+            observations = int(con.execute("SELECT COUNT(*) FROM observations").fetchone()[0])
+        return {"ok": True, "available": True, "enabled": self.enabled, "db_path": str(self.path), "fts": self._fts_available, "total": total, "observations": observations, "by_kind": by_kind}
+
+    def schema(self) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "available": True,
+            "tables": ["memories", "observations", "memories_fts" if self._fts_available else "fallback_ranker"],
+            "kinds": ["person", "place", "object", "episode", "preference", "fact", "observation", "sound", "decision"],
+            "fields": ["id", "kind", "name", "summary", "confidence", "salience", "source", "location", "tags", "first_seen", "last_seen", "observation_count"],
+        }
+
+    @staticmethod
+    def _row_to_item(row: sqlite3.Row) -> Dict[str, Any]:
+        return {
+            "id": row["id"],
+            "kind": row["kind"],
+            "name": row["name"],
+            "summary": row["summary"],
+            "details": _json_loads(row["details_json"], {}),
+            "source": row["source"],
+            "confidence": round(float(row["confidence"] or 0.0), 3),
+            "salience": round(float(row["salience"] or 0.0), 3),
+            "observation_count": int(row["observation_count"] or 0),
+            "first_seen": float(row["first_seen"] or 0.0),
+            "last_seen": float(row["last_seen"] or 0.0),
+            "location": row["location"],
+            "tags": _json_loads(row["tags_json"], []),
+        }
+
+
+__all__ = ["WorldMemoryRAG"]

--- a/tests/modules/autonomy/test_audio_event_needs_bridge.py
+++ b/tests/modules/autonomy/test_audio_event_needs_bridge.py
@@ -1,0 +1,58 @@
+
+from modules.autonomy.services.audio_event_needs_bridge import AudioEventNeedsBridge
+from modules.autonomy.services.needs_engine import CompanionNeedsEngine
+
+
+def test_audio_bridge_wakeword_sets_owner_context():
+    bridge = AudioEventNeedsBridge({"ttl_s": 60})
+    out = bridge.observe({"wakeword": True, "confidence": 0.9}, now=100.0)
+    assert out["available"] is True
+    assert out["reason"] == "audio.wakeword"
+    ctx = bridge.context(now=101.0)
+    assert ctx["available"] is True
+    assert ctx["owner_present"] is True
+    assert ctx["audio_context"]["wakeword"] is True
+    assert ctx["needs_overrides"]["social"] >= 90
+
+
+def test_audio_bridge_loud_sets_fear_override():
+    bridge = AudioEventNeedsBridge({"ttl_s": 60})
+    bridge.observe({"loud": True}, now=100.0)
+    ctx = bridge.context(now=101.0)
+    assert ctx["audio_context"]["loud"] is True
+    assert ctx["mood_overrides"]["fear"] >= 50
+
+
+def test_audio_bridge_stale_context_is_not_available():
+    bridge = AudioEventNeedsBridge({"ttl_s": 1})
+    bridge.observe({"sound": True}, now=10.0)
+    ctx = bridge.context(now=20.0)
+    assert ctx["available"] is False
+
+
+def test_needs_engine_wakeword_can_select_social_goal():
+    engine = CompanionNeedsEngine({"boredom_threshold_s": 100, "alone_threshold_s": 120})
+    out = engine.tick(
+        now=100.0,
+        last_interaction_ts=98.0,
+        mood_state={"energy": 95, "curiosity": 45},
+        needs_state={"stimulation": 40},
+        scene={"audio_context": {"wakeword": True}},
+    )
+    assert out["reasons"]["audio_context"]["wakeword"] is True
+    assert out["dominant_need"] == "social"
+    assert out["recommended_goal"] == "seek_owner_or_invite_interaction"
+
+
+def test_needs_engine_loud_audio_selects_safety_goal():
+    engine = CompanionNeedsEngine({"boredom_threshold_s": 100})
+    out = engine.tick(
+        now=100.0,
+        last_interaction_ts=98.0,
+        mood_state={"energy": 95, "curiosity": 45},
+        needs_state={"stimulation": 40},
+        scene={"audio_context": {"loud": True}},
+    )
+    assert out["reasons"]["audio_context"]["loud"] is True
+    assert out["dominant_need"] == "safety"
+    assert out["recommended_goal"] == "pause_and_observe"

--- a/tests/modules/autonomy/test_companion_auto_execute_gate.py
+++ b/tests/modules/autonomy/test_companion_auto_execute_gate.py
@@ -1,0 +1,56 @@
+from modules.autonomy.services.companion_auto_execute_gate import CompanionAutoExecuteGate
+
+
+def plan(auto=True, risk="low", priority="normal"):
+    return {
+        "plan_id": "boredom:choose_idle_activity:stretch_or_scan",
+        "dominant_need": "boredom",
+        "recommended_goal": "choose_idle_activity",
+        "behavior": "choose_idle_activity",
+        "priority": priority,
+        "safe_to_execute": True,
+        "auto_execute": auto,
+        "actions": [
+            {"type": "expression", "event": "needs.boredom", "risk": "none"},
+            {"type": "motion", "name": "stretch_or_scan", "risk": risk},
+        ],
+    }
+
+
+def test_gate_requires_auto_execute_flag_by_default():
+    gate = CompanionAutoExecuteGate()
+    out = gate.decide(plan(auto=False), dry_run=True, now=100.0)
+    assert out["should_execute"] is False
+    assert out["reason"] == "auto_execute_false"
+
+
+def test_gate_force_allows_manual_dry_run():
+    gate = CompanionAutoExecuteGate()
+    out = gate.decide(plan(auto=False), dry_run=True, force=True, now=100.0)
+    assert out["should_execute"] is True
+    assert out["dry_run"] is True
+    assert out["reason"] == "force_dry_run"
+
+
+def test_gate_blocks_high_risk_action():
+    gate = CompanionAutoExecuteGate()
+    out = gate.decide(plan(auto=True, risk="medium"), dry_run=True, now=100.0)
+    assert out["should_execute"] is False
+    assert out["reason"] == "risk_blocked:medium"
+
+
+def test_gate_forces_dry_run_on_pc_when_real_execution_requested():
+    gate = CompanionAutoExecuteGate({"dry_run_default": False, "allow_real_hardware": True})
+    out = gate.decide(plan(auto=True), dry_run=False, pc_test=True, now=100.0)
+    assert out["should_execute"] is True
+    assert out["dry_run"] is True
+    assert out["pc_real_execution_blocked"] is True
+
+
+def test_gate_applies_cooldown_for_same_plan():
+    gate = CompanionAutoExecuteGate({"min_interval_s": 30})
+    first = gate.decide(plan(auto=True), dry_run=True, now=100.0)
+    second = gate.decide(plan(auto=True), dry_run=True, now=110.0)
+    assert first["should_execute"] is True
+    assert second["should_execute"] is False
+    assert second["reason"] == "cooldown"

--- a/tests/modules/autonomy/test_companion_behavior_loop.py
+++ b/tests/modules/autonomy/test_companion_behavior_loop.py
@@ -1,0 +1,50 @@
+from modules.autonomy.services.companion_behavior_loop import CompanionBehaviorLoop
+
+
+def goal(plan_id="p1", priority="normal"):
+    return {
+        "plan_id": plan_id,
+        "dominant_need": "exploration",
+        "recommended_goal": "look_around_and_learn",
+        "behavior": "look_around_and_learn",
+        "priority": priority,
+        "actions": [{"type": "expression", "event": "needs.exploration"}],
+    }
+
+
+def needs(idle=30):
+    return {"idle_s": idle, "dominant_need": "exploration", "recommended_goal": "look_around_and_learn"}
+
+
+def test_behavior_loop_allows_pc_dry_run_tick_after_idle():
+    loop = CompanionBehaviorLoop({"interval_s": 10, "min_idle_s": 5, "dry_run": True, "force_dry_run": True})
+    out = loop.decide(needs=needs(12), goal=goal(), now=100.0)
+    assert out["should_tick"] is True
+    assert out["dry_run"] is True
+    assert out["gate_force"] is True
+    assert out["reason"] == "force_dry_run"
+
+
+def test_behavior_loop_blocks_fresh_idle_without_force():
+    loop = CompanionBehaviorLoop({"interval_s": 10, "min_idle_s": 20})
+    out = loop.decide(needs=needs(3), goal=goal(), now=100.0)
+    assert out["should_tick"] is False
+    assert out["reason"] == "idle_too_fresh"
+
+
+def test_behavior_loop_cooldown():
+    loop = CompanionBehaviorLoop({"interval_s": 30, "min_idle_s": 0})
+    first = loop.decide(needs=needs(50), goal=goal(), now=100.0)
+    second = loop.decide(needs=needs(55), goal=goal(), now=110.0)
+    assert first["should_tick"] is True
+    assert second["should_tick"] is False
+    assert second["reason"] == "cooldown"
+
+
+def test_behavior_loop_mark_execution():
+    loop = CompanionBehaviorLoop({"interval_s": 10, "min_idle_s": 0})
+    decision = loop.decide(needs=needs(50), goal=goal(), now=100.0)
+    result = loop.mark_execution(decision, {"available": True, "applied": False, "reason": "dry_run"})
+    assert result["executed"] is True
+    assert result["applied"] is False
+    assert result["execution_reason"] == "dry_run"

--- a/tests/modules/autonomy/test_companion_goal_executor.py
+++ b/tests/modules/autonomy/test_companion_goal_executor.py
@@ -1,0 +1,53 @@
+from modules.autonomy.services.companion_goal_executor import CompanionGoalExecutor
+
+
+def sample_plan():
+    return {
+        "ok": True,
+        "plan_id": "exploration:look_around:look_around_and_learn",
+        "dominant_need": "exploration",
+        "recommended_goal": "look_around_and_learn",
+        "behavior": "look_around_and_learn",
+        "priority": "normal",
+        "safe_to_execute": True,
+        "auto_execute": False,
+        "actions": [
+            {"type": "expression", "event": "needs.exploration"},
+            {"type": "vision", "mode": "cheap", "reason": "exploration"},
+            {"type": "motion", "name": "look_around", "risk": "low"},
+        ],
+    }
+
+
+def test_executor_dry_run_builds_steps_without_applying():
+    ex = CompanionGoalExecutor({"enabled": True, "dry_run_default": True})
+    result = ex.execute(sample_plan(), dry_run=True, pc_test=True, now=100.0)
+    assert result["ok"] is True
+    assert result["applied"] is False
+    assert result["dry_run"] is True
+    assert result["step_count"] == 3
+    assert result["steps"][0]["component"] == "expression"
+    assert result["steps"][1]["component"] == "vlm_bridge"
+    assert result["steps"][2]["url"] == "/piservo/gesture?name=look_around"
+
+
+def test_executor_blocks_real_execution_on_pc():
+    ex = CompanionGoalExecutor({"enabled": True, "dry_run_default": False, "allow_real_hardware": True})
+    result = ex.execute(sample_plan(), dry_run=False, pc_test=True, now=100.0)
+    assert result["applied"] is False
+    assert result["dry_run"] is True
+    assert result["reason"] == "pc_real_execution_blocked"
+
+
+def test_executor_blocks_real_execution_without_hardware_permission():
+    ex = CompanionGoalExecutor({"enabled": True, "dry_run_default": False, "allow_real_hardware": False})
+    result = ex.execute(sample_plan(), dry_run=False, pc_test=False, now=100.0)
+    assert result["applied"] is False
+    assert result["reason"] == "real_hardware_not_allowed"
+
+
+def test_executor_wait_action_is_noop():
+    ex = CompanionGoalExecutor()
+    result = ex.execute({"actions": [{"type": "wait", "label": "calm_idle"}]}, dry_run=True)
+    assert result["steps"][0]["component"] == "scheduler"
+    assert result["steps"][0]["risk"] == "none"

--- a/tests/modules/autonomy/test_companion_goal_executor_semantic_noop.py
+++ b/tests/modules/autonomy/test_companion_goal_executor_semantic_noop.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from modules.autonomy.services.companion_goal_executor import (
+    AUTONOMY_SEMANTIC_NOOP_CONTRACT,
+    AUTONOMY_SEMANTIC_NOOP_ROLE,
+    CompanionGoalExecutor,
+)
+
+
+def test_wait_action_is_explicit_safe_semantic_noop_step():
+    executor = CompanionGoalExecutor({"dry_run_default": True})
+    result = executor.execute(
+        {
+            "plan_id": "p1",
+            "safe_to_execute": True,
+            "actions": [{"type": "wait", "label": "calm_idle"}],
+        },
+        dry_run=True,
+        pc_test=True,
+        now=1.0,
+    )
+    assert AUTONOMY_SEMANTIC_NOOP_CONTRACT is True
+    assert AUTONOMY_SEMANTIC_NOOP_ROLE == "safe_semantic_passive_goal_step"
+    assert result["applied"] is False
+    assert result["dry_run"] is True
+    assert result["steps"][0]["component"] == "scheduler"
+    assert result["steps"][0]["method"] == "NOOP"
+    assert result["steps"][0]["url"] == "noop:wait"
+    assert result["steps"][0]["risk"] == "none"
+
+
+def test_unknown_action_becomes_safe_noop_not_raw_hardware_command():
+    executor = CompanionGoalExecutor({"dry_run_default": True})
+    result = executor.execute(
+        {
+            "plan_id": "p2",
+            "safe_to_execute": True,
+            "actions": [{"type": "dance", "risk": "unknown"}],
+        },
+        dry_run=True,
+        pc_test=True,
+        now=2.0,
+    )
+    step = result["steps"][0]
+    assert step["component"] == "unknown"
+    assert step["method"] == "NOOP"
+    assert step["url"] == "noop:unknown_action"
+    assert step["payload"] == {"type": "dance", "risk": "unknown"}

--- a/tests/modules/autonomy/test_companion_goal_selector.py
+++ b/tests/modules/autonomy/test_companion_goal_selector.py
@@ -1,0 +1,38 @@
+from modules.autonomy.services.companion_goal_selector import CompanionGoalSelector
+
+
+def test_goal_selector_maps_exploration_to_safe_plan():
+    selector = CompanionGoalSelector({"event_cooldown_s": 10})
+    plan = selector.select(
+        {
+            "dominant_need": "exploration",
+            "recommended_goal": "look_around_and_learn",
+            "confidence": 0.8,
+            "scores": {"exploration": 82, "energy": 90},
+        },
+        pc_test=True,
+        now=100.0,
+    )
+    assert plan["ok"] is True
+    assert plan["behavior"] == "look_around_and_learn"
+    assert plan["expression_event"] == "needs.exploration"
+    assert plan["auto_execute"] is False
+    assert any(a["type"] == "vision" for a in plan["actions"])
+
+
+def test_goal_selector_event_cooldown():
+    selector = CompanionGoalSelector({"event_cooldown_s": 10})
+    first = selector.select({"dominant_need": "curiosity", "recommended_goal": "inspect_environment"}, now=100.0)
+    second = selector.select({"dominant_need": "curiosity", "recommended_goal": "inspect_environment"}, now=105.0)
+    third = selector.select({"dominant_need": "curiosity", "recommended_goal": "inspect_environment"}, now=111.0)
+    assert first["event"] == "goal.curiosity"
+    assert second["event"] == ""
+    assert third["event"] == "goal.curiosity"
+
+
+def test_goal_selector_safety_is_critical():
+    selector = CompanionGoalSelector()
+    plan = selector.select({"dominant_need": "safety", "recommended_goal": "pause_and_observe", "confidence": 0.9})
+    assert plan["priority"] == "critical"
+    assert plan["safe_to_execute"] is True
+    assert plan["expression_event"] == "needs.safety"

--- a/tests/modules/autonomy/test_companion_llm_unavailable_fallback.py
+++ b/tests/modules/autonomy/test_companion_llm_unavailable_fallback.py
@@ -1,0 +1,22 @@
+from modules.autonomy.services.companion_lines import CompanionLineGenerator
+
+
+class UnavailableClient:
+    def __init__(self):
+        self.calls = 0
+
+    def chat(self, *args, **kwargs):
+        self.calls += 1
+        return {"ok": False, "error": "llm_model_unavailable"}
+
+
+def test_companion_line_uses_template_when_llm_unavailable_and_cools_down():
+    client = UnavailableClient()
+    gen = CompanionLineGenerator(client, {"use_llm": True, "llm_cooldown_s": 100, "default_language": "tr"})
+
+    first = gen.generate("proactive", dominant_emotion="neutral", needs={"stimulation": 80})
+    second = gen.generate("proactive", dominant_emotion="neutral", needs={"stimulation": 80})
+
+    assert first
+    assert second
+    assert client.calls == 1

--- a/tests/modules/autonomy/test_companion_needs_engine.py
+++ b/tests/modules/autonomy/test_companion_needs_engine.py
@@ -1,0 +1,54 @@
+from modules.autonomy.services.needs_engine import CompanionNeedsEngine
+
+
+def test_needs_engine_detects_boredom_and_exploration():
+    engine = CompanionNeedsEngine({"boredom_threshold_s": 10, "alone_threshold_s": 60})
+    snap = engine.tick(
+        now=100.0,
+        last_interaction_ts=80.0,
+        mood_state={"energy": 90, "curiosity": 80, "fear": 0},
+        needs_state={"social": 30, "stimulation": 70, "rest": 80},
+        owner_present=False,
+        pc_test=True,
+    )
+    assert snap["ok"] is True
+    assert snap["scores"]["boredom"] == 100.0
+    assert snap["dominant_need"] in {"exploration", "boredom", "curiosity"}
+    assert snap["recommended_goal"] in {"look_around_and_learn", "choose_idle_activity", "inspect_environment"}
+    assert snap["event"].startswith("needs.")
+
+
+def test_needs_engine_safety_wins_over_curiosity():
+    engine = CompanionNeedsEngine({"boredom_threshold_s": 10})
+    snap = engine.tick(
+        now=200.0,
+        last_interaction_ts=100.0,
+        mood_state={"energy": 90, "curiosity": 95, "fear": 80},
+        needs_state={"social": 80, "stimulation": 90, "rest": 80},
+        scene={"hazards": ["edge"]},
+        pc_test=False,
+    )
+    assert snap["dominant_need"] == "safety"
+    assert snap["recommended_goal"] == "pause_and_observe"
+
+
+def test_needs_engine_interaction_reduces_social_need_when_owner_present():
+    engine = CompanionNeedsEngine({"alone_threshold_s": 60})
+    engine.observe_interaction("speech")
+    snap = engine.tick(
+        now=20.0,
+        last_interaction_ts=10.0,
+        mood_state={"energy": 75, "curiosity": 45, "fear": 0},
+        needs_state={"social": 10, "stimulation": 20, "rest": 80},
+        owner_present=True,
+        pc_test=True,
+    )
+    assert snap["scores"]["social"] < 15
+    assert snap["reasons"]["last_interaction_source"] == "speech"
+
+
+def test_needs_engine_snapshot_before_tick_is_safe():
+    engine = CompanionNeedsEngine()
+    snap = engine.snapshot()
+    assert snap["ok"] is True
+    assert snap["available"] is False

--- a/tests/modules/autonomy/test_memory_decision_shadow.py
+++ b/tests/modules/autonomy/test_memory_decision_shadow.py
@@ -1,0 +1,32 @@
+from modules.autonomy.services.memory_decision_shadow import MemoryDecisionShadow
+
+
+def eval_one(item):
+    return MemoryDecisionShadow().evaluate({"total": 1, "recent": [item]}, [item], now=100.0)
+
+
+def test_safety_has_highest_priority():
+    result = eval_one({"kind": "events", "name": "hazard", "summary": "obstacle close", "tags": ["safety"], "confidence": 0.8, "salience": 0.9, "last_seen_ts": 99.0})
+    assert result["available"] is True
+    assert result["recommended_need"] == "safety"
+    assert result["recommended_goal"] == "pause_and_observe"
+    assert result["priority"] == "critical"
+    assert result["apply_to_needs"] is False
+
+
+def test_owner_memory_suggests_social_shadow():
+    result = eval_one({"kind": "people", "name": "owner", "summary": "owner heard nearby", "tags": ["owner"], "confidence": 0.8, "last_seen_ts": 99.0})
+    assert result["recommended_need"] == "social"
+    assert result["recommended_goal"] == "seek_owner_or_invite_interaction"
+
+
+def test_object_memory_suggests_exploration_shadow():
+    result = eval_one({"kind": "objects", "name": "unknown object", "summary": "new object on desk", "tags": ["novel"], "confidence": 0.75, "last_seen_ts": 99.0})
+    assert result["recommended_need"] == "exploration"
+    assert result["recommended_goal"] == "look_around_and_learn"
+
+
+def test_quiet_memory_suggests_balance_shadow():
+    result = eval_one({"kind": "observations", "name": "stable quiet room", "summary": "stable quiet room", "tags": ["stable"], "confidence": 0.6, "last_seen_ts": 99.0})
+    assert result["recommended_need"] == "balance"
+    assert result["recommended_goal"] == "calm_idle"

--- a/tests/modules/autonomy/test_memory_needs_bias.py
+++ b/tests/modules/autonomy/test_memory_needs_bias.py
@@ -1,0 +1,56 @@
+from modules.autonomy.services.memory_needs_bias import MemoryNeedsBias
+
+
+def base_needs(**scores):
+    merged = {
+        "social": 40.0,
+        "curiosity": 40.0,
+        "boredom": 20.0,
+        "energy": 95.0,
+        "rest": 5.0,
+        "safety": 100.0,
+        "owner_proximity": 0.0,
+        "exploration": 40.0,
+    }
+    merged.update(scores)
+    return {"ok": True, "dominant_need": "balance", "recommended_goal": "calm_idle", "confidence": 0.55, "scores": merged, "reasons": {}}
+
+
+def shadow(need, goal, priority="normal", confidence=0.90):
+    return {"ok": True, "available": True, "recommended_need": need, "recommended_goal": goal, "priority": priority, "confidence": confidence, "top_item": {"name": need}}
+
+
+def test_social_memory_can_bias_near_threshold_need():
+    out = MemoryNeedsBias().apply(base_needs(social=56.0), shadow("social", "seek_owner_or_invite_interaction"), now=10.0)
+    assert out["memory_bias"]["applied"] is True
+    assert out["dominant_need"] == "social"
+    assert out["recommended_goal"] == "seek_owner_or_invite_interaction"
+
+
+def test_object_memory_can_bias_exploration_near_threshold():
+    out = MemoryNeedsBias().apply(base_needs(exploration=55.0), shadow("exploration", "look_around_and_learn", confidence=0.85), now=10.0)
+    assert out["memory_bias"]["applied"] is True
+    assert out["dominant_need"] == "exploration"
+    assert out["recommended_goal"] == "look_around_and_learn"
+
+
+def test_hazard_memory_uses_guarded_safety_override():
+    out = MemoryNeedsBias().apply(base_needs(), shadow("safety", "pause_and_observe", priority="critical", confidence=0.93), now=10.0)
+    assert out["memory_bias"]["applied"] is True
+    assert out["scores"]["safety"] <= 45.0
+    assert out["dominant_need"] == "safety"
+    assert out["recommended_goal"] == "pause_and_observe"
+
+
+def test_low_confidence_memory_is_not_applied():
+    out = MemoryNeedsBias().apply(base_needs(social=56.0), shadow("social", "seek_owner_or_invite_interaction", confidence=0.30), now=10.0)
+    assert out["memory_bias"]["applied"] is False
+    assert out["memory_bias"]["reason"] == "memory_confidence_low"
+    assert out["dominant_need"] == "balance"
+
+
+def test_balance_memory_is_annotation_only():
+    out = MemoryNeedsBias().apply(base_needs(), shadow("balance", "calm_idle", priority="low", confidence=0.8), now=10.0)
+    assert out["memory_bias"]["applied"] is False
+    assert out["memory_bias"]["reason"] == "balance_annotate_only"
+    assert out["dominant_need"] == "balance"

--- a/tests/modules/autonomy/test_memory_recency_decay.py
+++ b/tests/modules/autonomy/test_memory_recency_decay.py
@@ -1,0 +1,62 @@
+from modules.autonomy.services.memory_decision_shadow import MemoryDecisionShadow
+
+NOW = 1000.0
+
+
+def item(kind, name, summary, tags=None, last_seen_ts=None, confidence=0.85, salience=0.85, source="probe"):
+    return {
+        "kind": kind,
+        "name": name,
+        "summary": summary,
+        "tags": tags or [],
+        "confidence": confidence,
+        "salience": salience,
+        "source": source,
+        "last_seen_ts": last_seen_ts,
+    }
+
+
+def eval_items(*items):
+    return MemoryDecisionShadow().evaluate({"total": len(items), "recent": list(items)}, list(items), now=NOW)
+
+
+def test_fresh_hazard_can_influence_safety():
+    result = eval_items(item("events", "hazard", "possible obstacle", ["safety"], NOW - 5))
+    assert result["available"] is True
+    assert result["recommended_need"] == "safety"
+    assert result["priority"] == "critical"
+    assert result["stale_count"] == 0
+
+
+def test_stale_hazard_does_not_lock_safety():
+    result = eval_items(item("events", "hazard", "possible obstacle", ["safety"], NOW - 120))
+    assert result["available"] is False
+    assert result["reason"] == "memory_hints_stale"
+    assert result["stale_count"] == 1
+    assert result["stale"][0]["need"] == "safety"
+
+
+def test_fresh_object_can_influence_exploration():
+    result = eval_items(item("objects", "unknown object", "new object on desk", ["novel"], NOW - 30, confidence=0.75))
+    assert result["available"] is True
+    assert result["recommended_need"] == "exploration"
+    assert result["recommended_goal"] == "look_around_and_learn"
+
+
+def test_stale_object_is_ignored_after_age_limit():
+    result = eval_items(item("objects", "unknown object", "new object on desk", ["novel"], NOW - 400, confidence=0.75))
+    assert result["available"] is False
+    assert result["reason"] == "memory_hints_stale"
+    assert result["stale_count"] == 1
+
+
+def test_quiet_memory_has_longer_balance_window():
+    result = eval_items(item("observations", "stable quiet room", "stable quiet room", ["stable"], NOW - 300, confidence=0.65))
+    assert result["available"] is True
+    assert result["recommended_need"] == "balance"
+
+
+def test_very_old_quiet_memory_is_stale():
+    result = eval_items(item("observations", "stable quiet room", "stable quiet room", ["stable"], NOW - 900, confidence=0.65))
+    assert result["available"] is False
+    assert result["stale_count"] == 1

--- a/tests/modules/autonomy/test_pet_companion_core.py
+++ b/tests/modules/autonomy/test_pet_companion_core.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from modules.autonomy.services.pet_companion_core import (
+    PET_COMPANION_CORE_CONTRACT,
+    PET_COMPANION_CORE_HARDWARE_SAFE,
+    PET_COMPANION_CORE_ROLE,
+    DEFAULT_PROFILE,
+    PetCompanionCore,
+    PersonalityProfile,
+    decide_pet_companion_behavior,
+    load_personality_profile,
+)
+
+
+def test_pet_companion_core_contract_markers():
+    assert PET_COMPANION_CORE_CONTRACT is True
+    assert PET_COMPANION_CORE_ROLE == "personality_bond_routine_to_semantic_pet_behavior"
+    assert PET_COMPANION_CORE_HARDWARE_SAFE is True
+
+
+def test_owner_presence_and_bond_produces_attend_owner_intent():
+    core = PetCompanionCore()
+    decision = core.decide(
+        {
+            "needs": {"social": 0.7, "curiosity": 0.1, "boredom": 0.1, "safety": 0.0},
+            "bond": {"trust": 0.8, "affection": 0.9},
+            "routine": {"energy": 0.8},
+            "perception": {"owner_present": True},
+        }
+    ).as_dict()
+
+    assert decision["intent"] == "attend_owner"
+    assert "orient_to_owner" in decision["goal_hints"]
+    assert decision["safety"]["hardware_enabled"] is False
+    assert decision["status_only"] is True
+
+
+def test_safety_need_overrides_pet_curiosity():
+    core = PetCompanionCore()
+    decision = core.decide(
+        {
+            "needs": {"safety": 0.8, "curiosity": 1.0, "boredom": 1.0, "social": 0.9},
+            "routine": {"energy": 1.0},
+            "perception": {"owner_present": True},
+        }
+    ).as_dict()
+
+    assert decision["intent"] == "safe_observe"
+    assert "avoid_motion_until_clear" in decision["goal_hints"]
+    assert decision["safety"]["motion_started"] is False
+
+
+def test_low_energy_produces_rest_nearby_intent():
+    core = PetCompanionCore()
+    decision = core.decide(
+        {
+            "needs": {"social": 0.4, "curiosity": 0.4, "boredom": 0.4, "safety": 0.0},
+            "routine": {"energy": 0.1},
+            "perception": {"owner_present": True},
+        }
+    ).as_dict()
+
+    assert decision["intent"] == "rest_nearby"
+    assert "rest" in decision["goal_hints"]
+    assert decision["needs_bias"]["energy_recovery"] == 0.5
+
+
+def test_curiosity_or_boredom_produces_alive_behavior():
+    profile = PersonalityProfile.from_mapping(
+        {
+            **DEFAULT_PROFILE,
+            "traits": {**DEFAULT_PROFILE["traits"], "sociability": 0.2, "curiosity": 1.0},
+        }
+    )
+    core = PetCompanionCore(profile)
+    decision = core.decide(
+        {
+            "needs": {"social": 0.0, "curiosity": 0.8, "boredom": 0.5, "safety": 0.0},
+            "routine": {"energy": 0.9},
+            "perception": {"owner_present": False},
+        }
+    ).as_dict()
+
+    assert decision["intent"] in {"curious_inspect", "playful_ping"}
+    assert decision["safety"]["camera_started"] is False
+    assert decision["safety"]["vlm_started"] is False
+
+
+def test_load_profile_from_config_file(tmp_path):
+    path = tmp_path / "profile.json"
+    path.write_text(
+        json.dumps(
+            {
+                "name": "testbot",
+                "traits": {"curiosity": 0.1, "sociability": 0.9},
+                "style": {"speech": "quiet", "motion": "slow", "expression": "soft"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    profile = load_personality_profile(path)
+    assert profile.name == "testbot"
+    assert profile.curiosity == 0.1
+    assert profile.sociability == 0.9
+    assert profile.speech_style == "quiet"
+
+
+def test_public_decide_helper_returns_semantic_safe_decision():
+    decision = decide_pet_companion_behavior(
+        {
+            "needs": {"social": 0.6},
+            "bond": {"trust": 0.6, "affection": 0.6},
+            "routine": {"energy": 0.7},
+            "perception": {"owner_present": True},
+        }
+    )
+
+    assert isinstance(decision["intent"], str)
+    assert decision["safety"]["hardware_enabled"] is False
+    assert decision["safety"]["semantic_only"] is True

--- a/tests/modules/autonomy/test_pet_companion_goal_selector_integration.py
+++ b/tests/modules/autonomy/test_pet_companion_goal_selector_integration.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from modules.autonomy.services.companion_behavior_loop import (
+    PET_COMPANION_BEHAVIOR_LOOP_INTEGRATION_CONTRACT,
+    CompanionBehaviorLoop,
+)
+from modules.autonomy.services.companion_goal_selector import (
+    PET_COMPANION_GOAL_SELECTOR_INTEGRATION_CONTRACT,
+    CompanionGoalSelector,
+)
+
+
+def test_goal_selector_exports_pet_companion_integration_marker():
+    assert PET_COMPANION_GOAL_SELECTOR_INTEGRATION_CONTRACT is True
+
+
+def test_goal_selector_adds_pet_companion_side_channel_without_breaking_existing_behavior():
+    selector = CompanionGoalSelector({"event_cooldown_s": 0.0})
+    plan = selector.select(
+        {
+            "dominant_need": "social",
+            "recommended_goal": "engage_owner",
+            "confidence": 0.8,
+            "scores": {"social": 0.8, "curiosity": 0.1, "boredom": 0.1, "safety": 0.0},
+        },
+        owner_present=True,
+        now=10.0,
+    )
+
+    assert plan["behavior"] == "engage_owner"
+    assert plan["pet_intent"] == "attend_owner"
+    assert plan["pet_companion"]["intent"] == "attend_owner"
+    assert plan["pet_companion"]["safety"]["hardware_enabled"] is False
+    assert any(action.get("type") == "pet_intent" for action in plan["actions"])
+
+
+def test_goal_selector_safety_context_produces_pet_safe_observe():
+    selector = CompanionGoalSelector({"event_cooldown_s": 0.0})
+    plan = selector.select(
+        {
+            "dominant_need": "safety",
+            "recommended_goal": "pause",
+            "confidence": 0.9,
+            "scores": {"safety": 0.9, "social": 0.9, "curiosity": 0.9},
+        },
+        owner_present=True,
+        now=11.0,
+    )
+
+    assert plan["priority"] == "critical"
+    assert plan["pet_intent"] == "safe_observe"
+    assert "prefer_safe_observation" in plan["pet_companion"]["goal_hints"]
+    assert plan["pet_companion"]["safety"]["motion_started"] is False
+
+
+def test_goal_selector_can_disable_pet_companion_integration():
+    selector = CompanionGoalSelector({"pet_companion_enabled": False})
+    plan = selector.select(
+        {
+            "dominant_need": "social",
+            "recommended_goal": "engage_owner",
+            "scores": {"social": 0.8},
+        },
+        owner_present=True,
+        now=12.0,
+    )
+
+    assert plan["pet_companion"] == {}
+    assert plan["pet_intent"] == ""
+
+
+def test_behavior_loop_carries_pet_intent_and_hints():
+    assert PET_COMPANION_BEHAVIOR_LOOP_INTEGRATION_CONTRACT is True
+
+    loop = CompanionBehaviorLoop({"interval_s": 1.0, "min_idle_s": 0.0})
+    decision = loop.decide(
+        needs={"idle_s": 99.0},
+        goal={
+            "plan_id": "social:engage",
+            "priority": "normal",
+            "behavior": "engage_owner",
+            "pet_intent": "attend_owner",
+            "pet_companion": {
+                "intent": "attend_owner",
+                "expression_hint": "happy_attentive",
+                "motion_hint": "orient_to_owner",
+                "speech_hint": "short_warm",
+            },
+        },
+        now=100.0,
+        force=True,
+    )
+
+    assert decision["should_tick"] is True
+    assert decision["pet_intent"] == "attend_owner"
+    assert decision["pet_expression_hint"] == "happy_attentive"
+    assert decision["pet_motion_hint"] == "orient_to_owner"
+    assert decision["pet_speech_hint"] == "short_warm"

--- a/tests/modules/autonomy/test_pet_output_planner_integration.py
+++ b/tests/modules/autonomy/test_pet_output_planner_integration.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from modules.autonomy.services.companion_behavior_loop import (
+    PET_OUTPUT_PLANNER_BEHAVIOR_LOOP_INTEGRATION_CONTRACT,
+    CompanionBehaviorLoop,
+)
+from modules.autonomy.services.pet_output_planner import (
+    PET_OUTPUT_PLANNER_CONTRACT,
+    PET_OUTPUT_PLANNER_HARDWARE_SAFE,
+    PET_OUTPUT_PLANNER_ROLE,
+    build_pet_output_plan,
+)
+
+
+def test_pet_output_planner_contract_markers():
+    assert PET_OUTPUT_PLANNER_CONTRACT is True
+    assert PET_OUTPUT_PLANNER_ROLE == "pet_intent_to_expression_motion_speech_semantic_plan"
+    assert PET_OUTPUT_PLANNER_HARDWARE_SAFE is True
+
+
+def test_attend_owner_maps_to_expression_motion_speech_semantics():
+    plan = build_pet_output_plan(
+        {
+            "intent": "attend_owner",
+            "expression_hint": "happy_attentive",
+            "motion_hint": "orient_to_owner",
+            "speech_hint": "short_warm",
+        }
+    )
+
+    assert plan["intent"] == "attend_owner"
+    assert plan["expression"]["name"] == "happy_attentive"
+    assert plan["motion"]["name"] == "orient_to_owner"
+    assert plan["speech"]["style"] == "short_warm"
+    assert plan["speech"]["utterance"] == "BuradayÄ±m."
+    assert plan["semantic_only"] is True
+    assert plan["safety"]["hardware_enabled"] is False
+
+
+def test_safe_observe_remains_low_amplitude_and_silent_safe():
+    plan = build_pet_output_plan({"intent": "safe_observe"})
+
+    assert plan["expression"]["name"] == "alert_soft"
+    assert plan["motion"]["amplitude"] <= 0.05
+    assert plan["motion"]["requires_arm_gate"] is True
+    assert plan["safety"]["motion_started"] is False
+    assert plan["safety"]["camera_started"] is False
+
+
+def test_behavior_loop_builds_pet_output_plan_from_pet_companion():
+    assert PET_OUTPUT_PLANNER_BEHAVIOR_LOOP_INTEGRATION_CONTRACT is True
+
+    loop = CompanionBehaviorLoop({"interval_s": 1.0, "min_idle_s": 0.0})
+    decision = loop.decide(
+        needs={"idle_s": 99.0},
+        goal={
+            "plan_id": "social:engage",
+            "priority": "normal",
+            "behavior": "engage_owner",
+            "pet_intent": "attend_owner",
+            "pet_companion": {
+                "intent": "attend_owner",
+                "expression_hint": "happy_attentive",
+                "motion_hint": "orient_to_owner",
+                "speech_hint": "short_warm",
+            },
+        },
+        now=100.0,
+        force=True,
+    )
+
+    assert decision["should_tick"] is True
+    assert decision["pet_output_plan"]["intent"] == "attend_owner"
+    assert decision["pet_output_plan"]["expression"]["name"] == "happy_attentive"
+    assert decision["pet_expression_command"]["name"] == "happy_attentive"
+    assert decision["pet_motion_command"]["name"] == "orient_to_owner"
+    assert decision["pet_speech_command"]["style"] == "short_warm"
+    assert decision["pet_output_plan"]["safety"]["hardware_enabled"] is False
+
+
+def test_pet_output_plan_defaults_for_calm_idle():
+    plan = build_pet_output_plan({})
+
+    assert plan["intent"] == "calm_idle"
+    assert plan["expression"]["name"] == "calm_alive"
+    assert plan["motion"]["name"] == "breathing_idle"
+    assert plan["speech"]["style"] == "silent"
+    assert plan["speech"]["utterance"] == ""

--- a/tests/modules/autonomy/test_robot_capability_map_contract.py
+++ b/tests/modules/autonomy/test_robot_capability_map_contract.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from modules.autonomy.services import robot_capability_map as capmap
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_capability_map_contract_markers():
+    assert capmap.ROBOT_CAPABILITY_SOURCE_OF_TRUTH is True
+    assert capmap.ROBOT_CAPABILITY_BOUNDARY_ROLE == "autonomy_read_only_capability_registry_adapter"
+    assert capmap.ROBOT_CAPABILITY_CONFIG_PATH == "config/robot_capability_registry.json"
+
+
+def test_capability_registry_file_exists_and_loads():
+    path = capmap.registry_path(ROOT)
+    assert path.exists(), path
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(raw, dict)
+
+    registry = capmap.load_registry(ROOT)
+    assert registry["ok"] is True
+    assert registry["available"] is True
+    assert registry["source"] == "config/robot_capability_registry.json"
+
+
+def test_capability_status_is_read_only_and_safe():
+    st = capmap.status(ROOT)
+    assert st["read_only"] is True
+    assert st["hardware_enabled"] is False
+    assert st["armed"] is False
+    assert isinstance(st["capabilities"], list)
+    assert st["capability_count"] == len(st["capabilities"])
+
+
+def test_capability_lookup_contract():
+    names = capmap.list_capabilities(ROOT)
+    assert isinstance(names, list)
+
+    if names:
+        item = capmap.get_capability(names[0], ROOT)
+        assert item["name"] == names[0]
+        assert item["available"] is True
+
+    missing = capmap.get_capability("__missing_capability__", ROOT)
+    assert missing["available"] is False
+    assert missing["reason"] == "capability_not_found"

--- a/tests/modules/autonomy/test_robot_runtime_profile.py
+++ b/tests/modules/autonomy/test_robot_runtime_profile.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from modules.autonomy.services import robot_runtime_profile as profile
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_pi_runtime_profile_contract_markers():
+    assert profile.PI_RUNTIME_PROFILE_CONTRACT is True
+    assert profile.PI_RUNTIME_PROFILE_BOUNDARY_ROLE == "pi_robot_runtime_profile_resolver"
+    assert profile.PI_RUNTIME_PROFILE_CONFIG_PATH == "config/robot_execution_profiles.json"
+
+
+def test_profile_config_exists_and_loads():
+    path = profile.profile_config_path(ROOT)
+    assert path.exists(), path
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(raw, dict)
+    assert "profiles" in raw
+
+    cfg = profile.load_profile_config(ROOT)
+    assert cfg["ok"] is True
+    assert isinstance(cfg["profiles"], dict)
+
+
+def test_pc_dev_keeps_config_active_mode_safe():
+    env = {"SENTRYBOT_RUNTIME_TARGET": "pc"}
+    st = profile.status(ROOT, env)
+    assert st["ok"] is True
+    assert st["target"]["target"] == "pc_dev"
+    assert st["profile_name"]
+    assert st["read_only"] is True
+    assert st["armed"] is False
+    assert st["hardware_enabled"] is False
+
+
+def test_pi_robot_target_prefers_robot_safe_preview_not_pc_dry_run():
+    env = {"SENTRYBOT_RUNTIME_TARGET": "pi"}
+    st = profile.status(ROOT, env)
+    assert st["ok"] is True
+    assert st["target"]["target"] == "pi_robot"
+    assert st["profile_name"] == "robot_safe_preview"
+    assert st["profile_name"] != "pc_dry_run"
+    assert st["read_only"] is True
+    assert st["armed"] is False
+    assert st["hardware_enabled"] is False
+
+
+def test_explicit_profile_override_still_does_not_arm():
+    env = {
+        "SENTRYBOT_RUNTIME_TARGET": "pi",
+        "SENTRYBOT_EXECUTION_PROFILE": "robot_safe_manual",
+    }
+    st = profile.status(ROOT, env)
+    assert st["ok"] is True
+    assert st["profile_name"] == "robot_safe_manual"
+    assert st["requires_arm_gate"] is True
+    assert st["armed"] is False
+    assert st["hardware_enabled"] is False
+
+
+def test_invalid_explicit_profile_falls_back_to_robot_safe_preview():
+    env = {
+        "SENTRYBOT_RUNTIME_TARGET": "pi",
+        "SENTRYBOT_EXECUTION_PROFILE": "__missing__",
+    }
+    resolved = profile.resolve_runtime_profile(ROOT, env)
+    assert resolved["ok"] is True
+    assert resolved["profile_name"] == "robot_safe_preview"
+    assert "invalid_explicit_profile:__missing__" in resolved["warnings"]

--- a/tests/modules/autonomy/test_vision_context_bridge_contract.py
+++ b/tests/modules/autonomy/test_vision_context_bridge_contract.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.autonomy.services.vision_context_bridge import (
+    VISION_CONTEXT_BRIDGE_CONTRACT,
+    VISION_CONTEXT_BRIDGE_ROLE,
+    VISION_CONTEXT_BRIDGE_STATUS_ONLY,
+    VisionContextBridge,
+    build_vision_context,
+)
+
+
+def test_vision_context_bridge_is_status_only_contract():
+    assert VISION_CONTEXT_BRIDGE_CONTRACT is True
+    assert VISION_CONTEXT_BRIDGE_ROLE == "camera_vlm_to_autonomy_semantic_context_adapter"
+    assert VISION_CONTEXT_BRIDGE_STATUS_ONLY is True
+
+    bridge = VisionContextBridge(history_limit=4)
+    context = bridge.ingest_camera_status(
+        {"enabled": False, "running": False, "has_frame": False, "reason": "disabled"},
+        now=1.0,
+    )
+    assert context["kind"] == "camera_status"
+    assert context["enabled"] is False
+    assert context["running"] is False
+    assert context["has_frame"] is False
+    assert bridge.latest() == context
+
+
+def test_vlm_result_is_normalized_without_inference_call():
+    bridge = VisionContextBridge(history_limit=4)
+    context = bridge.ingest_vlm_result(
+        {
+            "caption": "owner near desk",
+            "objects": ["desk", "cup"],
+            "people": ["owner"],
+            "scene": "room",
+            "risk": "none",
+            "confidence": 0.8,
+        },
+        now=2.0,
+    )
+    assert context["kind"] == "vlm_semantic_context"
+    assert context["caption"] == "owner near desk"
+    assert context["objects"] == ["desk", "cup"]
+    assert context["people"] == ["owner"]
+    assert context["risk"] == "none"
+
+
+def test_bundle_reports_no_activation_started():
+    bundle = build_vision_context(
+        camera_status={"enabled": True, "running": False, "has_frame": False},
+        vlm_result={"labels": ["person"]},
+        now=3.0,
+    )
+    assert bundle["kind"] == "vision_context_bundle"
+    assert bundle["status_only"] is True
+    assert bundle["activation_started"] is False
+    assert len(bundle["entries"]) == 2
+
+
+def test_bridge_source_does_not_contain_capture_or_network_starts():
+    source = Path("modules/autonomy/services/vision_context_bridge.py").read_text(encoding="utf-8")
+    forbidden = [
+        "VideoCapture(",
+        "cv2.",
+        "requests.",
+        "httpx.",
+        "/camera/start",
+        "/camera/snap",
+        "/camera/video",
+        "/vlm/analyze",
+        "/vlm/caption",
+    ]
+    for token in forbidden:
+        assert token not in source

--- a/tests/modules/autonomy/test_vision_context_needs_bridge.py
+++ b/tests/modules/autonomy/test_vision_context_needs_bridge.py
@@ -1,0 +1,55 @@
+
+from modules.autonomy.services.vision_context_needs_bridge import VisionContextNeedsBridge
+from modules.autonomy.services.needs_engine import CompanionNeedsEngine
+
+
+def test_vision_bridge_new_object_boosts_curiosity_context():
+    bridge = VisionContextNeedsBridge({"ttl_s": 60})
+    out = bridge.observe({"new_object": True, "summary": "new object"}, now=100.0)
+    assert out["available"] is True
+    assert out["reason"] == "vision.new_object"
+    ctx = bridge.context(now=101.0)
+    assert ctx["available"] is True
+    assert ctx["scene"]["new_object"] is True
+    assert ctx["mood_overrides"]["curiosity"] >= 80
+
+
+def test_vision_bridge_person_sets_owner_present():
+    bridge = VisionContextNeedsBridge({"ttl_s": 60})
+    bridge.observe({"person_seen": True, "owner_present": True}, now=200.0)
+    ctx = bridge.context(now=201.0)
+    assert ctx["owner_present"] is True
+    assert ctx["scene"]["person_seen"] is True
+
+
+def test_vision_bridge_stale_context_is_not_available():
+    bridge = VisionContextNeedsBridge({"ttl_s": 1})
+    bridge.observe({"new_object": True}, now=10.0)
+    ctx = bridge.context(now=20.0)
+    assert ctx["available"] is False
+
+
+def test_needs_engine_vision_new_object_recommends_exploration_or_curiosity():
+    engine = CompanionNeedsEngine({"boredom_threshold_s": 100})
+    out = engine.tick(
+        now=100.0,
+        last_interaction_ts=95.0,
+        mood_state={"energy": 90, "curiosity": 50},
+        needs_state={"stimulation": 40},
+        scene={"new_object": True},
+    )
+    assert out["scores"]["curiosity"] >= 80
+    assert out["recommended_goal"] in {"look_around_and_learn", "inspect_environment"}
+
+
+def test_needs_engine_hazard_overrides_to_safety():
+    engine = CompanionNeedsEngine({})
+    out = engine.tick(
+        now=100.0,
+        last_interaction_ts=0.0,
+        mood_state={"energy": 90, "curiosity": 90},
+        needs_state={"stimulation": 90},
+        scene={"hazards": ["obstacle"]},
+    )
+    assert out["dominant_need"] == "safety"
+    assert out["recommended_goal"] == "pause_and_observe"

--- a/tests/modules/autonomy/test_vision_context_to_autonomy_contract.py
+++ b/tests/modules/autonomy/test_vision_context_to_autonomy_contract.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.autonomy.services.vision_context_to_autonomy import (
+    VISION_CONTEXT_TO_AUTONOMY_CONTRACT,
+    VISION_CONTEXT_TO_AUTONOMY_ROLE,
+    VISION_CONTEXT_TO_AUTONOMY_STATUS_ONLY_SAFE,
+    VisionContextToAutonomyAdapter,
+    build_autonomy_vision_signal,
+)
+
+
+SOURCE_PATH = Path("modules/autonomy/services/vision_context_to_autonomy.py")
+
+
+def _root_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id.lower()
+    if isinstance(node, ast.Attribute):
+        return _root_name(node.value)
+    if isinstance(node, ast.Call):
+        return _root_name(node.func)
+    return ""
+
+
+def test_vision_context_to_autonomy_contract_markers():
+    assert VISION_CONTEXT_TO_AUTONOMY_CONTRACT is True
+    assert VISION_CONTEXT_TO_AUTONOMY_ROLE == "status_only_vision_semantics_to_autonomy_signal_adapter"
+    assert VISION_CONTEXT_TO_AUTONOMY_STATUS_ONLY_SAFE is True
+
+
+def test_camera_status_context_maps_to_safe_unavailable_signal():
+    signal = build_autonomy_vision_signal(
+        {
+            "kind": "camera_status",
+            "enabled": False,
+            "running": False,
+            "has_frame": False,
+        },
+        now=1.0,
+    )
+
+    assert signal["activation_started"] is False
+    assert signal["status_only"] is True
+    assert "vision_unavailable_keep_audio_memory_behaviour" in signal["goal_hints"]
+    assert signal["needs_bias"]["visual_confidence"] == 0.0
+
+
+def test_vlm_semantic_context_maps_to_autonomy_hints():
+    signal = build_autonomy_vision_signal(
+        {
+            "kind": "vision_context_bundle",
+            "entries": [
+                {
+                    "kind": "vlm_semantic_context",
+                    "caption": "owner near desk",
+                    "people": ["owner"],
+                    "objects": ["cup", "desk"],
+                    "scene": "room",
+                    "risk": "none",
+                    "confidence": 0.8,
+                }
+            ],
+        },
+        now=2.0,
+    )
+
+    assert "attend_to_known_person" in signal["goal_hints"]
+    assert "inspect_interesting_object" in signal["goal_hints"]
+    assert signal["needs_bias"]["social"] == 0.2
+    assert signal["needs_bias"]["curiosity"] == 0.12
+    assert signal["confidence"] == 0.8
+    assert signal["safety_flags"] == []
+
+
+def test_risky_vlm_context_adds_safety_bias_without_activation():
+    adapter = VisionContextToAutonomyAdapter()
+    signal = adapter.translate(
+        {
+            "kind": "vlm_semantic_context",
+            "caption": "object close to robot",
+            "risk": "obstacle close",
+            "confidence": 0.9,
+        },
+        now=3.0,
+    ).as_dict()
+
+    assert signal["activation_started"] is False
+    assert signal["needs_bias"]["safety"] == 0.6
+    assert signal["safety_flags"] == ["vision_risk:obstacle close"]
+    assert "prefer_safe_observation" in signal["goal_hints"]
+
+
+def test_vision_context_to_autonomy_source_has_no_capture_network_or_inference_start():
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    forbidden_import_roots = {"cv2", "requests", "httpx", "ollama"}
+    imports = []
+    calls = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0].lower()
+                if root in forbidden_import_roots:
+                    imports.append((alias.name, node.lineno))
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".", 1)[0].lower()
+            if root in forbidden_import_roots:
+                imports.append((node.module, node.lineno))
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                if node.func.id in {"VideoCapture"}:
+                    calls.append((node.func.id, node.lineno))
+            elif isinstance(node.func, ast.Attribute):
+                root = _root_name(node.func.value)
+                attr = node.func.attr
+                if root == "cv2" and attr == "VideoCapture":
+                    calls.append((f"{root}.{attr}", node.lineno))
+                if root in {"requests", "httpx"} and attr in {"get", "post", "request", "send"}:
+                    calls.append((f"{root}.{attr}", node.lineno))
+                if root == "ollama" and attr in {"generate", "chat"}:
+                    calls.append((f"{root}.{attr}", node.lineno))
+
+    assert imports == []
+    assert calls == []
+
+    for endpoint in ["/camera/start", "/camera/snap", "/camera/video", "/vlm/analyze", "/vlm/caption"]:
+        assert endpoint not in source

--- a/tests/modules/autonomy/test_world_memory.py
+++ b/tests/modules/autonomy/test_world_memory.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from modules.autonomy.services.world_memory import WorldMemory
+
+
+def test_schema_lists_core_kinds():
+    mem = WorldMemory({"persistence_enabled": False})
+    schema = mem.schema()
+    assert schema["ok"] is True
+    assert {"people", "places", "objects", "events", "observations", "habits"}.issubset(set(schema["kinds"]))
+
+
+def test_observe_person_merges_by_name():
+    mem = WorldMemory({"persistence_enabled": False})
+    first = mem.observe({"kind": "person", "name": "Emir", "confidence": 0.7}, source="test", now=1.0)
+    second = mem.observe({"kind": "person", "name": "Emir", "confidence": 0.9, "properties": {"role": "owner"}}, source="test", now=2.0)
+    assert first["created"] is True
+    assert second["created"] is False
+    assert second["item"]["kind"] == "people"
+    assert second["item"]["count"] == 2
+    assert second["item"]["confidence"] == 0.9
+    assert second["item"]["properties"]["role"] == "owner"
+
+
+def test_recent_filters_by_kind():
+    mem = WorldMemory({"persistence_enabled": False})
+    mem.observe({"kind": "object", "name": "red cube"}, now=1.0)
+    mem.observe({"kind": "place", "name": "desk"}, now=2.0)
+    recent = mem.recent(kind="objects", limit=5)
+    assert recent["ok"] is True
+    assert recent["count"] == 1
+    assert recent["items"][0]["name"] == "red cube"
+
+
+def test_observation_uses_summary_source_key():
+    mem = WorldMemory({"persistence_enabled": False})
+    a = mem.observe({"kind": "observation", "summary": "quiet room"}, source="vision", now=1.0)
+    b = mem.observe({"kind": "observation", "summary": "quiet room"}, source="vision", now=2.0)
+    assert a["created"] is True
+    assert b["created"] is False
+    assert b["item"]["count"] == 2
+
+
+def test_clear_one_kind():
+    mem = WorldMemory({"persistence_enabled": False})
+    mem.observe({"kind": "object", "name": "ball"})
+    mem.observe({"kind": "person", "name": "owner"})
+    result = mem.clear(kind="objects")
+    status = mem.status()
+    assert result["removed"] == 1
+    assert status["counts"]["objects"] == 0
+    assert status["counts"]["people"] == 1

--- a/tests/modules/autonomy/test_world_memory_autowriter.py
+++ b/tests/modules/autonomy/test_world_memory_autowriter.py
@@ -1,0 +1,43 @@
+from modules.autonomy.services.world_memory import WorldMemory
+from modules.autonomy.services.world_memory_autowriter import WorldMemoryAutoWriter
+
+
+def test_vision_new_object_builds_object_memory_payload():
+    writer = WorldMemoryAutoWriter()
+    payloads = writer.from_vision({"new_object": True, "objects": ["red cube"], "summary": "new object on desk", "confidence": 0.8})
+    assert payloads
+    assert payloads[0]["kind"] == "objects"
+    assert payloads[0]["name"] == "red cube"
+    assert payloads[0]["source"] == "vision"
+
+
+def test_vision_hazard_builds_event_payload():
+    writer = WorldMemoryAutoWriter()
+    payloads = writer.from_vision({"hazards": ["obstacle close"], "summary": "possible obstacle", "confidence": 0.9})
+    assert any(p["kind"] == "events" and p["name"] == "hazard" for p in payloads)
+
+
+def test_audio_wakeword_builds_owner_and_event_payloads():
+    writer = WorldMemoryAutoWriter()
+    payloads = writer.from_audio({"event_type": "wakeword", "wakeword": True, "owner_present": True, "confidence": 0.9})
+    kinds_names = {(p["kind"], p["name"]) for p in payloads}
+    assert ("people", "owner") in kinds_names
+    assert ("events", "wakeword") in kinds_names
+
+
+def test_audio_loud_builds_safety_event():
+    writer = WorldMemoryAutoWriter()
+    payloads = writer.from_audio({"event_type": "loud", "loud": True, "confidence": 0.8})
+    assert any(p["kind"] == "events" and p["name"] == "loud noise" and "safety" in p.get("tags", []) for p in payloads)
+
+
+def test_autowriter_payloads_merge_in_world_memory():
+    mem = WorldMemory()
+    writer = WorldMemoryAutoWriter()
+    for payload in writer.from_audio({"event_type": "wakeword", "wakeword": True, "owner_present": True, "confidence": 0.9}):
+        mem.observe(payload, source=payload.get("source", "audio"), now=1.0)
+    for payload in writer.from_audio({"event_type": "wakeword", "wakeword": True, "owner_present": True, "confidence": 0.9}):
+        mem.observe(payload, source=payload.get("source", "audio"), now=2.0)
+    people = mem.recent(kind="people", limit=5)["items"]
+    owner = next(item for item in people if item["name"] == "owner")
+    assert owner["count"] == 2

--- a/tests/modules/autonomy/test_world_memory_persistence.py
+++ b/tests/modules/autonomy/test_world_memory_persistence.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.autonomy.services.world_memory import WorldMemory
+
+
+def test_world_memory_persists_across_instances(tmp_path: Path):
+    path = tmp_path / "world_memory.json"
+    cfg = {"storage_path": str(path), "persistence_enabled": True}
+    first = WorldMemory(cfg)
+    observed = first.observe({"kind": "object", "name": "persistent cube", "summary": "cube on desk", "source": "test"}, now=1.0)
+    assert observed["ok"] is True
+    assert path.exists()
+    second = WorldMemory(cfg)
+    recent = second.recent(kind="objects", limit=5)
+    assert second.status()["persistence"]["loaded"] is True
+    assert recent["count"] == 1
+    assert recent["items"][0]["name"] == "persistent cube"
+
+
+def test_world_memory_persistence_can_be_disabled(tmp_path: Path):
+    path = tmp_path / "disabled.json"
+    mem = WorldMemory({"storage_path": str(path), "persistence_enabled": False})
+    mem.observe({"kind": "object", "name": "not written"})
+    assert path.exists() is False
+    assert mem.status()["persistence"]["enabled"] is False
+
+
+def test_world_memory_clear_is_persisted(tmp_path: Path):
+    path = tmp_path / "world_memory.json"
+    cfg = {"storage_path": str(path), "persistence_enabled": True}
+    mem = WorldMemory(cfg)
+    mem.observe({"kind": "person", "name": "owner"}, now=1.0)
+    mem.clear(kind="people")
+    loaded = WorldMemory(cfg)
+    assert loaded.status()["counts"]["people"] == 0
+
+
+
+def test_non_persistent_instances_do_not_read_storage(tmp_path: Path):
+    path = tmp_path / "world_memory.json"
+    seeded = WorldMemory({"storage_path": str(path), "persistence_enabled": True})
+    seeded.observe({"kind": "object", "name": "runtime-only object"}, now=1.0)
+    isolated = WorldMemory({"storage_path": str(path), "persistence_enabled": False})
+    assert isolated.status()["persistence"]["enabled"] is False
+    assert isolated.recent(kind="objects")["count"] == 0

--- a/tests/modules/autonomy/test_world_memory_persistence_truth_contract.py
+++ b/tests/modules/autonomy/test_world_memory_persistence_truth_contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from modules.autonomy.services.world_memory import (
+    WORLD_MEMORY_PERSISTENCE_TRUTH_CONTRACT,
+    WORLD_MEMORY_PERSISTENCE_ROLE,
+    WorldMemory,
+)
+
+
+def test_world_memory_reports_real_local_persistence_status(tmp_path):
+    path = tmp_path / "world_memory.json"
+    memory = WorldMemory({"storage_path": str(path), "persistence_enabled": True})
+    assert WORLD_MEMORY_PERSISTENCE_TRUTH_CONTRACT is True
+    assert WORLD_MEMORY_PERSISTENCE_ROLE == "local_json_semantic_memory_store"
+    status = memory.status()
+    assert status["persistence"]["enabled"] is True
+    assert status["persistence"]["path"] == str(path)
+    assert status["persistence"]["exists"] is False
+    memory.observe({"kind": "person", "name": "Emir"}, source="test", now=1.0)
+    status_after = memory.status()
+    assert status_after["persistence"]["exists"] is True
+    assert status_after["persistence"]["error"] == ""
+
+
+def test_world_memory_disabled_persistence_is_reported_without_disk_write(tmp_path):
+    path = tmp_path / "world_memory_disabled.json"
+    memory = WorldMemory({"storage_path": str(path), "persistence_enabled": False})
+    memory.observe({"kind": "object", "name": "cup"}, source="test", now=1.0)
+    status = memory.status()
+    assert status["total"] == 1
+    assert status["persistence"]["enabled"] is False
+    assert status["persistence"]["exists"] is False
+    assert not path.exists()


### PR DESCRIPTION
﻿## Summary
- Add needs engine, pet companion core, goal selector/executor, and behavior loop.
- Add world memory + RAG, vision-context bridges, capability registry, and safe motion helpers.
- Wire stack into autonomy brain/API/config with broad unit coverage.

## Change type
- [x] New feature

## Affected modules
`modules/autonomy`, `config/autonomy/*`, `config/robot_*.json`

## Test plan
- [ ] Companion needs/goal/pet tests pass
- [ ] World memory persistence truth contracts pass
- [ ] Vision bridge and capability map contracts pass

## Notes
- Largest feature PR in the stack. Depends on expression/vision/audio/agent-core foundations above.
- Stacked on `feat/agent-core-boundary-contracts`.

## Risk / rollback
Keep physical base motion gated; revert branch if companion auto-execute misbehaves in bench tests.
